### PR TITLE
Split up cmd package

### DIFF
--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -24,26 +24,20 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gogo/protobuf/types"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	pb "github.com/cilium/hubble/api/v1/flow"
 	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/cilium/hubble/pkg/api"
 	"github.com/cilium/hubble/pkg/format"
 	"github.com/cilium/hubble/pkg/logger"
 	hubprinter "github.com/cilium/hubble/pkg/printer"
 	hubtime "github.com/cilium/hubble/pkg/time"
-
-	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
-)
-
-const (
-	connTimeout        = 12 * time.Second
-	serverClientSocket = serverSocketPath
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -113,17 +107,30 @@ programs attached to endpoints and devices. This includes:
 			return nil
 		},
 	}
-	observerCmd.Flags().StringVarP(&serverURL, "server", "", serverClientSocket, "URL to connect to server")
+	observerCmd.Flags().StringVarP(&serverURL,
+		"server", "", api.DefaultSocketPath,
+		"URL to connect to server")
 	viper.BindEnv("server", "HUBBLE_SOCK")
-	observerCmd.Flags().StringVar(&serverTimeoutVar, "timeout", "5s", "How long to wait before giving up on server dialing")
+
+	observerCmd.Flags().StringVar(&serverTimeoutVar,
+		"timeout", "5s",
+		"How long to wait before giving up on server dialing")
 	observerCmd.Flags().VarP(filterVarP(
 		"type", "t", ofilter, allTypes,
 		fmt.Sprintf("Filter by event types TYPE[:SUBTYPE] (%v)", eventTypes())))
 
-	observerCmd.Flags().Uint64Var(&last, "last", 0, "Get last N flows stored in the hubble")
-	observerCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow flows output")
-	observerCmd.Flags().StringVar(&sinceVar, "since", "", "Filter flows since a specific date (relative or RFC3339)")
-	observerCmd.Flags().StringVar(&untilVar, "until", "", "Filter flows until a specific date (relative or RFC3339)")
+	observerCmd.Flags().Uint64Var(&last,
+		"last", 0,
+		"Get last N flows stored in the hubble")
+	observerCmd.Flags().BoolVarP(&follow,
+		"follow", "f", false,
+		"Follow flows output")
+	observerCmd.Flags().StringVar(&sinceVar,
+		"since", "",
+		"Filter flows since a specific date (relative or RFC3339)")
+	observerCmd.Flags().StringVar(&untilVar,
+		"until", "",
+		"Filter flows until a specific date (relative or RFC3339)")
 
 	observerCmd.Flags().Var(filterVar(
 		"not", ofilter,

--- a/cmd/observe/observe_filter.go
+++ b/cmd/observe/observe_filter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package observe
 
 import (
 	"bytes"
@@ -22,10 +22,9 @@ import (
 	"strings"
 
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	pb "github.com/cilium/hubble/api/v1/flow"
 	"github.com/gogo/protobuf/proto"
 	"github.com/spf13/pflag"
-
-	pb "github.com/cilium/hubble/api/v1/flow"
 )
 
 type (

--- a/cmd/observe/observe_usage.go
+++ b/cmd/observe/observe_usage.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package observe
 
 import (
 	"bytes"

--- a/cmd/observe/observe_usage_test.go
+++ b/cmd/observe/observe_usage_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package observe
 
 import (
 	"bytes"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/cilium/hubble/cmd/status"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -67,6 +68,8 @@ func init() {
 	)
 	rootCmd.PersistentFlags().Lookup("cpuprofile").Hidden = true
 	rootCmd.PersistentFlags().Lookup("memprofile").Hidden = true
+
+	rootCmd.AddCommand(status.New())
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/cilium/hubble/cmd/observe"
 	"github.com/cilium/hubble/cmd/serve"
 	"github.com/cilium/hubble/cmd/status"
 	"github.com/cilium/hubble/pkg/logger"
@@ -76,6 +77,7 @@ func init() {
 	// initialize all subcommands
 	rootCmd.AddCommand(status.New())
 	rootCmd.AddCommand(serve.New(l))
+	rootCmd.AddCommand(observe.New(l))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,9 @@ import (
 	"io"
 	"os"
 
+	"github.com/cilium/hubble/cmd/serve"
 	"github.com/cilium/hubble/cmd/status"
+	"github.com/cilium/hubble/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -69,7 +71,11 @@ func init() {
 	rootCmd.PersistentFlags().Lookup("cpuprofile").Hidden = true
 	rootCmd.PersistentFlags().Lookup("memprofile").Hidden = true
 
+	l := logger.GetLogger()
+
+	// initialize all subcommands
 	rootCmd.AddCommand(status.New())
+	rootCmd.AddCommand(serve.New(l))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -28,4 +28,10 @@ const (
 	SocketFileMode os.FileMode = 0660
 	// ClientTimeout specifies timeout to be used by clients
 	ClientTimeout = 90 * time.Second
+
+	// DefaultSocketPath which hubble listens to
+	DefaultSocketPath = "unix:///var/run/hubble.sock"
+
+	// ConnectionTimeout ...
+	ConnectionTimeout = 12 * time.Second
 )


### PR DESCRIPTION
This isolates individual sub-commands from each other and should set up a better structure moving forward. `pacakge cmd` was getting a little out of hand.

There is still more work that can be done to make these packages better testable (mostly removing a lot of the global vars and stuff), but it's currently not a priority.