### PR TITLE
Documentation: Provide Kubernetes bash helpers

### DIFF
--- a/install/kubernetes/helpers.bash
+++ b/install/kubernetes/helpers.bash
@@ -1,0 +1,28 @@
+# Copyright 2019 Authors of Hubble
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function hubble-cluster {
+    while read -r p; do
+        kubectl -n kube-system exec $p -- $*
+    done <<< "$(kubectl -n kube-system get pods -l k8s-app=hubble -o json | jq -r ".items[].metadata.name")"
+}
+
+function node-of-pod {
+    kubectl -n $1 get pods $2 -o json | jq '.spec.nodeName'
+}
+
+function hubble-pod {
+    kubectl -n kube-system get pods -l k8s-app=hubble -o json | \
+    jq -r ".items[] | select(.spec.nodeName==$(node-of-pod $1 $2)) | .metadata.name"
+}

--- a/tutorials/explore-flow-queries/README.md
+++ b/tutorials/explore-flow-queries/README.md
@@ -4,6 +4,29 @@
 
     hubble observe [OPTIONS] [FILTERS]
 
+# Kubernetes Helpers
+
+The file [helpers.bash](../../install/kubernetes/helpers.bash) contains a set
+of Bash functions which assist in using Hubble with Kubernetes. Source the file
+in you Bash environment as follows:
+
+``` bash
+source install/kubernetes/helpers.bash
+```
+
+You can then run a Hubble CLI command across the entire cluster:
+
+``` bash
+hubble-cluster hubble observe --protocol dns --since=10m
+```
+
+Identify the Hubble pod name which runs on the same node as the pod specified:
+
+``` bash
+kubectl -n kube-system exec -ti $(hubble-pod default mypod-xxx) -- \
+    hubble observe --since=5m --pod default/mypod-xxx -t drop
+```
+
 # Filters
 
 Most filters support three variants to be specified `--field`, `--to-field`,


### PR DESCRIPTION
Defines a set of helpers to simplify usage of Hubble with Kubernetes.

Signed-off-by: Thomas Graf <thomas@cilium.io>