### PR TITLE
Add support for specifying server in client via env variable

### DIFF
--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -37,6 +37,7 @@ import (
 
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 )
 
@@ -113,6 +114,7 @@ programs attached to endpoints and devices. This includes:
 		},
 	}
 	observerCmd.Flags().StringVarP(&serverURL, "server", "", serverClientSocket, "URL to connect to server")
+	viper.BindEnv("server", "HUBBLE_SOCK")
 	observerCmd.Flags().StringVar(&serverTimeoutVar, "timeout", "5s", "How long to wait before giving up on server dialing")
 	observerCmd.Flags().VarP(filterVarP(
 		"type", "t", ofilter, allTypes,

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/hubble/api/v1/observer"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -41,6 +42,7 @@ var (
 func init() {
 	rootCmd.AddCommand(statusCmd)
 	statusCmd.Flags().StringVarP(&serverURL, "server", "", serverClientSocket, "URL to connect to server")
+	viper.BindEnv("server", "HUBBLE_SOCK")
 }
 
 func runStatus(serverURL string) error {


### PR DESCRIPTION
Allow the $HUBBLE_SOCK environment variable to override the server socket
path for the client.