### PR TITLE
 api: Introduce interface for pb.Flow 

### DIFF
--- a/pkg/api/v1/flow.go
+++ b/pkg/api/v1/flow.go
@@ -15,15 +15,13 @@
 package v1
 
 import (
-	pb "github.com/cilium/hubble/api/v1/flow"
-
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
 
 // FlowProtocol returns the protocol best describing the flow. If available,
 // this is the L7 protocol name, then the L4 protocol name.
-func FlowProtocol(flow *pb.Flow) string {
-	switch flow.EventType.Type {
+func FlowProtocol(flow Flow) string {
+	switch flow.GetEventType().Type {
 	case monitorAPI.MessageTypeAccessLog:
 		if l7 := flow.GetL7(); l7 != nil {
 			switch {
@@ -40,13 +38,13 @@ func FlowProtocol(flow *pb.Flow) string {
 	case monitorAPI.MessageTypeDrop, monitorAPI.MessageTypeTrace:
 		if l4 := flow.GetL4(); l4 != nil {
 			switch {
-			case flow.L4.GetTCP() != nil:
+			case l4.GetTCP() != nil:
 				return "TCP"
-			case flow.L4.GetUDP() != nil:
+			case l4.GetUDP() != nil:
 				return "UDP"
-			case flow.L4.GetICMPv4() != nil:
+			case l4.GetICMPv4() != nil:
 				return "ICMPv4"
-			case flow.L4.GetICMPv6() != nil:
+			case l4.GetICMPv6() != nil:
 				return "ICMPv6"
 			}
 		}

--- a/pkg/api/v1/interface.go
+++ b/pkg/api/v1/interface.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	pb "github.com/cilium/hubble/api/v1/flow"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/proto"
+)
+
+// Flow is an interface matching pb.Flow
+type Flow interface {
+	proto.Message
+	GetTime() *types.Timestamp
+	GetVerdict() pb.Verdict
+	GetDropReason() uint32
+	GetEthernet() *pb.Ethernet
+	GetIP() *pb.IP
+	GetL4() *pb.Layer4
+	GetSource() *pb.Endpoint
+	GetDestination() *pb.Endpoint
+	GetType() pb.FlowType
+	GetNodeName() string
+	GetPayload() *pb.Payload
+	GetSourceNames() []string
+	GetDestinationNames() []string
+	GetL7() *pb.Layer7
+	GetReply() bool
+	GetEventType() *pb.CiliumEventType
+	GetSourceService() *pb.Service
+	GetDestinationService() *pb.Service
+	GetSummary() string
+}
+
+// This ensures that the protobuf definition implements the interface
+var _ Flow = &pb.Flow{}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -40,26 +40,20 @@ type Endpoint struct {
 type Event struct {
 	// Timestamp when event was observed in Hubble
 	Timestamp *types.Timestamp
-	// Payload is a raw cilium monitor payload
-	Payload *pb.Payload
-	// Flow is a decoded L3/L4/L7 flow event.
-	Flow *pb.Flow
+	// Event contains the actual event
+	Event interface{}
 }
 
-// GetPayload returns the payload, or nil if the payload or ev is nil
-func (ev *Event) GetPayload() *pb.Payload {
-	if ev == nil {
-		return nil
+// GetFlow returns the decoded flow, or nil if there is no event
+func (ev *Event) GetFlow() Flow {
+	if ev == nil || ev.Event == nil {
+		// returns typed nil so getter methods still work
+		return (*pb.Flow)(nil)
 	}
-	return ev.Payload
-}
-
-// GetFlow returns the decoded, or nil if the flow or ev is nil
-func (ev *Event) GetFlow() *pb.Flow {
-	if ev == nil {
-		return nil
+	if f, ok := ev.Event.(Flow); ok {
+		return f
 	}
-	return ev.Flow
+	return nil
 }
 
 // Endpoints is a slice of endpoints and their cached dns queries protected by a mutex.

--- a/pkg/container/ring.go
+++ b/pkg/container/ring.go
@@ -39,7 +39,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/math"
 )
 

--- a/pkg/container/ring_test.go
+++ b/pkg/container/ring_test.go
@@ -21,7 +21,8 @@ import (
 	"sync"
 	"testing"
 
-	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/hubble/pkg/api/v1"
+
 	"github.com/gogo/protobuf/types"
 )
 

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -270,7 +270,7 @@ func filterByVerdicts(vs []pb.Verdict) FilterFunc {
 			return false
 		}
 		for _, verdict := range vs {
-			if verdict == flow.Verdict {
+			if verdict == flow.GetVerdict() {
 				return true
 			}
 		}

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -99,10 +99,10 @@ func TestIPFilter(t *testing.T) {
 					{SourceIp: []string{"1.1.1.1", "f00d::a10:0:0:9195"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "1.1.1.1", Destination: "2.2.2.2"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "2.2.2.2", Destination: "1.1.1.1"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "f00d::a10:0:0:9195", Destination: "ff02::1:ff00:b3e5"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "ff02::1:ff00:b3e5", Destination: "f00d::a10:0:0:9195"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "1.1.1.1", Destination: "2.2.2.2"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "2.2.2.2", Destination: "1.1.1.1"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "f00d::a10:0:0:9195", Destination: "ff02::1:ff00:b3e5"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "ff02::1:ff00:b3e5", Destination: "f00d::a10:0:0:9195"}}},
 				},
 			},
 			want: []bool{
@@ -119,10 +119,10 @@ func TestIPFilter(t *testing.T) {
 					{DestinationIp: []string{"1.1.1.1", "f00d::a10:0:0:9195"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "1.1.1.1", Destination: "2.2.2.2"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "2.2.2.2", Destination: "1.1.1.1"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "f00d::a10:0:0:9195", Destination: "ff02::1:ff00:b3e5"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "ff02::1:ff00:b3e5", Destination: "f00d::a10:0:0:9195"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "1.1.1.1", Destination: "2.2.2.2"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "2.2.2.2", Destination: "1.1.1.1"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "f00d::a10:0:0:9195", Destination: "ff02::1:ff00:b3e5"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "ff02::1:ff00:b3e5", Destination: "f00d::a10:0:0:9195"}}},
 				},
 			},
 			want: []bool{
@@ -142,10 +142,10 @@ func TestIPFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "1.1.1.1", Destination: "2.2.2.2"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "2.2.2.2", Destination: "1.1.1.1"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "f00d::a10:0:0:9195", Destination: "ff02::1:ff00:b3e5"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "ff02::1:ff00:b3e5", Destination: "f00d::a10:0:0:9195"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "1.1.1.1", Destination: "2.2.2.2"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "2.2.2.2", Destination: "1.1.1.1"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "f00d::a10:0:0:9195", Destination: "ff02::1:ff00:b3e5"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "ff02::1:ff00:b3e5", Destination: "f00d::a10:0:0:9195"}}},
 				},
 			},
 			want: []bool{
@@ -163,10 +163,10 @@ func TestIPFilter(t *testing.T) {
 					{DestinationIp: []string{"2.2.2.2"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "1.1.1.1", Destination: "2.2.2.2"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "2.2.2.2", Destination: "1.1.1.1"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "1.1.1.1", Destination: "1.1.1.1"}}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: "2.2.2.2", Destination: "2.2.2.2"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "1.1.1.1", Destination: "2.2.2.2"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "2.2.2.2", Destination: "1.1.1.1"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "1.1.1.1", Destination: "1.1.1.1"}}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: "2.2.2.2", Destination: "2.2.2.2"}}},
 				},
 			},
 			want: []bool{
@@ -185,8 +185,8 @@ func TestIPFilter(t *testing.T) {
 				ev: []*v1.Event{
 					nil,
 					{},
-					{Flow: &pb.Flow{}},
-					{Flow: &pb.Flow{IP: &pb.IP{Source: ""}}},
+					{Event: &pb.Flow{}},
+					{Event: &pb.Flow{IP: &pb.IP{Source: ""}}},
 				},
 			},
 			want: []bool{
@@ -249,10 +249,10 @@ func TestPodFilter(t *testing.T) {
 					{SourcePod: []string{"xwing", "default/tiefighter"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{Source: &pb.Endpoint{Namespace: "default", PodName: "xwing"}}},
-					{Flow: &pb.Flow{Source: &pb.Endpoint{Namespace: "default", PodName: "tiefighter"}}},
-					{Flow: &pb.Flow{Source: &pb.Endpoint{Namespace: "kube-system", PodName: "xwing"}}},
-					{Flow: &pb.Flow{Destination: &pb.Endpoint{Namespace: "default", PodName: "xwing"}}},
+					{Event: &pb.Flow{Source: &pb.Endpoint{Namespace: "default", PodName: "xwing"}}},
+					{Event: &pb.Flow{Source: &pb.Endpoint{Namespace: "default", PodName: "tiefighter"}}},
+					{Event: &pb.Flow{Source: &pb.Endpoint{Namespace: "kube-system", PodName: "xwing"}}},
+					{Event: &pb.Flow{Destination: &pb.Endpoint{Namespace: "default", PodName: "xwing"}}},
 				},
 			},
 			want: []bool{
@@ -269,10 +269,10 @@ func TestPodFilter(t *testing.T) {
 					{DestinationPod: []string{"xwing", "default/tiefighter"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{Destination: &pb.Endpoint{Namespace: "default", PodName: "xwing"}}},
-					{Flow: &pb.Flow{Destination: &pb.Endpoint{Namespace: "default", PodName: "tiefighter"}}},
-					{Flow: &pb.Flow{Destination: &pb.Endpoint{Namespace: "kube-system", PodName: "xwing"}}},
-					{Flow: &pb.Flow{Source: &pb.Endpoint{Namespace: "default", PodName: "xwing"}}},
+					{Event: &pb.Flow{Destination: &pb.Endpoint{Namespace: "default", PodName: "xwing"}}},
+					{Event: &pb.Flow{Destination: &pb.Endpoint{Namespace: "default", PodName: "tiefighter"}}},
+					{Event: &pb.Flow{Destination: &pb.Endpoint{Namespace: "kube-system", PodName: "xwing"}}},
+					{Event: &pb.Flow{Source: &pb.Endpoint{Namespace: "default", PodName: "xwing"}}},
 				},
 			},
 			want: []bool{
@@ -292,19 +292,19 @@ func TestPodFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "default", PodName: "xwing"},
 						Destination: &pb.Endpoint{Namespace: "default", PodName: "deathstar"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "default", PodName: "tiefighter"},
 						Destination: &pb.Endpoint{Namespace: "default", PodName: "deathstar"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "default", PodName: "deathstar"},
 						Destination: &pb.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "default", PodName: "tiefighter"},
 						Destination: &pb.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
@@ -325,19 +325,19 @@ func TestPodFilter(t *testing.T) {
 					{DestinationPod: []string{"deathstar"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "default", PodName: "xwing"},
 						Destination: &pb.Endpoint{Namespace: "default", PodName: "deathstar"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "default", PodName: "tiefighter"},
 						Destination: &pb.Endpoint{Namespace: "default", PodName: "deathstar"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "default", PodName: "deathstar"},
 						Destination: &pb.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "default", PodName: "tiefighter"},
 						Destination: &pb.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
@@ -358,19 +358,19 @@ func TestPodFilter(t *testing.T) {
 					{DestinationPod: []string{"kube-system/"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
 						Destination: &pb.Endpoint{Namespace: "kube-system", PodName: "kube-proxy"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "default", PodName: "tiefighter"},
 						Destination: &pb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
 						Destination: &pb.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source:      &pb.Endpoint{Namespace: "default", PodName: "tiefighter"},
 						Destination: &pb.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
@@ -390,19 +390,19 @@ func TestPodFilter(t *testing.T) {
 					{SourcePod: []string{"xwing", "kube-system/coredns-"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source: &pb.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source: &pb.Endpoint{Namespace: "default", PodName: "xwing-t-65b"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source: &pb.Endpoint{Namespace: "kube-system", PodName: "coredns-12345"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source: &pb.Endpoint{Namespace: "kube-system", PodName: "-coredns-12345"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						Source: &pb.Endpoint{Namespace: "default", PodName: "tiefighter"},
 					}},
 				},
@@ -424,8 +424,8 @@ func TestPodFilter(t *testing.T) {
 				ev: []*v1.Event{
 					nil,
 					{},
-					{Flow: &pb.Flow{}},
-					{Flow: &pb.Flow{Source: &pb.Endpoint{Namespace: "", PodName: "xwing"}}},
+					{Event: &pb.Flow{}},
+					{Event: &pb.Flow{Source: &pb.Endpoint{Namespace: "", PodName: "xwing"}}},
 				},
 			},
 			want: []bool{
@@ -488,10 +488,10 @@ func TestFQDNFilter(t *testing.T) {
 					{SourceFqdn: []string{"cilium.io", "ebpf.io"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{SourceNames: []string{"cilium.io"}}},
-					{Flow: &pb.Flow{SourceNames: []string{"ebpf.io"}}},
-					{Flow: &pb.Flow{DestinationNames: []string{"cilium.io"}}},
-					{Flow: &pb.Flow{DestinationNames: []string{"ebpf.io"}}},
+					{Event: &pb.Flow{SourceNames: []string{"cilium.io"}}},
+					{Event: &pb.Flow{SourceNames: []string{"ebpf.io"}}},
+					{Event: &pb.Flow{DestinationNames: []string{"cilium.io"}}},
+					{Event: &pb.Flow{DestinationNames: []string{"ebpf.io"}}},
 				},
 			},
 			want: []bool{
@@ -508,10 +508,10 @@ func TestFQDNFilter(t *testing.T) {
 					{DestinationFqdn: []string{"cilium.io", "ebpf.io"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{SourceNames: []string{"cilium.io"}}},
-					{Flow: &pb.Flow{SourceNames: []string{"ebpf.io"}}},
-					{Flow: &pb.Flow{DestinationNames: []string{"cilium.io"}}},
-					{Flow: &pb.Flow{DestinationNames: []string{"ebpf.io"}}},
+					{Event: &pb.Flow{SourceNames: []string{"cilium.io"}}},
+					{Event: &pb.Flow{SourceNames: []string{"ebpf.io"}}},
+					{Event: &pb.Flow{DestinationNames: []string{"cilium.io"}}},
+					{Event: &pb.Flow{DestinationNames: []string{"ebpf.io"}}},
 				},
 			},
 			want: []bool{
@@ -531,15 +531,15 @@ func TestFQDNFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						SourceNames:      []string{"cilium.io"},
 						DestinationNames: []string{"ebpf.io"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						SourceNames:      []string{"ebpf.io"},
 						DestinationNames: []string{"cilium.io"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						SourceNames:      []string{"deathstar.empire.svc.cluster.local", "docs.cilium.io"},
 						DestinationNames: []string{"ebpf.io"},
 					}},
@@ -559,21 +559,21 @@ func TestFQDNFilter(t *testing.T) {
 					{DestinationFqdn: []string{"ebpf.io"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						SourceNames:      []string{"cilium.io"},
 						DestinationNames: []string{"ebpf.io"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						SourceNames:      []string{"ebpf.io"},
 						DestinationNames: []string{"cilium.io"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						SourceNames: []string{"deathstar.empire.svc.cluster.local", "docs.cilium.io"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						DestinationNames: []string{"ebpf.io"},
 					}},
-					{Flow: &pb.Flow{
+					{Event: &pb.Flow{
 						SourceNames:      []string{"deathstar.empire.svc.cluster.local", "docs.cilium.io"},
 						DestinationNames: []string{"ebpf.io"},
 					}},
@@ -596,10 +596,10 @@ func TestFQDNFilter(t *testing.T) {
 				ev: []*v1.Event{
 					nil,
 					{},
-					{Flow: &pb.Flow{}},
-					{Flow: &pb.Flow{SourceNames: []string{"cilium.io."}}}, // should not have trailing dot
-					{Flow: &pb.Flow{SourceNames: []string{"www.cilium.io"}}},
-					{Flow: &pb.Flow{SourceNames: []string{""}}},
+					{Event: &pb.Flow{}},
+					{Event: &pb.Flow{SourceNames: []string{"cilium.io."}}}, // should not have trailing dot
+					{Event: &pb.Flow{SourceNames: []string{"www.cilium.io"}}},
+					{Event: &pb.Flow{SourceNames: []string{""}}},
 				},
 			},
 			want: []bool{
@@ -637,13 +637,13 @@ func TestFQDNFilter(t *testing.T) {
 					{DestinationFqdn: []string{"*"}},
 				},
 				ev: []*v1.Event{
-					{Flow: &pb.Flow{SourceNames: []string{"www.cilium.io"}}},
-					{Flow: &pb.Flow{SourceNames: []string{"multiple.domains.org"}}},
-					{Flow: &pb.Flow{SourceNames: []string{"cilium.io"}}},
-					{Flow: &pb.Flow{SourceNames: []string{"tiefighter", "empire.org"}}},
-					{Flow: &pb.Flow{DestinationNames: []string{}}},
-					{Flow: &pb.Flow{DestinationNames: []string{"anything.really"}}},
-					{Flow: &pb.Flow{DestinationNames: []string{""}}},
+					{Event: &pb.Flow{SourceNames: []string{"www.cilium.io"}}},
+					{Event: &pb.Flow{SourceNames: []string{"multiple.domains.org"}}},
+					{Event: &pb.Flow{SourceNames: []string{"cilium.io"}}},
+					{Event: &pb.Flow{SourceNames: []string{"tiefighter", "empire.org"}}},
+					{Event: &pb.Flow{DestinationNames: []string{}}},
+					{Event: &pb.Flow{DestinationNames: []string{"anything.really"}}},
+					{Event: &pb.Flow{DestinationNames: []string{""}}},
 				},
 			},
 			want: []bool{
@@ -675,7 +675,7 @@ func TestFQDNFilter(t *testing.T) {
 
 func TestVerdictFilter(t *testing.T) {
 	ev := &v1.Event{
-		Flow: &pb.Flow{
+		Event: &pb.Flow{
 			Verdict: pb.Verdict_FORWARDED,
 		},
 	}
@@ -686,7 +686,7 @@ func TestVerdictFilter(t *testing.T) {
 func TestHttpStatusCodeFilter(t *testing.T) {
 	httpFlow := func(http *pb.HTTP) *v1.Event {
 		return &v1.Event{
-			Flow: &pb.Flow{
+			Event: &pb.Flow{
 				EventType: &pb.CiliumEventType{
 					Type: api.MessageTypeAccessLog,
 				},
@@ -776,9 +776,9 @@ func TestHttpStatusCodeFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Payload: &pb.Payload{Data: nil}},
-					{Payload: &pb.Payload{Data: []byte{byte(api.MessageTypeAccessLog)}}},
-					{Flow: &pb.Flow{}},
+					{Event: &pb.Flow{Payload: &pb.Payload{Data: nil}}},
+					{Event: &pb.Flow{Payload: &pb.Payload{Data: []byte{byte(api.MessageTypeAccessLog)}}}},
+					{Event: &pb.Flow{}},
 					httpFlow(&pb.HTTP{}),
 					httpFlow(&pb.HTTP{Code: 666}),
 				},
@@ -928,28 +928,28 @@ func TestLabelSelectorFilter(t *testing.T) {
 				f: []*pb.FlowFilter{{SourceLabel: []string{"label1", "label2"}}},
 				ev: []*v1.Event{
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1=val1"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label2", "label3", "label4=val4"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label3"},
 							},
@@ -970,56 +970,56 @@ func TestLabelSelectorFilter(t *testing.T) {
 				f: []*pb.FlowFilter{{SourceLabel: []string{"label1=val1", "label2=val2"}}},
 				ev: []*v1.Event{
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1=val1"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1=val2", "label2=val1", "label3"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label2=val2", "label3"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label3=val1"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{""},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: nil,
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1=val1=toomuch"},
 							},
@@ -1044,35 +1044,35 @@ func TestLabelSelectorFilter(t *testing.T) {
 				f: []*pb.FlowFilter{{SourceLabel: []string{"label1 in (val1, val2), label3 notin ()"}}},
 				ev: []*v1.Event{
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1=val1"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1=val2", "label2=val1", "label3=val3"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label2=val2", "label3"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1=val1", "label3=val3"},
 							},
@@ -1099,7 +1099,7 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"src1", "src2=val2"},
 							},
@@ -1109,21 +1109,21 @@ func TestLabelSelectorFilter(t *testing.T) {
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"label1=val1"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Destination: &pb.Endpoint{
 								Labels: []string{"dst1", "dst2=val2"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"dst1", "dst2=val2"},
 							},
@@ -1133,7 +1133,7 @@ func TestLabelSelectorFilter(t *testing.T) {
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"src1"},
 							},
@@ -1162,21 +1162,21 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"src1", "src2=val2"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: nil,
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{""},
 							},
@@ -1200,28 +1200,28 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"k8s:app=bar"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"k8s:foo=baz"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"k8s.app=bar"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"container:foo=bar", "reserved:host"},
 							},
@@ -1246,21 +1246,21 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"key"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"reserved:key"},
 							},
 						},
 					},
 					{
-						Flow: &pb.Flow{
+						Event: &pb.Flow{
 							Source: &pb.Endpoint{
 								Labels: []string{"any.key"},
 							},
@@ -1331,7 +1331,7 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "udp",
 			args: args{
 				f: []*pb.FlowFilter{{Protocol: []string{"udp"}}},
-				ev: &v1.Event{Flow: &pb.Flow{
+				ev: &v1.Event{Event: &pb.Flow{
 					L4: &pb.Layer4{Protocol: &pb.Layer4_UDP{UDP: &pb.UDP{}}},
 				}},
 			},
@@ -1341,7 +1341,7 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "http",
 			args: args{
 				f: []*pb.FlowFilter{{Protocol: []string{"http"}}},
-				ev: &v1.Event{Flow: &pb.Flow{
+				ev: &v1.Event{Event: &pb.Flow{
 					L4: &pb.Layer4{Protocol: &pb.Layer4_TCP{TCP: &pb.TCP{}}},
 					L7: &pb.Layer7{Record: &pb.Layer7_Http{Http: &pb.HTTP{}}},
 				}},
@@ -1352,7 +1352,7 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "icmp (v4)",
 			args: args{
 				f: []*pb.FlowFilter{{Protocol: []string{"icmp"}}},
-				ev: &v1.Event{Flow: &pb.Flow{
+				ev: &v1.Event{Event: &pb.Flow{
 					L4: &pb.Layer4{Protocol: &pb.Layer4_ICMPv4{ICMPv4: &pb.ICMPv4{}}},
 				}},
 			},
@@ -1362,7 +1362,7 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "icmp (v6)",
 			args: args{
 				f: []*pb.FlowFilter{{Protocol: []string{"icmp"}}},
-				ev: &v1.Event{Flow: &pb.Flow{
+				ev: &v1.Event{Event: &pb.Flow{
 					L4: &pb.Layer4{Protocol: &pb.Layer4_ICMPv6{ICMPv6: &pb.ICMPv6{}}},
 				}},
 			},
@@ -1372,7 +1372,7 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "multiple protocols",
 			args: args{
 				f: []*pb.FlowFilter{{Protocol: []string{"tcp", "kafka"}}},
-				ev: &v1.Event{Flow: &pb.Flow{
+				ev: &v1.Event{Event: &pb.Flow{
 					L4: &pb.Layer4{Protocol: &pb.Layer4_TCP{TCP: &pb.TCP{}}},
 				}},
 			},
@@ -1422,7 +1422,7 @@ func TestPortFilter(t *testing.T) {
 					SourcePort:      []string{"12345"},
 					DestinationPort: []string{"53"},
 				}},
-				ev: &v1.Event{Flow: &pb.Flow{
+				ev: &v1.Event{Event: &pb.Flow{
 					L4: &pb.Layer4{Protocol: &pb.Layer4_UDP{UDP: &pb.UDP{
 						SourcePort:      12345,
 						DestinationPort: 53,
@@ -1438,7 +1438,7 @@ func TestPortFilter(t *testing.T) {
 					SourcePort:      []string{"32320"},
 					DestinationPort: []string{"80"},
 				}},
-				ev: &v1.Event{Flow: &pb.Flow{
+				ev: &v1.Event{Event: &pb.Flow{
 					L4: &pb.Layer4{Protocol: &pb.Layer4_TCP{TCP: &pb.TCP{
 						SourcePort:      32320,
 						DestinationPort: 80,
@@ -1453,7 +1453,7 @@ func TestPortFilter(t *testing.T) {
 				f: []*pb.FlowFilter{{
 					DestinationPort: []string{"80"},
 				}},
-				ev: &v1.Event{Flow: &pb.Flow{
+				ev: &v1.Event{Event: &pb.Flow{
 					L4: &pb.Layer4{Protocol: &pb.Layer4_TCP{TCP: &pb.TCP{
 						SourcePort:      80,
 						DestinationPort: 32320,
@@ -1468,7 +1468,7 @@ func TestPortFilter(t *testing.T) {
 				f: []*pb.FlowFilter{{
 					DestinationPort: []string{"0"},
 				}},
-				ev: &v1.Event{Flow: &pb.Flow{
+				ev: &v1.Event{Event: &pb.Flow{
 					L4: &pb.Layer4{Protocol: &pb.Layer4_ICMPv4{ICMPv4: &pb.ICMPv4{}}},
 				}},
 			},

--- a/pkg/metrics/api/api.go
+++ b/pkg/metrics/api/api.go
@@ -17,7 +17,7 @@ package api
 import (
 	"strings"
 
-	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/api/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -71,7 +71,7 @@ type Handler interface {
 
 	// ProcessFlow must processes a flow event and perform metrics
 	// accounting
-	ProcessFlow(flow *pb.Flow)
+	ProcessFlow(flow v1.Flow)
 
 	// Status returns the configuration status of the metric handler
 	Status() string
@@ -79,7 +79,7 @@ type Handler interface {
 
 // ProcessFlow processes a flow by calling ProcessFlow it on to all enabled
 // metric handlers
-func (h Handlers) ProcessFlow(flow *pb.Flow) {
+func (h Handlers) ProcessFlow(flow v1.Flow) {
 	for _, mh := range h {
 		mh.ProcessFlow(flow)
 	}

--- a/pkg/metrics/api/context.go
+++ b/pkg/metrics/api/context.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"strings"
 
-	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/api/v1"
 )
 
 // ContextIdentifier describes the identification method of a transmission or
@@ -113,25 +113,25 @@ func ParseContextOptions(options Options) (*ContextOptions, error) {
 	return o, nil
 }
 
-func sourceNamespaceContext(flow *pb.Flow) (context string) {
-	if flow.Source != nil {
-		context = flow.Source.Namespace
+func sourceNamespaceContext(flow v1.Flow) (context string) {
+	if flow.GetSource() != nil {
+		context = flow.GetSource().Namespace
 	}
 	return
 }
 
-func sourceIdentityContext(flow *pb.Flow) (context string) {
-	if flow.Source != nil {
-		context = strings.Join(flow.Source.Labels, ",")
+func sourceIdentityContext(flow v1.Flow) (context string) {
+	if flow.GetSource() != nil {
+		context = strings.Join(flow.GetSource().Labels, ",")
 	}
 	return
 }
 
-func sourcePodContext(flow *pb.Flow) (context string) {
-	if flow.Source != nil {
-		context = flow.Source.PodName
-		if flow.Source.Namespace != "" {
-			context = flow.Source.Namespace + "/" + context
+func sourcePodContext(flow v1.Flow) (context string) {
+	if flow.GetSource() != nil {
+		context = flow.GetSource().PodName
+		if flow.GetSource().Namespace != "" {
+			context = flow.GetSource().Namespace + "/" + context
 		}
 	}
 	return
@@ -141,45 +141,45 @@ func shortenPodName(name string) string {
 	return shortPodPattern.ReplaceAllString(name, "${1}")
 }
 
-func sourcePodShortContext(flow *pb.Flow) (context string) {
-	if flow.Source != nil {
-		context = shortenPodName(flow.Source.PodName)
-		if flow.Source.Namespace != "" {
-			context = flow.Source.Namespace + "/" + context
+func sourcePodShortContext(flow v1.Flow) (context string) {
+	if flow.GetSource() != nil {
+		context = shortenPodName(flow.GetSource().PodName)
+		if flow.GetSource().Namespace != "" {
+			context = flow.GetSource().Namespace + "/" + context
 		}
 	}
 	return
 }
 
-func destinationNamespaceContext(flow *pb.Flow) (context string) {
-	if flow.Destination != nil {
-		context = flow.Destination.Namespace
+func destinationNamespaceContext(flow v1.Flow) (context string) {
+	if flow.GetDestination() != nil {
+		context = flow.GetDestination().Namespace
 	}
 	return
 }
 
-func destinationIdentityContext(flow *pb.Flow) (context string) {
-	if flow.Destination != nil {
-		context = strings.Join(flow.Destination.Labels, ",")
+func destinationIdentityContext(flow v1.Flow) (context string) {
+	if flow.GetDestination() != nil {
+		context = strings.Join(flow.GetDestination().Labels, ",")
 	}
 	return
 }
 
-func destinationPodContext(flow *pb.Flow) (context string) {
-	if flow.Destination != nil {
-		context = flow.Destination.PodName
-		if flow.Destination.Namespace != "" {
-			context = flow.Destination.Namespace + "/" + context
+func destinationPodContext(flow v1.Flow) (context string) {
+	if flow.GetDestination() != nil {
+		context = flow.GetDestination().PodName
+		if flow.GetDestination().Namespace != "" {
+			context = flow.GetDestination().Namespace + "/" + context
 		}
 	}
 	return
 }
 
-func destinationPodShortContext(flow *pb.Flow) (context string) {
-	if flow.Destination != nil {
-		context = shortenPodName(flow.Destination.PodName)
-		if flow.Destination.Namespace != "" {
-			context = flow.Destination.Namespace + "/" + context
+func destinationPodShortContext(flow v1.Flow) (context string) {
+	if flow.GetDestination() != nil {
+		context = shortenPodName(flow.GetDestination().PodName)
+		if flow.GetDestination().Namespace != "" {
+			context = flow.GetDestination().Namespace + "/" + context
 		}
 	}
 	return
@@ -188,7 +188,7 @@ func destinationPodShortContext(flow *pb.Flow) (context string) {
 // GetLabelValues returns the values of the context relevant labels according
 // to the configured options. The order of the values is the same as the order
 // of the label names returned by GetLabelNames()
-func (o *ContextOptions) GetLabelValues(flow *pb.Flow) (labels []string) {
+func (o *ContextOptions) GetLabelValues(flow v1.Flow) (labels []string) {
 	switch o.Source {
 	case ContextNamespace:
 		labels = append(labels, sourceNamespaceContext(flow))

--- a/pkg/metrics/api/registry_test.go
+++ b/pkg/metrics/api/registry_test.go
@@ -17,7 +17,7 @@ package api
 import (
 	"testing"
 
-	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/api/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -47,7 +47,7 @@ func (t *testHandler) Status() string {
 	return ""
 }
 
-func (t *testHandler) ProcessFlow(p *pb.Flow) {
+func (t *testHandler) ProcessFlow(p v1.Flow) {
 	t.ProcessCalled++
 }
 

--- a/pkg/metrics/dns/handler.go
+++ b/pkg/metrics/dns/handler.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/metrics/api"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -99,12 +100,12 @@ func (d *dnsHandler) Status() string {
 	return strings.Join(append(status, d.context.Status()), ",")
 }
 
-func (d *dnsHandler) ProcessFlow(flow *pb.Flow) {
-	if flow.L7 == nil {
+func (d *dnsHandler) ProcessFlow(flow v1.Flow) {
+	if flow.GetL7() == nil {
 		return
 	}
 
-	dns := flow.L7.GetDns()
+	dns := flow.GetL7().GetDns()
 	if dns == nil {
 		return
 	}
@@ -125,7 +126,7 @@ func (d *dnsHandler) ProcessFlow(flow *pb.Flow) {
 		labels[0] = "Policy denied"
 		d.responses.WithLabelValues(labels...).Inc()
 	} else {
-		if flow.Reply {
+		if flow.GetReply() {
 			labels[0] = rcodeNames[dns.Rcode]
 			d.responses.WithLabelValues(labels...).Inc()
 

--- a/pkg/metrics/drop/handler.go
+++ b/pkg/metrics/drop/handler.go
@@ -52,7 +52,7 @@ func (d *dropHandler) Status() string {
 	return d.context.Status()
 }
 
-func (d *dropHandler) ProcessFlow(flow *pb.Flow) {
+func (d *dropHandler) ProcessFlow(flow v1.Flow) {
 	if flow.GetVerdict() != pb.Verdict_DROPPED {
 		return
 	}

--- a/pkg/metrics/flow/handler.go
+++ b/pkg/metrics/flow/handler.go
@@ -15,7 +15,7 @@
 package flow
 
 import (
-	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/metrics/api"
 
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -41,9 +41,9 @@ func (h *flowHandler) Status() string {
 	return ""
 }
 
-func (h *flowHandler) ProcessFlow(flow *pb.Flow) {
+func (h *flowHandler) ProcessFlow(flow v1.Flow) {
 	var typeName, subType string
-	switch flow.EventType.Type {
+	switch flow.GetEventType().Type {
 	case monitorAPI.MessageTypeAgent:
 		typeName = "Agent"
 	case monitorAPI.MessageTypeAccessLog:
@@ -67,8 +67,8 @@ func (h *flowHandler) ProcessFlow(flow *pb.Flow) {
 		typeName = "Capture"
 	case monitorAPI.MessageTypeTrace:
 		typeName = "Trace"
-		subType = monitorAPI.TraceObservationPoints[uint8(flow.EventType.SubType)]
+		subType = monitorAPI.TraceObservationPoints[uint8(flow.GetEventType().SubType)]
 	}
 
-	h.flows.WithLabelValues(typeName, subType, flow.Verdict.String()).Inc()
+	h.flows.WithLabelValues(typeName, subType, flow.GetVerdict().String()).Inc()
 }

--- a/pkg/metrics/http/handler.go
+++ b/pkg/metrics/http/handler.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/metrics/api"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -65,7 +66,7 @@ func (h *httpHandler) Status() string {
 	return h.context.Status()
 }
 
-func (h *httpHandler) ProcessFlow(flow *pb.Flow) {
+func (h *httpHandler) ProcessFlow(flow v1.Flow) {
 	l7 := flow.GetL7()
 	if l7 == nil {
 		return

--- a/pkg/metrics/icmp/handler.go
+++ b/pkg/metrics/icmp/handler.go
@@ -15,7 +15,7 @@
 package icmp
 
 import (
-	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/metrics/api"
 
 	"github.com/google/gopacket/layers"
@@ -51,7 +51,7 @@ func (h *icmpHandler) Status() string {
 	return h.context.Status()
 }
 
-func (h *icmpHandler) ProcessFlow(flow *pb.Flow) {
+func (h *icmpHandler) ProcessFlow(flow v1.Flow) {
 	l4 := flow.GetL4()
 	if l4 == nil {
 		return

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,7 +17,7 @@ package metrics
 import (
 	"net/http"
 
-	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/metrics/api"
 	_ "github.com/cilium/hubble/pkg/metrics/dns"               // invoke init
 	_ "github.com/cilium/hubble/pkg/metrics/drop"              // invoke init
@@ -37,7 +37,7 @@ var (
 )
 
 // ProcessFlow processes a flow and updates metrics
-func ProcessFlow(flow *pb.Flow) {
+func ProcessFlow(flow v1.Flow) {
 	if enabledMetrics != nil {
 		enabledMetrics.ProcessFlow(flow)
 	}

--- a/pkg/metrics/port-distribution/handler.go
+++ b/pkg/metrics/port-distribution/handler.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/metrics/api"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -52,27 +53,27 @@ func (h *portDistributionHandler) Status() string {
 	return h.context.Status()
 }
 
-func (h *portDistributionHandler) ProcessFlow(flow *pb.Flow) {
-	if flow.GetVerdict() != pb.Verdict_FORWARDED || flow.L4 == nil || flow.Reply {
+func (h *portDistributionHandler) ProcessFlow(flow v1.Flow) {
+	if flow.GetVerdict() != pb.Verdict_FORWARDED || flow.GetL4() == nil || flow.GetReply() {
 		return
 	}
 
-	if tcp := flow.L4.GetTCP(); tcp != nil {
+	if tcp := flow.GetL4().GetTCP(); tcp != nil {
 		labels := append([]string{"TCP", fmt.Sprintf("%d", tcp.DestinationPort)}, h.context.GetLabelValues(flow)...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}
 
-	if udp := flow.L4.GetUDP(); udp != nil {
+	if udp := flow.GetL4().GetUDP(); udp != nil {
 		labels := append([]string{"UDP", fmt.Sprintf("%d", udp.DestinationPort)}, h.context.GetLabelValues(flow)...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}
 
-	if flow.L4.GetICMPv4() != nil {
+	if flow.GetL4().GetICMPv4() != nil {
 		labels := append([]string{"ICMPv4", "0"}, h.context.GetLabelValues(flow)...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}
 
-	if flow.L4.GetICMPv6() != nil {
+	if flow.GetL4().GetICMPv6() != nil {
 		labels := append([]string{"ICMPv6", "0"}, h.context.GetLabelValues(flow)...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}

--- a/pkg/metrics/tcp/handler.go
+++ b/pkg/metrics/tcp/handler.go
@@ -16,6 +16,7 @@ package tcp
 
 import (
 	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/metrics/api"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,13 +51,13 @@ func (h *tcpHandler) Status() string {
 	return h.context.Status()
 }
 
-func (h *tcpHandler) ProcessFlow(flow *pb.Flow) {
-	if flow.GetVerdict() != pb.Verdict_FORWARDED || flow.L4 == nil {
+func (h *tcpHandler) ProcessFlow(flow v1.Flow) {
+	if flow.GetVerdict() != pb.Verdict_FORWARDED || flow.GetL4() == nil {
 		return
 	}
 
 	ip := flow.GetIP()
-	tcp := flow.L4.GetTCP()
+	tcp := flow.GetL4().GetTCP()
 	if ip == nil || tcp == nil || tcp.Flags == nil {
 		return
 	}


### PR DESCRIPTION
This introduces an interface for `pb.Flow` and generalizes `v1.Event` to return an instance of the interface. This allows better mocking and alternative flow implementations in the future.

The second PR moves the `metrics.ProcessFlow` over to the new interface .
