### PR TITLE
install/kubernetes: Switch to quay.io/cilium/hubble

### DIFF
--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -25,11 +25,11 @@ instead of unix domain socket. For example, to listen to port 8080 on localhost:
 
 1. Metrics can be enabled via the `metrics.enabled` helm option:
 
-    helm template hubble \
-        --namespace kube-system \
-        --set metrics.enabled="{dns:query,drop,tcp,flow,port-distribution}" \
-        > hubble.yaml
-    kubectl apply -f hubble.yaml
+        helm template hubble \
+            --namespace kube-system \
+            --set metrics.enabled="{dns:query,drop,tcp,flow,port-distribution}" \
+            > hubble.yaml
+        kubectl apply -f hubble.yaml
 
 2. Deploy Prometheus & Grafana
 

--- a/install/kubernetes/hubble/templates/daemonset.yaml
+++ b/install/kubernetes/hubble/templates/daemonset.yaml
@@ -43,8 +43,13 @@ spec:
             {{- end }}
       containers:
       - name: hubble
+{{- if .Values.ui.enabled }}
+        image: "{{ .Values.ui.image.hubble.repository }}:{{ .Values.ui.image.hubble.tag }}"
+        imagePullPolicy: {{ .Values.ui.image.hubble.pullPolicy }}
+{{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- end }}
         command:
         - hubble
         args:

--- a/install/kubernetes/hubble/values.yaml
+++ b/install/kubernetes/hubble/values.yaml
@@ -1,7 +1,7 @@
 # image used for hubble server
 image:
   # repository of the docker image
-  repository: quay.io/isovalent/hubble
+  repository: quay.io/cilium/hubble
   # tag is the container image tag to use
   tag: latest
   # pullPolicy is the container image pull policy
@@ -38,6 +38,15 @@ metrics:
 ui:
   enabled: false
   image:
+    # hubble image used for hubble-ui
+    hubble:
+      # repository of the Hubble docker image
+      repository: quay.io/isovalent/hubble
+      # tag is the container image tag to use
+      tag: latest
+      # pullPolicy is the container image pull policy
+      pullPolicy: Always
+
     # repository of the docker image
     repository: quay.io/isovalent/hubble-ui
     # tag is the container image tag to use


### PR DESCRIPTION
This switches the Helm chart over to use the image of the open-source repository of Hubble. Deployments of the preview of Hubble-UI still use the old image.