### PR TITLE
endpoints: Improve handling of deleted endpoints

### DIFF
--- a/pkg/api/v1/endpoint.go
+++ b/pkg/api/v1/endpoint.go
@@ -101,6 +101,10 @@ func (es *Endpoints) FindEPs(epID uint64, namespace string, podName string) []En
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 	for _, ep := range es.eps {
+		if ep.Deleted != nil {
+			continue
+		}
+
 		// If is the endpoint ID we are looking for
 		if (epID != 0 && ep.ID == epID) ||
 			// The pod name is the one we are looking for
@@ -172,7 +176,7 @@ func (es *Endpoints) GetEndpoint(ip net.IP) (endpoint *Endpoint, ok bool) {
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 	for _, ep := range es.eps {
-		if ep.IPv4.Equal(ip) || ep.IPv6.Equal(ip) {
+		if ep.Deleted == nil && (ep.IPv4.Equal(ip) || ep.IPv6.Equal(ip)) {
 			return ep, true
 		}
 	}

--- a/pkg/api/v1/endpoint.go
+++ b/pkg/api/v1/endpoint.go
@@ -171,6 +171,20 @@ func (es *Endpoints) MarkDeleted(del *Endpoint) {
 	es.eps = append(es.eps, del)
 }
 
+// GarbageCollect removes all endpoints marked as deleted from the collection
+func (es *Endpoints) GarbageCollect() {
+	es.mutex.Lock()
+	defer es.mutex.Unlock()
+	n := 0
+	for _, ep := range es.eps {
+		if ep.Deleted == nil {
+			es.eps[n] = ep
+			n++
+		}
+	}
+	es.eps = es.eps[:n]
+}
+
 // GetEndpoint returns the endpoint that has the given ip.
 func (es *Endpoints) GetEndpoint(ip net.IP) (endpoint *Endpoint, ok bool) {
 	es.mutex.RLock()

--- a/pkg/server/endpoint.go
+++ b/pkg/server/endpoint.go
@@ -63,6 +63,7 @@ func (s *ObserverServer) syncEndpoints() {
 		}
 
 		s.endpoints.SyncEndpoints(parsedEPs)
+		s.endpoints.GarbageCollect()
 	}
 }
 

--- a/pkg/server/endpoint_test.go
+++ b/pkg/server/endpoint_test.go
@@ -95,6 +95,7 @@ type fakeEndpointsHandler struct {
 	fakeMarkDeleted    func(*v1.Endpoint)
 	fakeFindEPs        func(epID uint64, ns, pod string) []v1.Endpoint
 	fakeGetEndpoint    func(ip net.IP) (endpoint *v1.Endpoint, ok bool)
+	fakeGarbageCollect func()
 }
 
 func (f *fakeEndpointsHandler) SyncEndpoints(eps []*v1.Endpoint) {
@@ -133,6 +134,14 @@ func (f *fakeEndpointsHandler) GetEndpoint(ip net.IP) (ep *v1.Endpoint, ok bool)
 		return f.fakeGetEndpoint(ip)
 	}
 	panic("GetEndpoint(ip net.IP) (ep *v1.Endpoint, ok bool) should not have been called since it was not defined")
+}
+
+func (f *fakeEndpointsHandler) GarbageCollect() {
+	if f.fakeGarbageCollect != nil {
+		f.fakeGarbageCollect()
+		return
+	}
+	panic("GarbageCollect() should not have been called since it was not defined")
 }
 
 func TestObserverServer_syncAllEndpoints(t *testing.T) {
@@ -204,6 +213,7 @@ func TestObserverServer_syncAllEndpoints(t *testing.T) {
 			endpoints = append(endpoints, ep)
 			endpointsMutex.Unlock()
 		},
+		fakeGarbageCollect: func() {},
 	}
 	s := &ObserverServer{
 		ciliumClient: fakeClient,

--- a/pkg/server/observer.go
+++ b/pkg/server/observer.go
@@ -54,6 +54,7 @@ type endpointsHandler interface {
 	MarkDeleted(*v1.Endpoint)
 	FindEPs(epID uint64, ns, pod string) []v1.Endpoint
 	GetEndpoint(ip net.IP) (endpoint *v1.Endpoint, ok bool)
+	GarbageCollect()
 }
 
 type fqdnCache interface {


### PR DESCRIPTION
This adds two commits improving the handling of deleted endpoints.

The first commit ensures that no deleted endpoints are used to annotate flows, while the second periodically removes deleted endpoints from the cache.