### PR TITLE
Fix missing labels in new local endpoints

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -391,8 +391,7 @@ func getMonitorParser(conn net.Conn, version listener.Version) (parser eventPars
 func consumeMonitorEvents(s *server.ObserverServer, conn net.Conn, version listener.Version) error {
 	defer conn.Close()
 	ch := s.GetEventsChannel()
-	epAdd := s.GetEpAddChannel()
-	epDel := s.GetEpDelChannel()
+	endpointEvents := s.GetEndpointEventsChannel()
 
 	dnsAdd := s.GetLogRecordNotifyChannel()
 
@@ -424,10 +423,10 @@ func consumeMonitorEvents(s *server.ObserverServer, conn net.Conn, version liste
 				continue
 			}
 			switch an.Type {
-			case monitorAPI.AgentNotifyEndpointCreated:
-				epAdd <- an.Text
-			case monitorAPI.AgentNotifyEndpointDeleted:
-				epDel <- an.Text
+			case monitorAPI.AgentNotifyEndpointCreated,
+				monitorAPI.AgentNotifyEndpointRegenerateSuccess,
+				monitorAPI.AgentNotifyEndpointDeleted:
+				endpointEvents <- an
 			case monitorAPI.AgentNotifyIPCacheUpserted:
 				ipCacheEvents <- an
 			case monitorAPI.AgentNotifyIPCacheDeleted:

--- a/pkg/api/v1/endpoint.go
+++ b/pkg/api/v1/endpoint.go
@@ -43,6 +43,9 @@ func (e *Endpoint) SetFrom(o *Endpoint) {
 	if o.IPv6 != nil {
 		e.IPv6 = o.IPv6
 	}
+	if len(o.Labels) != 0 {
+		e.Labels = o.Labels
+	}
 	if o.PodName != "" {
 		e.PodName = o.PodName
 	}

--- a/pkg/api/v1/endpoint_test.go
+++ b/pkg/api/v1/endpoint_test.go
@@ -162,6 +162,7 @@ func TestEndpoint_SetFrom(t *testing.T) {
 		IPv6         net.IP
 		PodName      string
 		PodNamespace string
+		Labels       []string
 	}
 	type args struct {
 		o *Endpoint
@@ -182,6 +183,7 @@ func TestEndpoint_SetFrom(t *testing.T) {
 				IPv6:         nil,
 				PodName:      "",
 				PodNamespace: "",
+				Labels:       nil,
 			},
 			args: args{
 				o: &Endpoint{
@@ -193,6 +195,7 @@ func TestEndpoint_SetFrom(t *testing.T) {
 					IPv6:         net.ParseIP("fd00::"),
 					PodName:      "pod-bar",
 					PodNamespace: "cilium",
+					Labels:       []string{"a", "b"},
 				},
 			},
 			want: &Endpoint{
@@ -203,6 +206,7 @@ func TestEndpoint_SetFrom(t *testing.T) {
 				IPv6:         net.ParseIP("fd00::"),
 				PodName:      "pod-bar",
 				PodNamespace: "cilium",
+				Labels:       []string{"a", "b"},
 			},
 		},
 	}


### PR DESCRIPTION
Endpoint labels are not always available when an endpoint is initially created. The following `cilium monitor` output exemplifies this:

    >> Endpoint created: {"id":1407,"pod-name":"deathstar-657477f57d-5nl8t","namespace":"default"}
    >> IPCache entry upserted: {"cidr":"10.16.65.104/32","id":20927,"host-ip":"192.168.33.11","encrypt-key":0,"namespace":"default","pod-name":"deathstar-657477f57d-5nl8t"}
    >> IPCache entry upserted: {"cidr":"f00d::a10:0:0:dc8e/128","id":20927,"host-ip":"192.168.33.11","encrypt-key":0,"namespace":"default","pod-name":"deathstar-657477f57d-5nl8t"}
    >> Endpoint regenerated: {"id":1407,"labels":["k8s:io.cilium.k8s.policy.serviceaccount=default","k8s:io.cilium.k8s.policy.cluster=default","k8s:class=deathstar","k8s:org=empire","k8s:io.kubernetes.pod.namespace=default"]}

As can be seen in the above output, the Kubernetes labels are not yet associated with the endpoint in the creation event. The labels are only added a few moments later. Therefore we have to listen to endpoint regeneration events to update Hubble's endpoint cache with the updated label information.

In addition, there was also a second bug in the endpoint update logic, where labels of existing endpoints were never updated. This caused stale labels even when Hubble synced endpoints from the Cilium API.

This PR also unifies all the endpoint events into a single channel. This preserves the ordering between add, update and delete events.

Fixes: #19
