### PR TITLE
parser: Populate labels for remote endpoints

### DIFF
--- a/pkg/parser/getters/getters.go
+++ b/pkg/parser/getters/getters.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/hubble/pkg/ipcache"
 )
 
 // DNSGetter ...
@@ -40,8 +41,8 @@ type IdentityGetter interface {
 	GetIdentity(id uint64) (*models.Identity, error)
 }
 
-// K8sGetter fetches per-IP K8s metadata
-type K8sGetter interface {
-	// GetPodNameOf fetches K8s pod and namespace information.
-	GetPodNameOf(ip net.IP) (ns, pod string, ok bool)
+// IPGetter fetches per-IP metadata
+type IPGetter interface {
+	// GetIPIdentity fetches information known about a remote IP.
+	GetIPIdentity(ip net.IP) (identity ipcache.IPIdentity, ok bool)
 }

--- a/pkg/parser/new.go
+++ b/pkg/parser/new.go
@@ -36,16 +36,16 @@ func New(
 	endpointGetter getters.EndpointGetter,
 	identityGetter getters.IdentityGetter,
 	dnsGetter getters.DNSGetter,
-	k8sGetter getters.K8sGetter,
+	ipGetter getters.IPGetter,
 	opts ...options.Option,
 ) (*Parser, error) {
 
-	l34, err := threefour.New(endpointGetter, identityGetter, dnsGetter, k8sGetter)
+	l34, err := threefour.New(endpointGetter, identityGetter, dnsGetter, ipGetter)
 	if err != nil {
 		return nil, err
 	}
 
-	l7, err := seven.New(dnsGetter, k8sGetter, opts...)
+	l7, err := seven.New(dnsGetter, ipGetter, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/observer_test.go
+++ b/pkg/server/observer_test.go
@@ -541,12 +541,12 @@ func TestObserverServer_GetFlowsOfANonLocalPod(t *testing.T) {
 			},
 		},
 	}
-	fakeK8sGetter := &testutils.FakeK8sGetter{
-		OnGetPodNameOf: func(ip net.IP) (ns, pod string, ok bool) {
+	fakeIPGetter := &testutils.FakeIPGetter{
+		OnGetIPIdentity: func(ip net.IP) (identity ipcache.IPIdentity, ok bool) {
 			if ip.Equal(net.ParseIP("1.1.1.1")) {
-				return "default", "foo-bar", true
+				return ipcache.IPIdentity{Namespace: "default", PodName: "foo-bar"}, true
 			}
-			return "", "", false
+			return ipcache.IPIdentity{}, false
 		},
 	}
 
@@ -554,7 +554,7 @@ func TestObserverServer_GetFlowsOfANonLocalPod(t *testing.T) {
 	ipc := ipcache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, fakeK8sGetter)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, fakeIPGetter)
 	assert.NoError(t, err)
 
 	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, pp, 30)

--- a/pkg/testutils/fake.go
+++ b/pkg/testutils/fake.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/hubble/pkg/ipcache"
 )
 
 // FakeDNSGetter is used for unit tests that needs DNSGetter.
@@ -48,22 +49,22 @@ var NoopEndpointGetter = FakeEndpointGetter{
 	},
 }
 
-// FakeK8sGetter is used for unit tests that needs K8sGetter.
-type FakeK8sGetter struct {
-	OnGetPodNameOf func(ip net.IP) (ns, pod string, ok bool)
+// FakeIPGetter is used for unit tests that needs IPGetter.
+type FakeIPGetter struct {
+	OnGetIPIdentity func(ip net.IP) (id ipcache.IPIdentity, ok bool)
 }
 
-// GetPodNameOf implements K8sGetter.GetPodNameOf.
-func (f *FakeK8sGetter) GetPodNameOf(ip net.IP) (ns, pod string, ok bool) {
-	if f.OnGetPodNameOf != nil {
-		return f.OnGetPodNameOf(ip)
+// GetIPIdentity implements FakeIPGetter.GetIPIdentity.
+func (f *FakeIPGetter) GetIPIdentity(ip net.IP) (id ipcache.IPIdentity, ok bool) {
+	if f.OnGetIPIdentity != nil {
+		return f.OnGetIPIdentity(ip)
 	}
-	panic("OnGetPodNameOf not set")
+	panic("OnGetIPIdentity not set")
 }
 
-// NoopK8sGetter always returns an empty response.
-var NoopK8sGetter = FakeK8sGetter{
-	OnGetPodNameOf: func(ip net.IP) (ns, pod string, ok bool) {
-		return "", "", false
+// NoopIPGetter always returns an empty response.
+var NoopIPGetter = FakeIPGetter{
+	OnGetIPIdentity: func(ip net.IP) (id ipcache.IPIdentity, ok bool) {
+		return ipcache.IPIdentity{}, false
 	},
 }


### PR DESCRIPTION
Previously, the IPCache was only consulted to obtain the K8s pod name
and namespace. However, we also want to obtain the numeric security
identity to fetch labels for endpoints running on remote nodes. This
change extends the IPCache interface to expose this information to the
parser.

Flow endpoints running on local nodes still be populated from the local
endpoint collection, as this will us save us an extra api call to obtain
the labels. Additionally, for local endpoints we also will populate the
endpoint id this way (which is distinct from the numerical security
identity and currently unavailable for remote endpoints).

Fixes: #8

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>