### PR TITLE
serve: Add "local" mode

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -90,7 +90,30 @@ func New(log *zap.Logger) *cobra.Command {
 				}()
 			}
 
-			err = Serve(log, listenClientUrls)
+			ciliumClient, err := client.NewClient()
+			if err != nil {
+				log.Fatal("failed to get Cilium client", zap.Error(err))
+			}
+			ipCache := ipcache.New()
+			fqdnCache := fqdncache.New()
+			endpoints := v1.NewEndpoints()
+			podGetter := &server.LegacyPodGetter{
+				PodGetter:      ipCache,
+				EndpointGetter: endpoints,
+			}
+			payloadParser, err := parser.New(endpoints, ciliumClient, fqdnCache, podGetter)
+			if err != nil {
+				log.Fatal("failed to get parser", zap.Error(err))
+			}
+			s := server.NewServer(
+				ciliumClient,
+				endpoints,
+				ipCache,
+				fqdnCache,
+				payloadParser,
+				int(maxFlows),
+			)
+			err = Serve(log, listenClientUrls, s)
 			if err != nil {
 				log.Fatal("", zap.Error(err))
 			}
@@ -224,38 +247,11 @@ func setupListeners(listenClientUrls []string) (listeners map[string]net.Listene
 
 // Serve starts the GRPC server on the provided socketPath. If the port is non-zero, it listens
 // to the TCP port instead of the unix domain socket.
-func Serve(log *zap.Logger, listenClientUrls []string) error {
+func Serve(log *zap.Logger, listenClientUrls []string, s server.Observer) error {
 	clientListeners, err := setupListeners(listenClientUrls)
 	if err != nil {
 		return err
 	}
-
-	ciliumClient, err := client.NewClient()
-	if err != nil {
-		return err
-	}
-
-	ipCache := ipcache.New()
-	fqdnCache := fqdncache.New()
-	endpoints := v1.NewEndpoints()
-	podGetter := &server.LegacyPodGetter{
-		PodGetter:      ipCache,
-		EndpointGetter: endpoints,
-	}
-
-	payloadParser, err := parser.New(endpoints, ciliumClient, fqdnCache, podGetter)
-	if err != nil {
-		return err
-	}
-
-	s := server.NewServer(
-		ciliumClient,
-		endpoints,
-		ipCache,
-		fqdnCache,
-		payloadParser,
-		int(maxFlows),
-	)
 
 	serverStart = time.Now()
 	go s.Start()
@@ -292,6 +288,11 @@ func Serve(log *zap.Logger, listenClientUrls []string) error {
 
 	setupSigHandler()
 	fmt.Printf("Press Ctrl-C to quit\n")
+
+	if !s.UseMonitorSocket() {
+		// Don't connect to monitor socket. Block here.
+		select {}
+	}
 
 	// On EOF, retry
 	// On other errors, exit
@@ -387,7 +388,7 @@ func getMonitorParser(conn net.Conn, version listener.Version) (parser eventPars
 // consumeMonitorEvents handles and prints events on a monitor connection. It
 // calls getMonitorParsed to construct a monitor-version appropriate parser.
 // It closes conn on return, and returns on error, including io.EOF
-func consumeMonitorEvents(s *server.ObserverServer, conn net.Conn, version listener.Version) error {
+func consumeMonitorEvents(s server.Observer, conn net.Conn, version listener.Version) error {
 	defer conn.Close()
 	ch := s.GetEventsChannel()
 	endpointEvents := s.GetEndpointEventsChannel()

--- a/pkg/server/local_observer.go
+++ b/pkg/server/local_observer.go
@@ -1,0 +1,160 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/math"
+	"github.com/cilium/cilium/pkg/monitor"
+	"github.com/cilium/cilium/pkg/monitor/api"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"go.uber.org/zap"
+
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/cilium/hubble/pkg/container"
+	"github.com/cilium/hubble/pkg/logger"
+	"github.com/cilium/hubble/pkg/parser"
+)
+
+// LocalObserverServer is an implementation of the server.Observer interface
+// that's meant to be run embedded inside the Cilium process. It ignores all
+// the state change events since the state is available locally.
+type LocalObserverServer struct {
+	// ring buffer that contains the references of all flows
+	ring *container.Ring
+
+	// events is the channel used by the writer(s) to send the flow data
+	// into the observer server.
+	events chan *pb.Payload
+
+	// stopped is mostly used in unit tests to signalize when the events
+	// channel is empty, once it's closed.
+	stopped chan struct{}
+
+	log *zap.Logger
+
+	// channel to receive events from observer server.
+	eventschan chan *observer.GetFlowsResponse
+
+	// payloadParser decodes pb.Payload into pb.Flow
+	payloadParser *parser.Parser
+
+	// noop channels
+	endpointEvents chan monitorAPI.AgentNotify
+	logRecord      chan monitor.LogRecordNotify
+}
+
+// NewLocalServer returns a new local observer server.
+func NewLocalServer(
+	payloadParser *parser.Parser,
+	maxFlows int,
+) *LocalObserverServer {
+	return &LocalObserverServer{
+		log:  logger.GetLogger(),
+		ring: container.NewRing(maxFlows),
+		// have a channel with 1% of the max flows that we can receive
+		events:         make(chan *pb.Payload, uint64(math.IntMin(maxFlows/100, 100))),
+		stopped:        make(chan struct{}),
+		eventschan:     make(chan *observer.GetFlowsResponse, 100),
+		payloadParser:  payloadParser,
+		endpointEvents: make(chan monitorAPI.AgentNotify),
+		logRecord:      make(chan monitor.LogRecordNotify),
+	}
+}
+
+// Start starts the server to handle the events sent to the events channel as
+// well as handle events to the EpAdd and EpDel channels.
+func (s *LocalObserverServer) Start() {
+	go s.consumeEndpointEvents()
+	go s.consumeLogRecordNotify()
+	processEvents(s)
+}
+
+// GetEventsChannel returns the event channel to receive pb.Payload events.
+func (s *LocalObserverServer) GetEventsChannel() chan *pb.Payload {
+	return s.events
+}
+
+// GetRingBuffer implements Observer.GetRingBuffer.
+func (s *LocalObserverServer) GetRingBuffer() *container.Ring {
+	return s.ring
+}
+
+// GetLogger implements Observer.GetLogger.
+func (s *LocalObserverServer) GetLogger() *zap.Logger {
+	return s.log
+}
+
+// GetStopped implements Observer.GetStopped.
+func (s *LocalObserverServer) GetStopped() chan struct{} {
+	return s.stopped
+}
+
+// GetPayloadParser implements Observer.GetPayloadParser.
+func (s *LocalObserverServer) GetPayloadParser() *parser.Parser {
+	return s.payloadParser
+}
+
+// ServerStatus should have a comment, apparently. It returns the server status.
+func (s *LocalObserverServer) ServerStatus(
+	ctx context.Context, req *observer.ServerStatusRequest,
+) (*observer.ServerStatusResponse, error) {
+	return getServerStatusFromObserver(s)
+}
+
+// GetFlows implements the proto method for client requests.
+func (s *LocalObserverServer) GetFlows(
+	req *observer.GetFlowsRequest,
+	server observer.Observer_GetFlowsServer,
+) (err error) {
+	return getFlowsFromObserver(req, server, s)
+}
+
+// GetEndpointEventsChannel implements Observer.GetEndpointEventsChannel.
+func (s *LocalObserverServer) GetEndpointEventsChannel() chan<- api.AgentNotify {
+	return s.endpointEvents
+}
+
+// GetLogRecordNotifyChannel implements Observer.GetLogRecordNotifyChannel.
+func (s *LocalObserverServer) GetLogRecordNotifyChannel() chan<- monitor.LogRecordNotify {
+	return s.logRecord
+}
+
+// StartMirroringIPCache implements Observer.StartMirroringIPCache.
+func (s *LocalObserverServer) StartMirroringIPCache(ipCacheEvents <-chan api.AgentNotify) {
+	go s.consumeAgentNotify(ipCacheEvents)
+}
+
+// UseMonitorSocket implements Observer.UseMonitorSocket.
+func (s *LocalObserverServer) UseMonitorSocket() bool {
+	return false
+}
+
+func (s *LocalObserverServer) consumeEndpointEvents() {
+	for range s.endpointEvents {
+	}
+}
+
+func (s *LocalObserverServer) consumeLogRecordNotify() {
+	for range s.logRecord {
+	}
+}
+
+func (s *LocalObserverServer) consumeAgentNotify(ipCacheEvents <-chan api.AgentNotify) {
+	for range ipCacheEvents {
+	}
+}

--- a/pkg/server/local_observer_test.go
+++ b/pkg/server/local_observer_test.go
@@ -1,0 +1,106 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/monitor"
+	"github.com/cilium/cilium/pkg/monitor/api"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/cilium/hubble/pkg/parser"
+	"github.com/cilium/hubble/pkg/testutils"
+)
+
+func TestNewLocalServer(t *testing.T) {
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, 10)
+	assert.NotNil(t, s.GetStopped())
+	assert.NotNil(t, s.GetPayloadParser())
+	assert.NotNil(t, s.GetRingBuffer())
+	assert.NotNil(t, s.GetLogger())
+	assert.NotNil(t, s.GetEventsChannel())
+	assert.NotNil(t, s.GetEndpointEventsChannel())
+	assert.NotNil(t, s.GetLogRecordNotifyChannel())
+	assert.False(t, s.UseMonitorSocket())
+}
+
+func TestLocalObserverServer_ServerStatus(t *testing.T) {
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, 1)
+	res, err := s.ServerStatus(context.Background(), &observer.ServerStatusRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, &observer.ServerStatusResponse{NumFlows: 0, MaxFlows: 2}, res)
+}
+
+func TestLocalObserverServer_GetFlows(t *testing.T) {
+	numFlows := 100
+	req := &observer.GetFlowsRequest{Number: uint64(10)}
+	i := 0
+	fakeServer := &FakeGetFlowsServer{
+		OnSend: func(response *observer.GetFlowsResponse) error {
+			i++
+			return nil
+		},
+		FakeGRPCServerStream: &FakeGRPCServerStream{
+			OnContext: func() context.Context {
+				return context.Background()
+			},
+		},
+	}
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, numFlows)
+	go s.Start()
+	s.StartMirroringIPCache(make(<-chan api.AgentNotify))
+
+	m := s.GetEventsChannel()
+	for i := 0; i < numFlows; i++ {
+		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+		data := testutils.MustCreateL3L4Payload(tn)
+		pl := &pb.Payload{
+			Time: &types.Timestamp{Seconds: int64(i)},
+			Type: pb.EventType_EventSample,
+			Data: data,
+		}
+		m <- pl
+	}
+	close(s.GetEventsChannel())
+	<-s.GetStopped()
+	err = s.GetFlows(req, fakeServer)
+	assert.NoError(t, err)
+	assert.Equal(t, req.Number, uint64(i))
+}


### PR DESCRIPTION
Define an interface for the observer server, and add a new implementation
LocalObserverServer that simply ignores all the state change events. It's
meant to be started embeeded in Cilium process, and thus the parser can
access the Cilium state directly without maintaining a copy.

Note that LocalObserverServer still connects to the monitor socket to
receive monitor events from Cilium. We need to figure out how to access
monitor events from Cilium's ring buffer.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>