### PR TITLE
actions: Nail the version of actions/checkout to v1

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
       with:
         path: go/src/github.com/cilium/hubble
     - uses: actions/setup-go@v1


### PR DESCRIPTION
Master is not compatible with v1. We can migrate to v2 once it's out
of beta.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>