### PR TITLE
enable service address to service name translation

### DIFF
--- a/pkg/cilium/client/client.go
+++ b/pkg/cilium/client/client.go
@@ -85,6 +85,15 @@ func (c *Cilium) GetIPCache() ([]*models.IPListEntry, error) {
 	return ips.Payload, nil
 }
 
+// GetServiceCache retrieves the contents of the Cilium service cache.
+func (c *Cilium) GetServiceCache() ([]*models.Service, error) {
+	svcs, err := c.Client.Service.GetService(nil)
+	if err != nil {
+		return nil, err
+	}
+	return svcs.Payload, nil
+}
+
 // IsIPCacheNotFoundErr is true if the IPCache fetch error was a 404
 func IsIPCacheNotFoundErr(err error) bool {
 	_, ok := err.(*ciliumPolicy.GetIPNotFound)

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -75,16 +75,18 @@ func TCPPort(p layers.TCPPort) string {
 }
 
 // Hostname returns a "host:ip" formatted pair for the given ip and port. If
-// port is empty, only the host is returned. The host part is either the pod
-// name (if set), or a comman-separated list of domain names (if set), or just
-// the ip address if EnableIPTranslation is false and/or there are no pod and
-// domain names.
-func Hostname(ip, port string, ns, pod string, names []string) (host string) {
+// port is empty, only the host is returned. The host part is either the pod or
+// service name (if set), or a comma-separated list of domain names (if set),
+// or just the ip address if EnableIPTranslation is false and/or there are no
+// pod nor service name and domain names.
+func Hostname(ip, port string, ns, pod, svc string, names []string) (host string) {
 	host = ip
 	if EnableIPTranslation {
 		if pod != "" {
 			// path.Join omits the slash if ns is empty
 			host = path.Join(ns, pod)
+		} else if svc != "" {
+			host = path.Join(ns, svc)
 		} else if len(names) != 0 {
 			host = strings.Join(names, ",")
 		}

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -51,9 +51,13 @@ func TestHostname(t *testing.T) {
 	}()
 
 	EnableIPTranslation = true
-	assert.Equal(t, "default/pod", Hostname("", "", "default", "pod", []string{}))
-	assert.Equal(t, "a,b", Hostname("", "", "", "", []string{"a", "b"}))
+	assert.Equal(t, "default/pod", Hostname("", "", "default", "pod", "", []string{}))
+	assert.Equal(t, "default/pod", Hostname("", "", "default", "pod", "service", []string{}))
+	assert.Equal(t, "default/service", Hostname("", "", "default", "", "service", []string{}))
+	assert.Equal(t, "a,b", Hostname("", "", "", "", "", []string{"a", "b"}))
 	EnableIPTranslation = false
-	assert.Equal(t, "1.1.1.1:80", Hostname("1.1.1.1", "80", "default", "pod", []string{}))
-	assert.Equal(t, "1.1.1.1", Hostname("1.1.1.1", "0", "default", "pod", []string{}))
+	assert.Equal(t, "1.1.1.1:80", Hostname("1.1.1.1", "80", "default", "pod", "", []string{}))
+	assert.Equal(t, "1.1.1.1:80", Hostname("1.1.1.1", "80", "default", "pod", "service", []string{}))
+	assert.Equal(t, "1.1.1.1", Hostname("1.1.1.1", "0", "default", "pod", "", []string{}))
+	assert.Equal(t, "1.1.1.1", Hostname("1.1.1.1", "0", "default", "pod", "service", []string{}))
 }

--- a/pkg/parser/getters/getters.go
+++ b/pkg/parser/getters/getters.go
@@ -17,9 +17,11 @@ package getters
 import (
 	"net"
 
-	"github.com/cilium/cilium/api/v1/models"
+	pb "github.com/cilium/hubble/api/v1/flow"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/ipcache"
+
+	"github.com/cilium/cilium/api/v1/models"
 )
 
 // DNSGetter ...
@@ -45,4 +47,10 @@ type IdentityGetter interface {
 type IPGetter interface {
 	// GetIPIdentity fetches information known about a remote IP.
 	GetIPIdentity(ip net.IP) (identity ipcache.IPIdentity, ok bool)
+}
+
+// ServiceGetter fetches service metadata.
+type ServiceGetter interface {
+	GetServiceByAddr(ip net.IP, port uint16) (service pb.Service, ok bool)
+	GetServiceByID(id int64) (service pb.Service, ok bool)
 }

--- a/pkg/parser/new.go
+++ b/pkg/parser/new.go
@@ -37,15 +37,16 @@ func New(
 	identityGetter getters.IdentityGetter,
 	dnsGetter getters.DNSGetter,
 	ipGetter getters.IPGetter,
+	serviceGetter getters.ServiceGetter,
 	opts ...options.Option,
 ) (*Parser, error) {
 
-	l34, err := threefour.New(endpointGetter, identityGetter, dnsGetter, ipGetter)
+	l34, err := threefour.New(endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter)
 	if err != nil {
 		return nil, err
 	}
 
-	l7, err := seven.New(dnsGetter, ipGetter, opts...)
+	l7, err := seven.New(dnsGetter, ipGetter, serviceGetter, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -112,7 +112,7 @@ func getPorts(f v1.Flow) (string, string) {
 }
 
 func getHostNames(f v1.Flow) (string, string) {
-	var srcNamespace, dstNamespace, srcPodName, dstPodName string
+	var srcNamespace, dstNamespace, srcPodName, dstPodName, srcSvcName, dstSvcName string
 	if f == nil || f.GetIP() == nil {
 		return "", ""
 	}
@@ -124,9 +124,17 @@ func getHostNames(f v1.Flow) (string, string) {
 		dstNamespace = dst.Namespace
 		dstPodName = dst.PodName
 	}
+	if svc := f.GetSourceService(); svc != nil {
+		srcNamespace = svc.Namespace
+		srcSvcName = svc.Name
+	}
+	if svc := f.GetDestinationService(); svc != nil {
+		dstNamespace = svc.Namespace
+		dstSvcName = svc.Name
+	}
 	srcPort, dstPort := getPorts(f)
-	src := format.Hostname(f.GetIP().Source, srcPort, srcNamespace, srcPodName, f.GetSourceNames())
-	dst := format.Hostname(f.GetIP().Destination, dstPort, dstNamespace, dstPodName, f.GetSourceNames())
+	src := format.Hostname(f.GetIP().Source, srcPort, srcNamespace, srcPodName, srcSvcName, f.GetSourceNames())
+	dst := format.Hostname(f.GetIP().Destination, dstPort, dstNamespace, dstPodName, dstSvcName, f.GetSourceNames())
 	return src, dst
 }
 

--- a/pkg/server/endpoint_test.go
+++ b/pkg/server/endpoint_test.go
@@ -32,11 +32,12 @@ import (
 )
 
 type fakeCiliumClient struct {
-	fakeEndpointList func() ([]*models.Endpoint, error)
-	fakeGetEndpoint  func(uint64) (*models.Endpoint, error)
-	fakeGetIdentity  func(uint64) (*models.Identity, error)
-	fakeGetFqdnCache func() ([]*models.DNSLookup, error)
-	fakeGetIPCache   func() ([]*models.IPListEntry, error)
+	fakeEndpointList    func() ([]*models.Endpoint, error)
+	fakeGetEndpoint     func(uint64) (*models.Endpoint, error)
+	fakeGetIdentity     func(uint64) (*models.Identity, error)
+	fakeGetFqdnCache    func() ([]*models.DNSLookup, error)
+	fakeGetIPCache      func() ([]*models.IPListEntry, error)
+	fakeGetServiceCache func() ([]*models.Service, error)
 }
 
 func (c *fakeCiliumClient) EndpointList() ([]*models.Endpoint, error) {
@@ -72,6 +73,13 @@ func (c *fakeCiliumClient) GetIPCache() ([]*models.IPListEntry, error) {
 		return c.fakeGetIPCache()
 	}
 	panic("GetIPCache() should not have been called since it was not defined")
+}
+
+func (c *fakeCiliumClient) GetServiceCache() ([]*models.Service, error) {
+	if c.fakeGetServiceCache != nil {
+		return c.fakeGetServiceCache()
+	}
+	panic("GetServiceCache() should not have been called since it was not defined")
 }
 
 var fakeDummyCiliumClient = &fakeCiliumClient{

--- a/pkg/server/observer_test.go
+++ b/pkg/server/observer_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/hubble/pkg/fqdncache"
 	"github.com/cilium/hubble/pkg/ipcache"
 	"github.com/cilium/hubble/pkg/parser"
+	"github.com/cilium/hubble/pkg/servicecache"
 	"github.com/cilium/hubble/pkg/testutils"
 
 	"github.com/gogo/protobuf/types"
@@ -113,12 +114,13 @@ func (s *FakeGRPCServerStream) RecvMsg(m interface{}) error {
 func TestObserverServer_GetLastNFlows(t *testing.T) {
 	es := v1.NewEndpoints()
 	ipc := ipcache.New()
+	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, pp, 0xff)
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff)
 	if s.ring.Cap() != 0x100 {
 		t.Errorf("s.ring.Len() got = %#v, want %#v", s.ring.Cap(), 0x100)
 	}
@@ -182,12 +184,13 @@ func TestObserverServer_GetLastNFlows(t *testing.T) {
 func TestObserverServer_GetLastNFlows_With_Follow(t *testing.T) {
 	es := v1.NewEndpoints()
 	ipc := ipcache.New()
+	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, pp, 0xff)
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff)
 	if s.ring.Cap() != 0x100 {
 		t.Errorf("s.ring.Len() got = %#v, want %#v", s.ring.Cap(), 0x100)
 	}
@@ -283,12 +286,13 @@ func TestObserverServer_GetLastNFlows_With_Follow(t *testing.T) {
 func TestObserverServer_GetFlowsBetween(t *testing.T) {
 	es := v1.NewEndpoints()
 	ipc := ipcache.New()
+	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, pp, 0xff)
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff)
 	if s.ring.Cap() != 0x100 {
 		t.Errorf("s.ring.Len() got = %#v, want %#v", s.ring.Cap(), 0x100)
 	}
@@ -377,12 +381,13 @@ func TestObserverServer_GetFlows(t *testing.T) {
 	}
 	es := v1.NewEndpoints()
 	ipc := ipcache.New()
+	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, pp, 30)
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30)
 	go s.Start()
 	m := s.GetEventsChannel()
 	eth := layers.Ethernet{
@@ -441,12 +446,13 @@ func TestObserverServer_GetFlowsWithFilters(t *testing.T) {
 
 	es := v1.NewEndpoints()
 	ipc := ipcache.New()
+	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, pp, 30)
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30)
 	go s.Start()
 	m := s.GetEventsChannel()
 	eth := layers.Ethernet{
@@ -519,12 +525,13 @@ func TestObserverServer_GetFlowsOfANonLocalPod(t *testing.T) {
 
 	es := v1.NewEndpoints()
 	ipc := ipcache.New()
+	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, fakeIPGetter)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, fakeIPGetter, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, pp, 30)
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30)
 	go s.Start()
 	m := s.GetEventsChannel()
 	eth := layers.Ethernet{

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -1,0 +1,105 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"time"
+
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"go.uber.org/zap"
+)
+
+const (
+	serviceCacheInitRetryInterval = 5 * time.Second
+	serviceCacheRefreshInterval   = 5 * time.Minute
+)
+
+// fetchServiceCache fetches the service cache from cilium and initializes the
+// local service cache.
+func (s *ObserverServer) fetchServiceCache() error {
+	entries, err := s.ciliumClient.GetServiceCache()
+	if err != nil {
+		return err
+	}
+	if err := s.serviceCache.InitializeFrom(entries); err != nil {
+		return err
+	}
+	s.log.Debug("Fetched service cache from cilium", zap.Int("entries", len(entries)))
+	return nil
+}
+
+// processServiceEvent decodes and applies a service update. It returns true
+// when successful.
+func (s *ObserverServer) processServiceEvent(an monitorAPI.AgentNotify) bool {
+	switch an.Type {
+	case monitorAPI.AgentNotifyServiceUpserted:
+		n := monitorAPI.ServiceUpsertNotification{}
+		if err := json.Unmarshal([]byte(an.Text), &n); err != nil {
+			s.log.Error("Unable to unmarshal service upsert notification",
+				zap.Int("type", int(an.Type)), zap.String("ServiceUpsertNotification", an.Text))
+			return false
+		}
+		return s.serviceCache.Upsert(int64(n.ID), n.Name, n.Type, n.Namespace, n.Frontend.IP, n.Frontend.Port)
+	case monitorAPI.AgentNotifyServiceDeleted:
+		n := monitorAPI.ServiceDeleteNotification{}
+		if err := json.Unmarshal([]byte(an.Text), &n); err != nil {
+			s.log.Error("Unable to unmarshal service delete notification",
+				zap.Int("type", int(an.Type)), zap.String("ServiceDeleteNotification", an.Text))
+			return false
+		}
+		return s.serviceCache.DeleteByID(int64(n.ID))
+	default:
+		s.log.Warn("Received unknown service notification type", zap.Int("type", int(an.Type)))
+		return false
+	}
+}
+
+func (s *ObserverServer) syncServiceCache(serviceEvents <-chan monitorAPI.AgentNotify) {
+	for err := s.fetchServiceCache(); err != nil; err = s.fetchServiceCache() {
+		s.log.Error("Failed to fetch service cache from Cilium", zap.Error(err))
+		time.Sleep(serviceCacheInitRetryInterval)
+	}
+
+	refresh := time.NewTimer(serviceCacheInitRetryInterval)
+	inSync := false
+
+	for serviceEvents != nil {
+		select {
+		case <-refresh.C:
+			if err := s.fetchServiceCache(); err != nil {
+				s.log.Error("Failed to fetch service cache from Cilium", zap.Error(err))
+			}
+			refresh.Reset(serviceCacheInitRetryInterval)
+		case an, ok := <-serviceEvents:
+			if !ok {
+				return
+			}
+			// Initially we might see stale updates that were enqued before we
+			// initialized the service cache.
+			// Once we see the first applicable update though, all subsequent
+			// updates must be applicable as well.
+			updated := s.processServiceEvent(an)
+			switch {
+			case !updated && !inSync:
+				s.log.Debug("Received stale service update", zap.Int("type", int(an.Type)), zap.String("AgentNotification", an.Text))
+			case !updated && inSync:
+				s.log.Warn("Received unapplicable service update", zap.Int("type", int(an.Type)), zap.String("AgentNotification", an.Text))
+			case updated && !inSync:
+				inSync = true
+			}
+		}
+	}
+}

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -1,0 +1,173 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/cilium/api/v1/models"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/servicecache"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestObserverServer_syncServiceCache(t *testing.T) {
+	svcc := servicecache.New()
+	fakeClient := &fakeCiliumClient{
+		fakeGetServiceCache: func() ([]*models.Service, error) {
+			return []*models.Service{
+				{
+					Spec: &models.ServiceSpec{
+						ID:              100,
+						FrontendAddress: &models.FrontendAddress{IP: "1.1.1.1", Port: 53},
+						Flags:           &models.ServiceSpecFlags{Name: "svc-1", Namespace: "ns-1"},
+					},
+				}, {
+					Spec: &models.ServiceSpec{
+						ID:              200,
+						FrontendAddress: &models.FrontendAddress{IP: "2.2.2.2", Port: 42},
+						Flags:           &models.ServiceSpecFlags{Name: "svc-2", Namespace: "ns-2"},
+					},
+				}, {
+					Spec: &models.ServiceSpec{
+						ID:              300,
+						FrontendAddress: &models.FrontendAddress{IP: "3.3.3.3", Port: 24},
+						Flags:           &models.ServiceSpecFlags{Name: "svc-3", Namespace: "ns-3"},
+					},
+				}, {
+					Spec: &models.ServiceSpec{
+						ID:              400,
+						FrontendAddress: &models.FrontendAddress{IP: "2001:db8::68", Port: 22},
+						Flags:           &models.ServiceSpecFlags{Name: "svc-4", Namespace: "ns-4"},
+					},
+				},
+			}, nil
+		},
+	}
+
+	s := &ObserverServer{
+		ciliumClient: fakeClient,
+		serviceCache: svcc,
+		log:          zap.L(),
+	}
+
+	serviceCacheEvents := make(chan monitorAPI.AgentNotify, 100)
+	go func() {
+		// stale update, should be ignored
+		n, err := monitorAPI.ServiceUpsertRepr(
+			100,
+			monitorAPI.ServiceUpsertNotificationAddr{IP: net.IPv4(1, 1, 1, 1), Port: 53},
+			[]monitorAPI.ServiceUpsertNotificationAddr{},
+			"",
+			"",
+			"svc-1",
+			"ns-1",
+		)
+		require.NoError(t, err)
+		serviceCacheEvents <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyServiceUpserted, Text: n}
+
+		// delete 2.2.2.2
+		n, err = monitorAPI.ServiceDeleteRepr(200)
+		require.NoError(t, err)
+		serviceCacheEvents <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyServiceDeleted, Text: n}
+
+		// reinsert 2.2.2.2 with new service name
+		n, err = monitorAPI.ServiceUpsertRepr(
+			200,
+			monitorAPI.ServiceUpsertNotificationAddr{IP: net.IPv4(2, 2, 2, 2), Port: 42},
+			[]monitorAPI.ServiceUpsertNotificationAddr{},
+			"",
+			"",
+			"svc-2b-or-not-2b",
+			"ns-2",
+		)
+		require.NoError(t, err)
+		serviceCacheEvents <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyServiceUpserted, Text: n}
+
+		// update 3.3.3.3 with new port
+		n, err = monitorAPI.ServiceUpsertRepr(
+			300,
+			monitorAPI.ServiceUpsertNotificationAddr{IP: net.IPv4(3, 3, 3, 3), Port: 443},
+			[]monitorAPI.ServiceUpsertNotificationAddr{},
+			"",
+			"",
+			"svc-3",
+			"ns-3",
+		)
+		require.NoError(t, err)
+		serviceCacheEvents <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyServiceUpserted, Text: n}
+
+		// delete 2001:db8::68
+		n, err = monitorAPI.ServiceDeleteRepr(400)
+		require.NoError(t, err)
+		serviceCacheEvents <- monitorAPI.AgentNotify{Type: monitorAPI.AgentNotifyServiceDeleted, Text: n}
+
+		close(serviceCacheEvents)
+	}()
+
+	// blocks until channel is closed
+	s.syncServiceCache(serviceCacheEvents)
+	assert.Equal(t, 0, len(serviceCacheEvents))
+
+	tests := []struct {
+		ip      net.IP
+		port    uint16
+		service pb.Service
+		ok      bool
+	}{
+		{
+			ip:   net.IPv4(1, 1, 1, 1),
+			port: 53,
+			service: pb.Service{
+				Name:      "svc-1",
+				Namespace: "ns-1",
+			},
+			ok: true,
+		}, {
+			ip:   net.IPv4(2, 2, 2, 2),
+			port: 42,
+			service: pb.Service{
+				Name:      "svc-2b-or-not-2b",
+				Namespace: "ns-2",
+			},
+			ok: true,
+		}, {
+			ip:   net.IPv4(3, 3, 3, 3),
+			port: 443,
+			service: pb.Service{
+				Name:      "svc-3",
+				Namespace: "ns-3",
+			},
+			ok: true,
+		}, {
+			ip:      net.ParseIP("2001:db8::68"),
+			port:    22,
+			service: pb.Service{},
+			ok:      false,
+		},
+	}
+	for _, tt := range tests {
+		gotService, gotOK := svcc.GetServiceByAddr(tt.ip, tt.port)
+		assert.Equal(t, tt.service, gotService)
+		if gotOK != tt.ok {
+			t.Errorf("ServiceCache.GetServiceByAddr() gotOK = %v, want %v", gotOK, tt.ok)
+		}
+	}
+}

--- a/pkg/servicecache/service_cache.go
+++ b/pkg/servicecache/service_cache.go
@@ -1,0 +1,174 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servicecache
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+
+	pb "github.com/cilium/hubble/api/v1/flow"
+
+	"github.com/cilium/cilium/api/v1/models"
+)
+
+// ServiceCache is a cache of existing services.
+type ServiceCache struct {
+	mu    sync.RWMutex
+	cache map[string]*entry
+}
+
+// New creates a new empty ServiceCache.
+func New() *ServiceCache {
+	return &ServiceCache{
+		cache: map[string]*entry{},
+	}
+}
+
+type entry struct {
+	ID           int64
+	Name         string
+	Namespace    string
+	FrontendIP   net.IP
+	FrontendPort uint16
+}
+
+// GetServiceByAddr retrieves a service from the cache given its frontend IP
+// and port. If the service was found in the cache, ok is true.
+func (svcc *ServiceCache) GetServiceByAddr(ip net.IP, port uint16) (service pb.Service, ok bool) {
+	svcc.mu.RLock()
+	defer svcc.mu.RUnlock()
+
+	if e, ok := svcc.cache[genAddrKey(ip, port)]; ok {
+		return pb.Service{
+			Name:      e.Name,
+			Namespace: e.Namespace,
+		}, true
+	}
+	return pb.Service{}, false
+}
+
+// GetServiceByID retrieves a service from the cache given its ID. If the
+// service was found in the cache, ok is true.
+func (svcc *ServiceCache) GetServiceByID(id int64) (service pb.Service, ok bool) {
+	svcc.mu.RLock()
+	defer svcc.mu.RUnlock()
+
+	if e, ok := svcc.cache[genIDKey(id)]; ok {
+		return pb.Service{
+			Name:      e.Name,
+			Namespace: e.Namespace,
+		}, true
+	}
+	return pb.Service{}, false
+}
+
+// InitializeFrom initializes the cache with the given list of services.
+func (svcc *ServiceCache) InitializeFrom(entries []*models.Service) error {
+	cache := map[string]*entry{}
+	for _, e := range entries {
+		if e == nil || e.Spec == nil || e.Spec.FrontendAddress == nil || e.Spec.Flags == nil {
+			return fmt.Errorf("received invalid service entry from cilium: %+v", e)
+		}
+		frontendIP := net.ParseIP(e.Spec.FrontendAddress.IP)
+		if frontendIP == nil {
+			return fmt.Errorf("received service entry with invalid address: %s", e.Spec.FrontendAddress.IP)
+		}
+		frontendPort := e.Spec.FrontendAddress.Port
+		ce := &entry{
+			ID:           e.Spec.ID,
+			Name:         e.Spec.Flags.Name,
+			Namespace:    e.Spec.Flags.Namespace,
+			FrontendIP:   frontendIP,
+			FrontendPort: frontendPort,
+		}
+		cache[genAddrKey(frontendIP, frontendPort)] = ce
+		cache[genIDKey(e.Spec.ID)] = ce
+	}
+	svcc.mu.Lock()
+	svcc.cache = cache
+	svcc.mu.Unlock()
+	return nil
+}
+
+// Upsert updates or inserts a cache entry and returns true if the update was
+// performed.
+func (svcc *ServiceCache) Upsert(id int64, name, typ, ns string, frontendIP net.IP, frontendPort uint16) bool {
+	svcc.mu.Lock()
+	defer svcc.mu.Unlock()
+
+	idKey := genIDKey(id)
+	// the ID of a service should never change and should be unique
+	// thus, it acts as the reference key when unsure which entry to update
+	if old, exist := svcc.cache[idKey]; exist {
+		// make sure to remove the old addr reference
+		delete(svcc.cache, genAddrKey(old.FrontendIP, old.FrontendPort))
+	}
+	e := &entry{
+		ID:           id,
+		Name:         name,
+		Namespace:    ns,
+		FrontendIP:   frontendIP,
+		FrontendPort: frontendPort,
+	}
+	svcc.cache[genAddrKey(frontendIP, frontendPort)] = e
+	svcc.cache[idKey] = e
+	return true
+}
+
+// DeleteByID removes the cache entry identified by the given id. It returns
+// true if an entry was deleted.
+func (svcc *ServiceCache) DeleteByID(id int64) bool {
+	svcc.mu.Lock()
+	defer svcc.mu.Unlock()
+
+	idKey := genIDKey(id)
+	e, found := svcc.cache[idKey]
+	if found {
+		delete(svcc.cache, idKey)
+		delete(svcc.cache, genAddrKey(e.FrontendIP, e.FrontendPort))
+	}
+	return found
+}
+
+// DeleteByAddr removes the cache entry identified by the given service
+// frontend ip and port. It returns true if an entry was deleted.
+func (svcc *ServiceCache) DeleteByAddr(ip net.IP, port uint16) bool {
+	svcc.mu.Lock()
+	defer svcc.mu.Unlock()
+
+	addrKey := genAddrKey(ip, port)
+	e, found := svcc.cache[addrKey]
+	if found {
+		delete(svcc.cache, addrKey)
+		delete(svcc.cache, genIDKey(e.ID))
+	}
+	return found
+}
+
+// genAddrKey generates an address key in the form addr:<ip:port>.
+func genAddrKey(ip net.IP, port uint16) string {
+	var ipStr string
+	if len(ip) > 0 { // an empty IP is usually represented as <nil>, we prefer having an empty string
+		ipStr = ip.String()
+	}
+	return fmt.Sprintf("addr:%s", net.JoinHostPort(ipStr, strconv.FormatUint(uint64(port), 10)))
+}
+
+// genIDKey generates an id key in the form id:<id>.
+func genIDKey(id int64) string {
+	return fmt.Sprintf("id:%d", id)
+}

--- a/pkg/servicecache/service_cache_test.go
+++ b/pkg/servicecache/service_cache_test.go
@@ -1,0 +1,791 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servicecache
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/cilium/api/v1/models"
+	pb "github.com/cilium/hubble/api/v1/flow"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceCache_Upsert(t *testing.T) {
+	type args struct {
+		id   int64
+		name string
+		typ  string
+		ns   string
+		ip   net.IP
+		port uint16
+	}
+	tests := []struct {
+		name   string
+		fields map[string]*entry
+		args   args
+		want   map[string]*entry
+	}{
+		{
+			name:   "upsert into empty cache",
+			fields: map[string]*entry{},
+			args: args{
+				id:   100,
+				name: "service",
+				typ:  "ClusterIP",
+				ns:   "default",
+				ip:   net.IPv4(1, 1, 1, 1),
+				port: 53,
+			},
+			want: map[string]*entry{
+				"addr:1.1.1.1:53": {
+					ID:           100,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(1, 1, 1, 1),
+					FrontendPort: 53,
+				},
+				"id:100": {
+					ID:           100,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(1, 1, 1, 1),
+					FrontendPort: 53,
+				},
+			},
+		}, {
+			name: "normal upsert",
+			fields: map[string]*entry{
+				"addr:2.2.2.2:42": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+			},
+			args: args{
+				id:   200,
+				name: "service",
+				typ:  "NodePort",
+				ns:   "default",
+				ip:   net.IPv4(3, 3, 3, 3),
+				port: 24,
+			},
+			want: map[string]*entry{
+				"addr:3.3.3.3:24": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(3, 3, 3, 3),
+					FrontendPort: 24,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(3, 3, 3, 3),
+					FrontendPort: 24,
+				},
+			},
+		}, {
+			name: "upsert additional",
+			fields: map[string]*entry{
+				"addr:1.1.1.1:53": {
+					ID:           100,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(1, 1, 1, 1),
+					FrontendPort: 53,
+				},
+				"id:100": {
+					ID:           100,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(1, 1, 1, 1),
+					FrontendPort: 53,
+				},
+			},
+			args: args{
+				id:   200,
+				name: "service",
+				typ:  "NodePort",
+				ns:   "default",
+				ip:   net.IPv4(2, 2, 2, 2),
+				port: 42,
+			},
+			want: map[string]*entry{
+				"addr:1.1.1.1:53": {
+					ID:           100,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(1, 1, 1, 1),
+					FrontendPort: 53,
+				},
+				"addr:2.2.2.2:42": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+				"id:100": {
+					ID:           100,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(1, 1, 1, 1),
+					FrontendPort: 53,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcc := New()
+			svcc.cache = tt.fields
+			svcc.Upsert(tt.args.id, tt.args.name, tt.args.typ, tt.args.ns, tt.args.ip, tt.args.port)
+			// ensure that the 2 entries point to the same address
+			assert.True(t, svcc.cache[genIDKey(tt.args.id)] == svcc.cache[genAddrKey(tt.args.ip, tt.args.port)])
+			assert.Equal(t, tt.want, svcc.cache)
+		})
+	}
+}
+
+func TestServiceCache_DeleteByAddr(t *testing.T) {
+	type args struct {
+		ip   net.IP
+		port uint16
+	}
+	type want struct {
+		result bool
+		cache  map[string]*entry
+	}
+	tests := []struct {
+		name   string
+		fields map[string]*entry
+		args   args
+		want   want
+	}{
+		{
+			name: "normal delete",
+			fields: map[string]*entry{
+				"addr:2.2.2.2:42": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+			},
+			args: args{
+				ip:   net.IPv4(2, 2, 2, 2),
+				port: 42,
+			},
+			want: want{
+				result: true,
+				cache:  map[string]*entry{},
+			},
+		}, {
+			name: "delete nonexisting",
+			fields: map[string]*entry{
+				"addr:2.2.2.2:42": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+			},
+			args: args{
+				ip:   net.IPv4(1, 1, 1, 1),
+				port: 53,
+			},
+			want: want{
+				result: false,
+				cache: map[string]*entry{
+					"addr:2.2.2.2:42": {
+						ID:           200,
+						Name:         "service",
+						Namespace:    "default",
+						FrontendIP:   net.IPv4(2, 2, 2, 2),
+						FrontendPort: 42,
+					},
+					"id:200": {
+						ID:           200,
+						Name:         "service",
+						Namespace:    "default",
+						FrontendIP:   net.IPv4(2, 2, 2, 2),
+						FrontendPort: 42,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcc := New()
+			svcc.cache = tt.fields
+			got := svcc.DeleteByAddr(tt.args.ip, tt.args.port)
+			if got != tt.want.result {
+				t.Errorf("ServiceCache.DeleteByAddr() = %v, want %v", got, tt.want.result)
+			}
+			assert.Equal(t, tt.want.cache, svcc.cache)
+		})
+	}
+}
+
+func TestServiceCache_DeleteByID(t *testing.T) {
+	type args struct {
+		id int64
+	}
+	type want struct {
+		result bool
+		cache  map[string]*entry
+	}
+	tests := []struct {
+		name   string
+		fields map[string]*entry
+		args   args
+		want   want
+	}{
+		{
+			name: "normal delete",
+			fields: map[string]*entry{
+				"addr:2.2.2.2:42": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+			},
+			args: args{id: 200},
+			want: want{
+				result: true,
+				cache:  map[string]*entry{},
+			},
+		}, {
+			name: "delete nonexisting",
+			fields: map[string]*entry{
+				"addr:2.2.2.2:42": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+			},
+			args: args{id: 100},
+			want: want{
+				result: false,
+				cache: map[string]*entry{
+					"addr:2.2.2.2:42": {
+						ID:           200,
+						Name:         "service",
+						Namespace:    "default",
+						FrontendIP:   net.IPv4(2, 2, 2, 2),
+						FrontendPort: 42,
+					},
+					"id:200": {
+						ID:           200,
+						Name:         "service",
+						Namespace:    "default",
+						FrontendIP:   net.IPv4(2, 2, 2, 2),
+						FrontendPort: 42,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcc := New()
+			svcc.cache = tt.fields
+
+			got := svcc.DeleteByID(tt.args.id)
+			if got != tt.want.result {
+				t.Errorf("ServiceCache.DeleteByAddr() = %v, want %v", got, tt.want.result)
+			}
+			assert.Equal(t, tt.want.cache, svcc.cache)
+		})
+	}
+}
+
+func TestServiceCache_InitializeFrom(t *testing.T) {
+	type args struct {
+		entries []*models.Service
+	}
+	type want struct {
+		hasErr bool
+		cache  map[string]*entry
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "normal initialize",
+			args: args{
+				entries: []*models.Service{
+					{
+						Spec: &models.ServiceSpec{
+							ID: 100,
+							FrontendAddress: &models.FrontendAddress{
+								IP:   "1.1.1.1",
+								Port: 53,
+							},
+							Flags: &models.ServiceSpecFlags{
+								Name:      "service",
+								Namespace: "default",
+							},
+						},
+					}, {
+						Spec: &models.ServiceSpec{
+							ID: 200,
+							FrontendAddress: &models.FrontendAddress{
+								IP:   "2.2.2.2",
+								Port: 42,
+							},
+							Flags: &models.ServiceSpecFlags{
+								Name:      "service",
+								Namespace: "default",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				cache: map[string]*entry{
+					"addr:1.1.1.1:53": {
+						ID:           100,
+						Name:         "service",
+						Namespace:    "default",
+						FrontendIP:   net.IPv4(1, 1, 1, 1),
+						FrontendPort: 53,
+					},
+					"addr:2.2.2.2:42": {
+						ID:           200,
+						Name:         "service",
+						Namespace:    "default",
+						FrontendIP:   net.IPv4(2, 2, 2, 2),
+						FrontendPort: 42,
+					},
+					"id:100": {
+						ID:           100,
+						Name:         "service",
+						Namespace:    "default",
+						FrontendIP:   net.IPv4(1, 1, 1, 1),
+						FrontendPort: 53,
+					},
+					"id:200": {
+						ID:           200,
+						Name:         "service",
+						Namespace:    "default",
+						FrontendIP:   net.IPv4(2, 2, 2, 2),
+						FrontendPort: 42,
+					},
+				},
+			},
+		}, {
+			name: "nil entry",
+			args: args{
+				entries: []*models.Service{nil},
+			},
+			want: want{
+				hasErr: true,
+				cache:  map[string]*entry{},
+			},
+		}, {
+			name: "missing spec",
+			args: args{
+				entries: []*models.Service{{}, {}},
+			},
+			want: want{
+				hasErr: true,
+				cache:  map[string]*entry{},
+			},
+		}, {
+			name: "missing frontend address",
+			args: args{
+				entries: []*models.Service{{
+					Spec: &models.ServiceSpec{
+						ID: 100,
+						Flags: &models.ServiceSpecFlags{
+							Name:      "service",
+							Namespace: "default",
+						},
+					},
+				}},
+			},
+			want: want{
+				hasErr: true,
+				cache:  map[string]*entry{},
+			},
+		}, {
+			name: "missing flags",
+			args: args{
+				entries: []*models.Service{{
+					Spec: &models.ServiceSpec{
+						ID: 100,
+						FrontendAddress: &models.FrontendAddress{
+							IP:   "1.1.1.1",
+							Port: 53,
+						},
+					},
+				}},
+			},
+			want: want{
+				hasErr: true,
+				cache:  map[string]*entry{},
+			},
+		}, {
+			name: "invalid frontend address",
+			args: args{
+				entries: []*models.Service{{
+					Spec: &models.ServiceSpec{
+						ID: 100,
+						FrontendAddress: &models.FrontendAddress{
+							IP:   "in-fact-i-m-not-an-ip",
+							Port: 53,
+						},
+						Flags: &models.ServiceSpecFlags{
+							Name:      "service",
+							Namespace: "default",
+						},
+					},
+				}},
+			},
+			want: want{
+				hasErr: true,
+				cache:  map[string]*entry{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcc := New()
+			if err := svcc.InitializeFrom(tt.args.entries); (err != nil) != tt.want.hasErr {
+				t.Errorf("ServiceCache.InitializeFrom() error = %v, wantErr %v", err, tt.want.hasErr)
+			}
+			assert.Equal(t, tt.want.cache, svcc.cache)
+		})
+	}
+}
+
+func TestServiceCache_GetServiceByAddr(t *testing.T) {
+	type args struct {
+		ip   net.IP
+		port uint16
+	}
+	type want struct {
+		service pb.Service
+		ok      bool
+	}
+	tests := []struct {
+		name   string
+		fields map[string]*entry
+		args   args
+		want   want
+	}{
+		{
+			name: "get IPv4 service",
+			fields: map[string]*entry{
+				"addr:2.2.2.2:42": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+			},
+			args: args{
+				ip:   net.IPv4(2, 2, 2, 2),
+				port: 42,
+			},
+			want: want{
+				service: pb.Service{
+					Name:      "service",
+					Namespace: "default",
+				},
+				ok: true,
+			},
+		}, {
+			name: "get IPv6 service",
+			fields: map[string]*entry{
+				"addr:[2001:db8::68]:42": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.ParseIP("2001:db8::68"),
+					FrontendPort: 42,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.ParseIP("2001:db8::68"),
+					FrontendPort: 42,
+				},
+			},
+			args: args{
+				ip:   net.ParseIP("2001:db8::68"),
+				port: 42,
+			},
+			want: want{
+				service: pb.Service{
+					Name:      "service",
+					Namespace: "default",
+				},
+				ok: true,
+			},
+		}, {
+			name: "missing entry",
+			args: args{
+				ip:   net.ParseIP("2001:db8::68"),
+				port: 42,
+			},
+			want: want{
+				service: pb.Service{},
+				ok:      false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcc := New()
+			svcc.cache = tt.fields
+			gotService, gotOK := svcc.GetServiceByAddr(tt.args.ip, tt.args.port)
+			assert.Equal(t, tt.want.service, gotService)
+			if gotOK != tt.want.ok {
+				t.Errorf("ServiceCache.GetServiceByAddr() gotOK = %v, want %v", gotOK, tt.want.ok)
+			}
+		})
+	}
+}
+
+func TestServiceCache_GetServiceByID(t *testing.T) {
+	type args struct {
+		id int64
+	}
+	type want struct {
+		service pb.Service
+		ok      bool
+	}
+	tests := []struct {
+		name   string
+		fields map[string]*entry
+		args   args
+		want   want
+	}{
+		{
+			name: "get IPv4 service",
+			fields: map[string]*entry{
+				"addr:2.2.2.2:42": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.IPv4(2, 2, 2, 2),
+					FrontendPort: 42,
+				},
+			},
+			args: args{
+				id: 200,
+			},
+			want: want{
+				service: pb.Service{
+					Name:      "service",
+					Namespace: "default",
+				},
+				ok: true,
+			},
+		}, {
+			name: "get IPv6 service",
+			fields: map[string]*entry{
+				"addr:[2001:db8::68]:42": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.ParseIP("2001:db8::68"),
+					FrontendPort: 42,
+				},
+				"id:200": {
+					ID:           200,
+					Name:         "service",
+					Namespace:    "default",
+					FrontendIP:   net.ParseIP("2001:db8::68"),
+					FrontendPort: 42,
+				},
+			},
+			args: args{
+				id: 200,
+			},
+			want: want{
+				service: pb.Service{
+					Name:      "service",
+					Namespace: "default",
+				},
+				ok: true,
+			},
+		}, {
+			name: "missing entry",
+			args: args{
+				id: 400,
+			},
+			want: want{
+				service: pb.Service{},
+				ok:      false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcc := New()
+			svcc.cache = tt.fields
+			gotService, gotOK := svcc.GetServiceByID(tt.args.id)
+			assert.Equal(t, tt.want.service, gotService)
+			if gotOK != tt.want.ok {
+				t.Errorf("ServiceCache.GetServiceByAddr() gotOK = %v, want %v", gotOK, tt.want.ok)
+			}
+		})
+	}
+}
+
+func TestServiceCache_genAddrKey(t *testing.T) {
+	type args struct {
+		ip   net.IP
+		port uint16
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "normal IPv4 address",
+			args: args{
+				ip:   net.IPv4(2, 2, 2, 2),
+				port: 42,
+			},
+			want: "addr:2.2.2.2:42",
+		}, {
+			name: "normal IPv6 address",
+			args: args{
+				ip:   net.ParseIP("2001:db8::68"),
+				port: 42,
+			},
+			want: "addr:[2001:db8::68]:42",
+		}, {
+			name: "nil ip address",
+			args: args{
+				ip:   nil,
+				port: 42,
+			},
+			want: "addr::42",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := genAddrKey(tt.args.ip, tt.args.port)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestServiceCache_genIDKey(t *testing.T) {
+	type args struct {
+		id int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "normal ID",
+			args: args{
+				id: 42,
+			},
+			want: "id:42",
+		}, {
+			name: "default ID value",
+			args: args{},
+			want: "id:0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := genIDKey(tt.args.id)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/testutils/fake.go
+++ b/pkg/testutils/fake.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 
+	pb "github.com/cilium/hubble/api/v1/flow"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/ipcache"
 )
@@ -68,6 +69,38 @@ func (f *FakeIPGetter) GetIPIdentity(ip net.IP) (id ipcache.IPIdentity, ok bool)
 var NoopIPGetter = FakeIPGetter{
 	OnGetIPIdentity: func(ip net.IP) (id ipcache.IPIdentity, ok bool) {
 		return ipcache.IPIdentity{}, false
+	},
+}
+
+// FakeServiceGetter is used for unit tests that need ServiceGetter.
+type FakeServiceGetter struct {
+	OnGetServiceByAddr func(ip net.IP, port uint16) (service pb.Service, ok bool)
+	OnGetServiceByID   func(id int64) (service pb.Service, ok bool)
+}
+
+// GetServiceByAddr implements FakeServiceGetter.GetServiceByAddr.
+func (f *FakeServiceGetter) GetServiceByAddr(ip net.IP, port uint16) (service pb.Service, ok bool) {
+	if f.OnGetServiceByAddr != nil {
+		return f.OnGetServiceByAddr(ip, port)
+	}
+	panic("OnGetServiceByAddr not set")
+}
+
+// GetServiceByID implements FakeServiceGetter.GetServiceByID.
+func (f *FakeServiceGetter) GetServiceByID(id int64) (service pb.Service, ok bool) {
+	if f.OnGetServiceByID != nil {
+		return f.OnGetServiceByID(id)
+	}
+	panic("OnGetServiceByID not set")
+}
+
+// NoopServiceGetter always returns an empty response.
+var NoopServiceGetter = FakeServiceGetter{
+	OnGetServiceByAddr: func(ip net.IP, port uint16) (service pb.Service, ok bool) {
+		return pb.Service{}, false
+	},
+	OnGetServiceByID: func(id int64) (service pb.Service, ok bool) {
+		return pb.Service{}, false
 	},
 }
 


### PR DESCRIPTION
This turns the output of `hubble observe` from this:
```
Jan 22 13:25:22.808 []: default/alpine:55822 -> 172.20.0.113:80(http) from-endpoint FORWARDED (TCP Flags: SYN)
```
To this (when ip translation is enabled):
```
Jan 22 13:25:22.808 []: default/alpine:55822 -> default/deathstar:80(http) from-endpoint FORWARDED (TCP Flags: SYN)
```
In short, the service IP is replaced by `<namespace>/<service name>`. The service port is left as it can be a useful information for whoever is observing the flow.

Note that for this feature to work, Cilium 1.7+ must be used. With Cilium <= 1.6, service addresses are simply not translated.

Closes #48 