### PR TITLE
helm: Enable TCP ports when ui.enable=true

### DIFF
--- a/install/kubernetes/hubble/templates/daemonset.yaml
+++ b/install/kubernetes/hubble/templates/daemonset.yaml
@@ -43,19 +43,20 @@ spec:
             {{- end }}
       containers:
       - name: hubble
-{{- if .Values.ui.enabled }}
-        image: "{{ .Values.ui.image.hubble.repository }}:{{ .Values.ui.image.hubble.tag }}"
-        imagePullPolicy: {{ .Values.ui.image.hubble.pullPolicy }}
-{{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- end }}
         command:
         - hubble
         args:
         - serve
 {{- range .Values.listenClientUrls }}
         - --listen-client-urls={{ . }}
+{{- end }}
+{{- if and .Values.ui.enabled (not (has "0.0.0.0:50051" .Values.listenClientUrls)) }}
+        - --listen-client-urls=0.0.0.0:50051
+{{- if not .Values.listenClientUrls }}
+        - --listen-client-urls=unix:///var/run/hubble.sock
+{{- end }}
 {{- end }}
 {{- if .Values.maxFlows }}
         - --max-flows

--- a/install/kubernetes/hubble/values.yaml
+++ b/install/kubernetes/hubble/values.yaml
@@ -38,15 +38,6 @@ metrics:
 ui:
   enabled: false
   image:
-    # hubble image used for hubble-ui
-    hubble:
-      # repository of the Hubble docker image
-      repository: quay.io/isovalent/hubble
-      # tag is the container image tag to use
-      tag: latest
-      # pullPolicy is the container image pull policy
-      pullPolicy: Always
-
     # repository of the docker image
     repository: quay.io/isovalent/hubble-ui
     # tag is the container image tag to use

--- a/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
+++ b/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
@@ -173,7 +173,7 @@ spec:
             - kube-system
       containers:
       - name: hubble
-        image: "quay.io/isovalent/hubble:latest"
+        image: "quay.io/cilium/hubble:latest"
         imagePullPolicy: Always
         command:
         - hubble


### PR DESCRIPTION
Adds "0.0.0.0:50051" to `listenClientUrls` when `ui.enabled` is true.
This ensures that Hubble exposes its gRPC service via TCP, which is
required for the UI.

In addition, this PR also cleans up the Helm chart with regards to the
UI. The new hubble-all-minikube.yaml has been gerated with the following
command:

    helm template hubble \
         --namespace kube-system \
         --set metrics.enabled="{dns:query,drop,tcp,flow,port-distribution}" \
         --set ui.enabled=true \
         > ../../tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml

Might fix issue #15.