### PR TITLE
make: Add ineffassign target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,10 @@ lint:
 check-fmt:
 	./contrib/scripts/check-fmt.sh
 
+ineffassign:
+	ineffassign .
+
 image:
 	$(CONTAINER_ENGINE) build -t $(IMAGE_REPOSITORY)$(if $(IMAGE_TAG),:$(IMAGE_TAG)) .
 
-.PHONY: all clean check-fmt image install lint test hubble
+.PHONY: all clean check-fmt image ineffassign install lint test hubble

--- a/pkg/parser/threefour/parser_test.go
+++ b/pkg/parser/threefour/parser_test.go
@@ -463,6 +463,7 @@ func TestTraceNotifyOriginalIP(t *testing.T) {
 		OrigIP: [16]byte{1, 1, 1, 1},
 	}
 	data, err = testutils.CreateL3L4Payload(v1, &eth, &ip, &layers.TCP{})
+	require.NoError(t, err)
 	err = parser.Decode(&pb.Payload{Data: data}, f)
 	require.NoError(t, err)
 	assert.Equal(t, f.IP.Source, "1.1.1.1")


### PR DESCRIPTION
This PR:

- adds the `ineffassign` target, similar to what we have in Cilium
- fixes one ineffassign error