### PR TITLE
make: Follow up changes

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         export PATH=${PATH}:${GOPATH}/bin
         go get -u github.com/golang/dep/cmd/dep
+        go get -u github.com/gordonklaus/ineffassign
         go get -u golang.org/x/lint/golint
         dep check
         make check-fmt lint test

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,18 @@ test:
 	go test -timeout=30s -cover $$(go list ./...)
 
 lint:
+ifeq (, $(shell which golint))
+	$(error "golint not installed; you can install it with `go get -u golang.org/x/lint/golint`")
+endif
 	golint -set_exit_status $$(go list ./...)
 
 check-fmt:
 	./contrib/scripts/check-fmt.sh
 
 ineffassign:
+ifeq (, $(shell which ineffassign))
+	$(error "ineffassign not installed; you can install it with `go get -u github.com/gordonklaus/ineffassign`")
+endif
 	ineffassign .
 
 image:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean:
 test:
 	go test -timeout=30s -cover $$(go list ./...)
 
-lint:
+lint: check-fmt ineffassign
 ifeq (, $(shell which golint))
 	$(error "golint not installed; you can install it with `go get -u golang.org/x/lint/golint`")
 endif


### PR DESCRIPTION
- Check whether binaries of linters exist
- Add `check-fmt` and `ineffassign` targets to the `lint` target