### PR TITLE
pkg/printer: Clean up the printer package

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -271,8 +271,12 @@ func handleArgs(
 		enableIPTranslation = false
 		enablePortTranslation = false
 	}
-	opts = append(opts, hubprinter.SetIPTranslation(enableIPTranslation))
-	opts = append(opts, hubprinter.SetPortTranslation(enablePortTranslation))
+	if enableIPTranslation {
+		opts = append(opts, hubprinter.WithIPTranslation())
+	}
+	if enablePortTranslation {
+		opts = append(opts, hubprinter.WithPortTranslation())
+	}
 	printer = hubprinter.New(opts...)
 	return nil
 }

--- a/pkg/printer/options.go
+++ b/pkg/printer/options.go
@@ -91,16 +91,16 @@ func IgnoreStderr() Option {
 	}
 }
 
-// SetPortTranslation sets the flag to translate port numbers to port names, i.e. `80` becomes `80(http)`.
-func SetPortTranslation(enabled bool) Option {
+// WithPortTranslation enables translation from port numbers to port names, i.e. `80` becomes `80(http)`.
+func WithPortTranslation() Option {
 	return func(opts *Options) {
-		opts.enablePortTranslation = enabled
+		opts.enablePortTranslation = true
 	}
 }
 
-// SetIPTranslation sets the flag to translate IPs to pod names, FQDNs, and service names.
-func SetIPTranslation(enabled bool) Option {
+// WithIPTranslation enables translation from IPs to pod names, FQDNs, and service names.
+func WithIPTranslation() Option {
 	return func(opts *Options) {
-		opts.enableIPTranslation = enabled
+		opts.enableIPTranslation = true
 	}
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -106,7 +106,8 @@ func (p *Printer) WriteErr(msg string) error {
 	return err
 }
 
-func (p *Printer) getPorts(f v1.Flow) (string, string) {
+// GetPorts returns source and destination port of a flow.
+func (p *Printer) GetPorts(f v1.Flow) (string, string) {
 	l4 := f.GetL4()
 	if l4 == nil {
 		return "", ""
@@ -121,7 +122,8 @@ func (p *Printer) getPorts(f v1.Flow) (string, string) {
 	}
 }
 
-func (p *Printer) getHostNames(f v1.Flow) (string, string) {
+// GetHostNames returns source and destination hostnames of a flow.
+func (p *Printer) GetHostNames(f v1.Flow) (string, string) {
 	var srcNamespace, dstNamespace, srcPodName, dstPodName, srcSvcName, dstSvcName string
 	if f == nil || f.GetIP() == nil {
 		return "", ""
@@ -142,7 +144,7 @@ func (p *Printer) getHostNames(f v1.Flow) (string, string) {
 		dstNamespace = svc.Namespace
 		dstSvcName = svc.Name
 	}
-	srcPort, dstPort := p.getPorts(f)
+	srcPort, dstPort := p.GetPorts(f)
 	src := p.Hostname(f.GetIP().Source, srcPort, srcNamespace, srcPodName, srcSvcName, f.GetSourceNames())
 	dst := p.Hostname(f.GetIP().Destination, dstPort, dstNamespace, dstPodName, dstSvcName, f.GetSourceNames())
 	return src, dst
@@ -159,7 +161,8 @@ func getTimestamp(f v1.Flow) string {
 	return MaybeTime(&ts)
 }
 
-func getFlowType(f v1.Flow) string {
+// GetFlowType returns the type of a flow as a string.
+func GetFlowType(f v1.Flow) string {
 	if f == nil || f.GetEventType() == nil {
 		return "UNKNOWN"
 	}
@@ -199,12 +202,12 @@ func (p *Printer) WriteProtoFlow(f v1.Flow) error {
 				return err
 			}
 		}
-		src, dst := p.getHostNames(f)
+		src, dst := p.GetHostNames(f)
 		_, err := fmt.Fprint(p.tw,
 			getTimestamp(f), tab,
 			src, tab,
 			dst, tab,
-			getFlowType(f), tab,
+			GetFlowType(f), tab,
 			f.GetVerdict().String(), tab,
 			f.GetSummary(), newline,
 		)
@@ -219,14 +222,14 @@ func (p *Printer) WriteProtoFlow(f v1.Flow) error {
 				return err
 			}
 		}
-		src, dst := p.getHostNames(f)
+		src, dst := p.GetHostNames(f)
 		// this is a little crude, but will do for now. should probably find the
 		// longest header and auto-format the keys
 		_, err := fmt.Fprint(p.opts.w,
 			"  TIMESTAMP: ", getTimestamp(f), newline,
 			"     SOURCE: ", src, newline,
 			"DESTINATION: ", dst, newline,
-			"       TYPE: ", getFlowType(f), newline,
+			"       TYPE: ", GetFlowType(f), newline,
 			"    VERDICT: ", f.GetVerdict().String(), newline,
 			"    SUMMARY: ", f.GetSummary(), newline,
 		)
@@ -234,14 +237,14 @@ func (p *Printer) WriteProtoFlow(f v1.Flow) error {
 			return fmt.Errorf("failed to write out packet: %v", err)
 		}
 	case CompactOutput:
-		src, dst := p.getHostNames(f)
+		src, dst := p.GetHostNames(f)
 		_, err := fmt.Fprintf(p.opts.w,
 			"%s [%s]: %s -> %s %s %s (%s)\n",
 			getTimestamp(f),
 			f.GetNodeName(),
 			src,
 			dst,
-			getFlowType(f),
+			GetFlowType(f),
 			f.GetVerdict().String(),
 			f.GetSummary(),
 		)

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -69,7 +69,7 @@ func TestPrinter_WriteProtoFlow(t *testing.T) {
 		{
 			name: "tabular",
 			options: []Option{
-				SetPortTranslation(true),
+				WithPortTranslation(),
 				Writer(&buf),
 			},
 			args: args{
@@ -83,7 +83,7 @@ Jan  1 00:20:34.567   1.1.1.1:31793   2.2.2.2:8080(http-alt)   Policy denied (L3
 			name: "compact",
 			options: []Option{
 				Compact(),
-				SetPortTranslation(true),
+				WithPortTranslation(),
 				Writer(&buf),
 			},
 			args: args{
@@ -116,7 +116,7 @@ Jan  1 00:20:34.567   1.1.1.1:31793   2.2.2.2:8080(http-alt)   Policy denied (L3
 			name: "dict",
 			options: []Option{
 				Dict(),
-				SetPortTranslation(true),
+				WithPortTranslation(),
 				Writer(&buf),
 			},
 			args: args{
@@ -308,15 +308,15 @@ func Test_getHostNames(t *testing.T) {
 			},
 		},
 	}
-	p := New(SetPortTranslation(true), SetIPTranslation(true))
+	p := New(WithPortTranslation(), WithIPTranslation())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotSrc, gotDst := p.getHostNames(tt.args.f)
+			gotSrc, gotDst := p.GetHostNames(tt.args.f)
 			if gotSrc != tt.want.src {
-				t.Errorf("getHostNames() got = %v, want %v", gotSrc, tt.want.src)
+				t.Errorf("GetHostNames() got = %v, want %v", gotSrc, tt.want.src)
 			}
 			if gotDst != tt.want.dst {
-				t.Errorf("getHostNames() got1 = %v, want %v", gotDst, tt.want.dst)
+				t.Errorf("GetHostNames() got1 = %v, want %v", gotDst, tt.want.dst)
 			}
 		})
 	}
@@ -471,8 +471,8 @@ func Test_getFlowType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getFlowType(tt.args.f); got != tt.want {
-				t.Errorf("getFlowType() = %v, want %v", got, tt.want)
+			if got := GetFlowType(tt.args.f); got != tt.want {
+				t.Errorf("GetFlowType() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -486,7 +486,7 @@ func TestMaybeTime(t *testing.T) {
 }
 
 func TestPorts(t *testing.T) {
-	p := New(SetPortTranslation(true))
+	p := New(WithPortTranslation())
 	assert.Equal(t, "80(http)", p.UDPPort(layers.UDPPort(80)))
 	assert.Equal(t, "443(https)", p.TCPPort(layers.TCPPort(443)))
 	assert.Equal(t, "4240(cilium-health)", p.TCPPort(layers.TCPPort(4240)))
@@ -496,7 +496,7 @@ func TestPorts(t *testing.T) {
 }
 
 func TestHostname(t *testing.T) {
-	p := New(SetIPTranslation(true))
+	p := New(WithIPTranslation())
 	assert.Equal(t, "default/pod", p.Hostname("", "", "default", "pod", "", []string{}))
 	assert.Equal(t, "default/pod", p.Hostname("", "", "default", "pod", "service", []string{}))
 	assert.Equal(t, "default/service", p.Hostname("", "", "default", "", "service", []string{}))


### PR DESCRIPTION
- Rename Set{IP,Port}Translation to With{IP,Port}Translation to be
  consistent with other options.
- Export GetPorts/GetHostNames/GetFlowType so that they can be called
  from outside the printer package.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>