### PR TITLE
helm: set priorityClassName to system-node-critical for hubble pods

### DIFF
--- a/install/kubernetes/hubble/templates/daemonset.yaml
+++ b/install/kubernetes/hubble/templates/daemonset.yaml
@@ -10,13 +10,8 @@ spec:
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      annotations:
-        # This annotation plus the CriticalAddonsOnly toleration makes
-        # hubble to be a critical pod in the cluster, which ensures hubble
-        # gets priority scheduling, same as cilium-agent.
-        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ""
 {{- if and .Values.metrics.enabled (not .Values.metrics.serviceMonitor.enabled) }}
+      annotations:
         prometheus.io/port: {{ regexReplaceAll ":([0-9]+)$" .Values.metrics.address "${1}" | quote }}
         prometheus.io/scrape: "true"
 {{- end }}
@@ -24,6 +19,7 @@ spec:
         k8s-app: hubble
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: system-node-critical
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
+++ b/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
@@ -147,17 +147,13 @@ spec:
   template:
     metadata:
       annotations:
-        # This annotation plus the CriticalAddonsOnly toleration makes
-        # hubble to be a critical pod in the cluster, which ensures hubble
-        # gets priority scheduling, same as cilium-agent.
-        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ""
         prometheus.io/port: "6943"
         prometheus.io/scrape: "true"
       labels:
         k8s-app: hubble
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: system-node-critical
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The annnotation `scheduler.alpha.kubernetes.io/critical-pod` is now obsolete and has to be replaced by the priorityClassName spec instead to mark an add-on pod as critical.

There exists 2 priority classes to mark an add-on pod as critical (only under the `kube-system` namespace), namely:
- `system-cluster-critical` (value: 2000000000)
- `system-node-critical`    (value: 2000001000)

As the hubble pod is critical to the node itself, the system-node-critical priority class is appropriate for hubble pods.

Closes #25 