### PR TITLE
Added prometheus-operator ServiceMonitor

### DIFF
--- a/install/kubernetes/hubble/templates/daemonset.yaml
+++ b/install/kubernetes/hubble/templates/daemonset.yaml
@@ -16,7 +16,7 @@ spec:
         # gets priority scheduling, same as cilium-agent.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
-{{- if .Values.metrics.enabled }}
+{{- if and .Values.metrics.enabled (not .Values.metrics.serviceMonitor.enabled) }}
         prometheus.io/port: {{ regexReplaceAll ":([0-9]+)$" .Values.metrics.address "${1}" | quote }}
         prometheus.io/scrape: "true"
 {{- end }}
@@ -86,6 +86,7 @@ spec:
 {{- if .Values.metrics.enabled }}
         - containerPort: {{ regexReplaceAll ":([0-9]+)$" .Values.metrics.address "${1}" }}
           protocol: TCP
+          name: metrics
 {{- end }}
         readinessProbe:
           exec:

--- a/install/kubernetes/hubble/templates/servicemonitor.yaml
+++ b/install/kubernetes/hubble/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.metrics.enabled (.Values.metrics.serviceMonitor.enabled) }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hubble
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: hubble-metrics
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: metrics
+    interval: 10s
+    honorLabels: true
+    path: /metrics
+{{- end }}

--- a/install/kubernetes/hubble/templates/svc.yaml
+++ b/install/kubernetes/hubble/templates/svc.yaml
@@ -30,5 +30,24 @@ spec:
       port: 12000
       targetPort: 12000
   type: ClusterIP
+{{- end }}
+{{- if and .Values.metrics.enabled (.Values.metrics.serviceMonitor.enabled) }}
 ---
+kind: Service
+apiVersion: v1
+metadata:
+  name: hubble-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: hubble-metrics
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: {{ regexReplaceAll ":([0-9]+)$" .Values.metrics.address "${1}" }}
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    k8s-app: hubble
 {{- end }}

--- a/install/kubernetes/hubble/values.yaml
+++ b/install/kubernetes/hubble/values.yaml
@@ -33,6 +33,9 @@ metrics:
   enabled:
    - drop
   address: ":6943"
+  # Create a prometheus-operator servicemonitor
+  serviceMonitor:
+    enabled: false
 
 # Configuration for hubble ui
 ui:


### PR DESCRIPTION
This adds an option to create prometheus-operator [ServiceMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#servicemonitor) resource.