### PR TITLE
Revert "refactor: Move ipCacheEvents channel inside ObserverServer"

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -391,8 +391,11 @@ func consumeMonitorEvents(s *server.ObserverServer, conn net.Conn, version liste
 	defer conn.Close()
 	ch := s.GetEventsChannel()
 	endpointEvents := s.GetEndpointEventsChannel()
-	ipCacheEvents := s.GetIPCacheChannel()
+
 	dnsAdd := s.GetLogRecordNotifyChannel()
+
+	ipCacheEvents := make(chan monitorAPI.AgentNotify, 100)
+	s.StartMirroringIPCache(ipCacheEvents)
 
 	getParsedPayload, err := getMonitorParser(conn, version)
 	if err != nil {

--- a/pkg/server/endpoint_test.go
+++ b/pkg/server/endpoint_test.go
@@ -87,9 +87,6 @@ var fakeDummyCiliumClient = &fakeCiliumClient{
 	fakeGetFqdnCache: func() ([]*models.DNSLookup, error) {
 		return nil, nil
 	},
-	fakeGetIPCache: func() ([]*models.IPListEntry, error) {
-		return nil, nil
-	},
 }
 
 type fakeEndpointsHandler struct {


### PR DESCRIPTION
This reverts commit d02b338a9eb5e60268466780a83f434002b0a603.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>