### PR TITLE
serve: Add a "local" server

### DIFF
--- a/pkg/server/local_observer.go
+++ b/pkg/server/local_observer.go
@@ -1,0 +1,150 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/math"
+	"github.com/cilium/cilium/pkg/monitor"
+	"github.com/cilium/cilium/pkg/monitor/api"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"go.uber.org/zap"
+
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/cilium/hubble/pkg/container"
+	"github.com/cilium/hubble/pkg/logger"
+	"github.com/cilium/hubble/pkg/parser"
+)
+
+// LocalObserverServer is an implementation of the server.Observer interface
+// that's meant to be run embedded inside the Cilium process. It ignores all
+// the state change events since the state is available locally.
+type LocalObserverServer struct {
+	// ring buffer that contains the references of all flows
+	ring *container.Ring
+
+	// events is the channel used by the writer(s) to send the flow data
+	// into the observer server.
+	events chan *pb.Payload
+
+	// stopped is mostly used in unit tests to signalize when the events
+	// channel is empty, once it's closed.
+	stopped chan struct{}
+
+	log *zap.Logger
+
+	// channel to receive events from observer server.
+	eventschan chan *observer.GetFlowsResponse
+
+	// payloadParser decodes pb.Payload into pb.Flow
+	payloadParser *parser.Parser
+
+	// noop channels
+	endpointEvents chan monitorAPI.AgentNotify
+	logRecord      chan monitor.LogRecordNotify
+}
+
+// NewLocalServer returns a new local observer server.
+func NewLocalServer(
+	payloadParser *parser.Parser,
+	maxFlows int,
+) *LocalObserverServer {
+	return &LocalObserverServer{
+		log:  logger.GetLogger(),
+		ring: container.NewRing(maxFlows),
+		// have a channel with 1% of the max flows that we can receive
+		events:         make(chan *pb.Payload, uint64(math.IntMin(maxFlows/100, 100))),
+		stopped:        make(chan struct{}),
+		eventschan:     make(chan *observer.GetFlowsResponse, 100),
+		payloadParser:  payloadParser,
+		endpointEvents: make(chan monitorAPI.AgentNotify),
+		logRecord:      make(chan monitor.LogRecordNotify),
+	}
+}
+
+// Start starts the server to handle the events sent to the events channel as
+// well as handle events to the EpAdd and EpDel channels.
+func (s *LocalObserverServer) Start() {
+	processEvents(s)
+}
+
+// GetEventsChannel returns the event channel to receive pb.Payload events.
+func (s *LocalObserverServer) GetEventsChannel() chan *pb.Payload {
+	return s.events
+}
+
+// GetRingBuffer implements Observer.GetRingBuffer.
+func (s *LocalObserverServer) GetRingBuffer() *container.Ring {
+	return s.ring
+}
+
+// GetLogger implements Observer.GetLogger.
+func (s *LocalObserverServer) GetLogger() *zap.Logger {
+	return s.log
+}
+
+// GetStopped implements Observer.GetStopped.
+func (s *LocalObserverServer) GetStopped() chan struct{} {
+	return s.stopped
+}
+
+// GetPayloadParser implements Observer.GetPayloadParser.
+func (s *LocalObserverServer) GetPayloadParser() *parser.Parser {
+	return s.payloadParser
+}
+
+// ServerStatus should have a comment, apparently. It returns the server status.
+func (s *LocalObserverServer) ServerStatus(
+	ctx context.Context, req *observer.ServerStatusRequest,
+) (*observer.ServerStatusResponse, error) {
+	return getServerStatusFromObserver(s)
+}
+
+// GetFlows implements the proto method for client requests.
+func (s *LocalObserverServer) GetFlows(
+	req *observer.GetFlowsRequest,
+	server observer.Observer_GetFlowsServer,
+) (err error) {
+	return getFlowsFromObserver(req, server, s)
+}
+
+// GetEndpointEventsChannel implements Observer.GetEndpointEventsChannel.
+// This is a noop since LocalObserverServer doesn't call consumeMonitorEvents.
+func (s *LocalObserverServer) GetEndpointEventsChannel() chan<- api.AgentNotify {
+	// This is a noop since LocalObserverServer doesn't call consumeMonitorEvents.
+	return nil
+}
+
+// GetLogRecordNotifyChannel implements Observer.GetLogRecordNotifyChannel.
+// This is a noop since LocalObserverServer doesn't call consumeMonitorEvents.
+func (s *LocalObserverServer) GetLogRecordNotifyChannel() chan<- monitor.LogRecordNotify {
+	return nil
+}
+
+// StartMirroringIPCache implements Observer.StartMirroringIPCache.
+// This is a noop since LocalObserverServer doesn't call consumeMonitorEvents.
+func (s *LocalObserverServer) StartMirroringIPCache(ipCacheEvents <-chan api.AgentNotify) {}
+
+// StartMirroringServiceCache implements Observer.StartMirroringServiceCache
+// This is a noop since LocalObserverServer doesn't call consumeMonitorEvents.
+func (s *LocalObserverServer) StartMirroringServiceCache(serviceEvents <-chan monitorAPI.AgentNotify) {
+}
+
+// UseMonitorSocket implements Observer.UseMonitorSocket.
+func (s *LocalObserverServer) UseMonitorSocket() bool {
+	return false
+}

--- a/pkg/server/local_observer_test.go
+++ b/pkg/server/local_observer_test.go
@@ -1,0 +1,109 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/monitor"
+	"github.com/cilium/cilium/pkg/monitor/api"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/cilium/hubble/pkg/parser"
+	"github.com/cilium/hubble/pkg/testutils"
+)
+
+func TestNewLocalServer(t *testing.T) {
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, 10)
+	assert.NotNil(t, s.GetStopped())
+	assert.NotNil(t, s.GetPayloadParser())
+	assert.NotNil(t, s.GetRingBuffer())
+	assert.NotNil(t, s.GetLogger())
+	assert.NotNil(t, s.GetEventsChannel())
+	assert.Nil(t, s.GetEndpointEventsChannel())
+	assert.Nil(t, s.GetLogRecordNotifyChannel())
+	assert.False(t, s.UseMonitorSocket())
+}
+
+func TestLocalObserverServer_ServerStatus(t *testing.T) {
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, 1)
+	res, err := s.ServerStatus(context.Background(), &observer.ServerStatusRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, &observer.ServerStatusResponse{NumFlows: 0, MaxFlows: 2}, res)
+}
+
+func TestLocalObserverServer_GetFlows(t *testing.T) {
+	numFlows := 100
+	req := &observer.GetFlowsRequest{Number: uint64(10)}
+	i := 0
+	fakeServer := &FakeGetFlowsServer{
+		OnSend: func(response *observer.GetFlowsResponse) error {
+			i++
+			return nil
+		},
+		FakeGRPCServerStream: &FakeGRPCServerStream{
+			OnContext: func() context.Context {
+				return context.Background()
+			},
+		},
+	}
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, numFlows)
+	go s.Start()
+	s.StartMirroringIPCache(make(<-chan api.AgentNotify))
+
+	m := s.GetEventsChannel()
+	for i := 0; i < numFlows; i++ {
+		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+		data := testutils.MustCreateL3L4Payload(tn)
+		pl := &pb.Payload{
+			Time: &types.Timestamp{Seconds: int64(i)},
+			Type: pb.EventType_EventSample,
+			Data: data,
+		}
+		m <- pl
+	}
+	close(s.GetEventsChannel())
+	<-s.GetStopped()
+	err = s.GetFlows(req, fakeServer)
+	assert.NoError(t, err)
+	assert.Equal(t, req.Number, uint64(i))
+}

--- a/pkg/server/observer.go
+++ b/pkg/server/observer.go
@@ -41,6 +41,22 @@ import (
 	"go.uber.org/zap"
 )
 
+// Observer defines the interface for observer server.
+type Observer interface {
+	observer.ObserverServer
+	Start()
+	GetEventsChannel() chan *pb.Payload
+	GetEndpointEventsChannel() chan<- monitorAPI.AgentNotify
+	GetLogRecordNotifyChannel() chan<- monitor.LogRecordNotify
+	StartMirroringIPCache(ipCacheEvents <-chan monitorAPI.AgentNotify)
+	StartMirroringServiceCache(ipCacheEvents <-chan monitorAPI.AgentNotify)
+	GetRingBuffer() *container.Ring
+	GetLogger() *zap.Logger
+	GetStopped() chan struct{}
+	GetPayloadParser() *parser.Parser
+	UseMonitorSocket() bool
+}
+
 type ciliumClient interface {
 	EndpointList() ([]*models.Endpoint, error)
 	GetEndpoint(id uint64) (*models.Endpoint, error)
@@ -149,22 +165,26 @@ func (s *ObserverServer) Start() {
 	go s.consumeEndpointEvents()
 	go s.consumeLogRecordNotifyChannel()
 
-	for pl := range s.events {
-		flow, err := s.decodeFlow(pl)
+	processEvents(s)
+}
+
+func processEvents(s Observer) {
+	for pl := range s.GetEventsChannel() {
+		flow, err := decodeFlow(s.GetPayloadParser(), pl)
 		if err != nil {
 			if !parserErrors.IsErrInvalidType(err) {
-				s.log.Debug("failed to decode payload", zap.ByteString("data", pl.Data), zap.Error(err))
+				s.GetLogger().Debug("failed to decode payload", zap.ByteString("data", pl.Data), zap.Error(err))
 			}
 			continue
 		}
 
 		metrics.ProcessFlow(flow)
-		s.ring.Write(&v1.Event{
+		s.GetRingBuffer().Write(&v1.Event{
 			Timestamp: pl.Time,
 			Event:     flow,
 		})
 	}
-	close(s.stopped)
+	close(s.GetStopped())
 }
 
 // StartMirroringIPCache will obtain an initial IPCache snapshot from Cilium
@@ -196,7 +216,7 @@ func (s *ObserverServer) GetLogRecordNotifyChannel() chan<- monitor.LogRecordNot
 }
 
 // GetEventsChannel returns the event channel to receive pb.Payload events.
-func (s *ObserverServer) GetEventsChannel() chan<- *pb.Payload {
+func (s *ObserverServer) GetEventsChannel() chan *pb.Payload {
 	return s.events
 }
 
@@ -207,10 +227,35 @@ func (s *ObserverServer) GetEndpointEventsChannel() chan<- monitorAPI.AgentNotif
 	return s.endpointEvents
 }
 
-func (s *ObserverServer) decodeFlow(pl *pb.Payload) (*pb.Flow, error) {
+// GetRingBuffer implements Observer.GetRingBuffer.
+func (s *ObserverServer) GetRingBuffer() *container.Ring {
+	return s.ring
+}
+
+// GetLogger implements Observer.GetLogger.
+func (s *ObserverServer) GetLogger() *zap.Logger {
+	return s.log
+}
+
+// GetStopped implements Observer.GetStopped.
+func (s *ObserverServer) GetStopped() chan struct{} {
+	return s.stopped
+}
+
+// GetPayloadParser implements Observer.GetPayloadParser.
+func (s *ObserverServer) GetPayloadParser() *parser.Parser {
+	return s.payloadParser
+}
+
+// UseMonitorSocket implements Observer.UseMonitorSocket.
+func (s *ObserverServer) UseMonitorSocket() bool {
+	return true
+}
+
+func decodeFlow(payloadParser *parser.Parser, pl *pb.Payload) (*pb.Flow, error) {
 	// TODO: Pool these instead of allocating new flows each time.
 	f := &pb.Flow{}
-	err := s.payloadParser.Decode(pl, f)
+	err := payloadParser.Decode(pl, f)
 	if err != nil {
 		return nil, err
 	}
@@ -222,9 +267,13 @@ func (s *ObserverServer) decodeFlow(pl *pb.Payload) (*pb.Flow, error) {
 func (s *ObserverServer) ServerStatus(
 	ctx context.Context, req *observer.ServerStatusRequest,
 ) (*observer.ServerStatusResponse, error) {
+	return getServerStatusFromObserver(s)
+}
+
+func getServerStatusFromObserver(obs Observer) (*observer.ServerStatusResponse, error) {
 	res := &observer.ServerStatusResponse{
-		MaxFlows: s.ring.Cap(),
-		NumFlows: s.ring.Len(),
+		MaxFlows: obs.GetRingBuffer().Cap(),
+		NumFlows: obs.GetRingBuffer().Len(),
 	}
 	return res, nil
 }
@@ -242,7 +291,15 @@ func (s *ObserverServer) GetFlows(
 	req *observer.GetFlowsRequest,
 	server observer.Observer_GetFlowsServer,
 ) (err error) {
-	reply, err := getFlows(server.Context(), s.log, s.ring, req)
+	return getFlowsFromObserver(req, server, s)
+}
+
+func getFlowsFromObserver(
+	req *observer.GetFlowsRequest,
+	server observer.Observer_GetFlowsServer,
+	obs Observer,
+) (err error) {
+	reply, err := getFlows(server.Context(), obs.GetLogger(), obs.GetRingBuffer(), req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Define an interface for the observer server, and add a new implementation
LocalObserverServer. It ignores all the state change events and does not
connect to Cilium's monitor socket. It's meant to be started embeeded in
Cilium process so that:

1. the parser can access Cilium state directly without making a copy, and
2. the server can receive monitor payloads by registering a listener.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>