### PR TITLE
Fixed UI deployment to use user specified namespace to call hubble-grpc

### DIFF
--- a/install/kubernetes/hubble/templates/deployment.yaml
+++ b/install/kubernetes/hubble/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             - name: HUBBLE
               value: "true"
             - name: HUBBLE_SERVICE
-              value: "hubble-grpc.kube-system.svc.cluster.local"
+              value: "hubble-grpc.{{ .Release.Namespace }}.svc.cluster.local"
             - name: HUBBLE_PORT
               value: "50051"
           ports:


### PR DESCRIPTION
Hubble-UI helm template uses hardcoded "kube-system" namespace.