### PR TITLE
refactor: Move ipCacheEvents channel inside ObserverServer

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -391,11 +391,8 @@ func consumeMonitorEvents(s *server.ObserverServer, conn net.Conn, version liste
 	defer conn.Close()
 	ch := s.GetEventsChannel()
 	endpointEvents := s.GetEndpointEventsChannel()
-
+	ipCacheEvents := s.GetIPCacheChannel()
 	dnsAdd := s.GetLogRecordNotifyChannel()
-
-	ipCacheEvents := make(chan monitorAPI.AgentNotify, 100)
-	s.StartMirroringIPCache(ipCacheEvents)
 
 	getParsedPayload, err := getMonitorParser(conn, version)
 	if err != nil {

--- a/pkg/server/endpoint_test.go
+++ b/pkg/server/endpoint_test.go
@@ -87,6 +87,9 @@ var fakeDummyCiliumClient = &fakeCiliumClient{
 	fakeGetFqdnCache: func() ([]*models.DNSLookup, error) {
 		return nil, nil
 	},
+	fakeGetIPCache: func() ([]*models.IPListEntry, error) {
+		return nil, nil
+	},
 }
 
 type fakeEndpointsHandler struct {

--- a/pkg/server/ipcache_test.go
+++ b/pkg/server/ipcache_test.go
@@ -57,12 +57,12 @@ func TestObserverServer_syncIPCache(t *testing.T) {
 	}
 
 	s := &ObserverServer{
-		ciliumClient: fakeClient,
-		ipcache:      ipc,
-		log:          zap.L(),
+		ciliumClient:  fakeClient,
+		ipcache:       ipc,
+		log:           zap.L(),
+		ipCacheEvents: make(chan monitorAPI.AgentNotify, 100),
 	}
 
-	ipCacheEvents := make(chan monitorAPI.AgentNotify, 100)
 	go func() {
 		id100 := uint32(100)
 		id200 := uint32(200)
@@ -70,34 +70,34 @@ func TestObserverServer_syncIPCache(t *testing.T) {
 		// stale update, should be ignored
 		n, err := monitorAPI.IPCacheNotificationRepr("3.3.3.3/32", id100, &id200, nil, nil, 0, "", "")
 		require.NoError(t, err)
-		ipCacheEvents <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyIPCacheUpserted, Text: n}
+		s.GetIPCacheChannel() <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyIPCacheUpserted, Text: n}
 
 		// delete 2.2.2.2
 		n, err = monitorAPI.IPCacheNotificationRepr("2.2.2.2/32", id100, nil, nil, nil, 0, "", "")
 		require.NoError(t, err)
-		ipCacheEvents <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyIPCacheDeleted, Text: n}
+		s.GetIPCacheChannel() <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyIPCacheDeleted, Text: n}
 
 		// reinsert 2.2.2.2 with pod name
 		n, err = monitorAPI.IPCacheNotificationRepr("2.2.2.2/32", id100, nil, nil, nil, 0, "ns-2", "pod-2")
 		require.NoError(t, err)
-		ipCacheEvents <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyIPCacheUpserted, Text: n}
+		s.GetIPCacheChannel() <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyIPCacheUpserted, Text: n}
 
 		// update 1.1.1.1 with pod name
 		n, err = monitorAPI.IPCacheNotificationRepr("1.1.1.1/32", id100, &id100, nil, nil, 0, "ns-1", "pod-1")
 		require.NoError(t, err)
-		ipCacheEvents <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyIPCacheUpserted, Text: n}
+		s.GetIPCacheChannel() <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyIPCacheUpserted, Text: n}
 
 		// delete 4.4.4.4
 		n, err = monitorAPI.IPCacheNotificationRepr("4.4.4.4/32", id100, nil, nil, nil, 0, "", "")
 		require.NoError(t, err)
-		ipCacheEvents <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyIPCacheDeleted, Text: n}
+		s.GetIPCacheChannel() <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyIPCacheDeleted, Text: n}
 
-		close(ipCacheEvents)
+		close(s.GetIPCacheChannel())
 	}()
 
 	// blocks until channel is closed
-	s.syncIPCache(ipCacheEvents)
-	assert.Equal(t, 0, len(ipCacheEvents))
+	s.syncIPCache()
+	assert.Equal(t, 0, len(s.GetIPCacheChannel()))
 
 	id100 := identity.NumericIdentity(100)
 

--- a/pkg/server/observer.go
+++ b/pkg/server/observer.go
@@ -104,6 +104,9 @@ type ObserverServer struct {
 
 	// payloadParser decodes pb.Payload into pb.Flow
 	payloadParser *parser.Parser
+
+	// channel to receive AgentNotify events to keep ipcache up to date.
+	ipCacheEvents chan monitorAPI.AgentNotify
 }
 
 // NewServer returns a server that can store up to the given of maxFlows
@@ -131,6 +134,7 @@ func NewServer(
 		logRecord:      make(chan monitor.LogRecordNotify, 100),
 		eventschan:     make(chan *observer.GetFlowsResponse, 100),
 		payloadParser:  payloadParser,
+		ipCacheEvents:  make(chan monitorAPI.AgentNotify, 100),
 	}
 }
 
@@ -141,6 +145,7 @@ func (s *ObserverServer) Start() {
 	go s.syncFQDNCache()
 	go s.consumeEndpointEvents()
 	go s.consumeLogRecordNotifyChannel()
+	go s.syncIPCache()
 
 	for pl := range s.events {
 		flow, err := s.decodeFlow(pl)
@@ -160,15 +165,9 @@ func (s *ObserverServer) Start() {
 	close(s.stopped)
 }
 
-// StartMirroringIPCache will obtain an initial IPCache snapshot from Cilium
-// and then start mirroring IPCache events based on IPCacheNotification sent
-// through the ipCacheEvents channels. Only messages of type
-// `AgentNotifyIPCacheUpserted` and `AgentNotifyIPCacheDeleted` should be sent
-// through that channel. This function assumes that the caller is already
-// connected to Cilium Monitor, i.e. no IPCacheNotification must be lost after
-// calling this method.
-func (s *ObserverServer) StartMirroringIPCache(ipCacheEvents <-chan monitorAPI.AgentNotify) {
-	go s.syncIPCache(ipCacheEvents)
+// GetIPCacheChannel returns the channel to receive AgentNotify events.
+func (s *ObserverServer) GetIPCacheChannel() chan<- monitorAPI.AgentNotify {
+	return s.ipCacheEvents
 }
 
 // GetLogRecordNotifyChannel returns the event channel to receive


### PR DESCRIPTION
To be consistent with other channels like endpointEvents and logRecord.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>