### PR TITLE
serve: Add a "local" server

### DIFF
--- a/pkg/server/dns_test.go
+++ b/pkg/server/dns_test.go
@@ -105,6 +105,6 @@ func TestObserverServer_consumeLogRecordNotifyChannel(t *testing.T) {
 	}
 	go s.consumeLogRecordNotifyChannel()
 
-	s.GetLogRecordNotifyChannel() <- lr
+	s.getLogRecordNotifyChannel() <- lr
 	wg.Wait()
 }

--- a/pkg/server/endpoint_test.go
+++ b/pkg/server/endpoint_test.go
@@ -353,7 +353,7 @@ func TestObserverServer_EndpointAddEvent(t *testing.T) {
 	}
 	go s.consumeEndpointEvents()
 
-	s.GetEndpointEventsChannel() <- monitorAPI.AgentNotify{
+	s.getEndpointEventsChannel() <- monitorAPI.AgentNotify{
 		Type: monitorAPI.AgentNotifyEndpointCreated,
 		Text: string(ecnMarshal),
 	}
@@ -377,7 +377,7 @@ func TestObserverServer_EndpointAddEvent(t *testing.T) {
 	}
 	go s.consumeEndpointEvents()
 
-	s.GetEndpointEventsChannel() <- monitorAPI.AgentNotify{
+	s.getEndpointEventsChannel() <- monitorAPI.AgentNotify{
 		Type: monitorAPI.AgentNotifyEndpointCreated,
 		Text: string(ecnMarshal),
 	}
@@ -418,7 +418,7 @@ func TestObserverServer_EndpointDeleteEvent(t *testing.T) {
 	}
 	go s.consumeEndpointEvents()
 
-	s.GetEndpointEventsChannel() <- monitorAPI.AgentNotify{
+	s.getEndpointEventsChannel() <- monitorAPI.AgentNotify{
 		Type: monitorAPI.AgentNotifyEndpointDeleted,
 		Text: string(ednMarshal),
 	}
@@ -482,7 +482,7 @@ func TestObserverServer_EndpointRegenEvent(t *testing.T) {
 	}
 	go s.consumeEndpointEvents()
 
-	s.GetEndpointEventsChannel() <- monitorAPI.AgentNotify{
+	s.getEndpointEventsChannel() <- monitorAPI.AgentNotify{
 		Type: monitorAPI.AgentNotifyEndpointRegenerateSuccess,
 		Text: string(ednMarshal),
 	}

--- a/pkg/server/local_observer.go
+++ b/pkg/server/local_observer.go
@@ -1,0 +1,119 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/math"
+	"go.uber.org/zap"
+
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/cilium/hubble/pkg/container"
+	"github.com/cilium/hubble/pkg/logger"
+	"github.com/cilium/hubble/pkg/parser"
+)
+
+// LocalObserverServer is an implementation of the server.Observer interface
+// that's meant to be run embedded inside the Cilium process. It ignores all
+// the state change events since the state is available locally.
+type LocalObserverServer struct {
+	// ring buffer that contains the references of all flows
+	ring *container.Ring
+
+	// events is the channel used by the writer(s) to send the flow data
+	// into the observer server.
+	events chan *pb.Payload
+
+	// stopped is mostly used in unit tests to signalize when the events
+	// channel is empty, once it's closed.
+	stopped chan struct{}
+
+	log *zap.Logger
+
+	// channel to receive events from observer server.
+	eventschan chan *observer.GetFlowsResponse
+
+	// payloadParser decodes pb.Payload into pb.Flow
+	payloadParser *parser.Parser
+}
+
+// NewLocalServer returns a new local observer server.
+func NewLocalServer(
+	payloadParser *parser.Parser,
+	maxFlows int,
+) *LocalObserverServer {
+	return &LocalObserverServer{
+		log:  logger.GetLogger(),
+		ring: container.NewRing(maxFlows),
+		// have a channel with 1% of the max flows that we can receive
+		events:        make(chan *pb.Payload, uint64(math.IntMin(maxFlows/100, 100))),
+		stopped:       make(chan struct{}),
+		eventschan:    make(chan *observer.GetFlowsResponse, 100),
+		payloadParser: payloadParser,
+	}
+}
+
+// Start starts the server to handle the events sent to the events channel as
+// well as handle events to the EpAdd and EpDel channels.
+func (s *LocalObserverServer) Start() {
+	processEvents(s)
+}
+
+// GetEventsChannel returns the event channel to receive pb.Payload events.
+func (s *LocalObserverServer) GetEventsChannel() chan *pb.Payload {
+	return s.events
+}
+
+// GetRingBuffer implements Observer.GetRingBuffer.
+func (s *LocalObserverServer) GetRingBuffer() *container.Ring {
+	return s.ring
+}
+
+// GetLogger implements Observer.GetLogger.
+func (s *LocalObserverServer) GetLogger() *zap.Logger {
+	return s.log
+}
+
+// GetStopped implements Observer.GetStopped.
+func (s *LocalObserverServer) GetStopped() chan struct{} {
+	return s.stopped
+}
+
+// GetPayloadParser implements Observer.GetPayloadParser.
+func (s *LocalObserverServer) GetPayloadParser() *parser.Parser {
+	return s.payloadParser
+}
+
+// ServerStatus should have a comment, apparently. It returns the server status.
+func (s *LocalObserverServer) ServerStatus(
+	ctx context.Context, req *observer.ServerStatusRequest,
+) (*observer.ServerStatusResponse, error) {
+	return getServerStatusFromObserver(s)
+}
+
+// GetFlows implements the proto method for client requests.
+func (s *LocalObserverServer) GetFlows(
+	req *observer.GetFlowsRequest,
+	server observer.Observer_GetFlowsServer,
+) (err error) {
+	return getFlowsFromObserver(req, server, s)
+}
+
+// HandleMonitorSocket is a noop for local server since it doesn't connect to the monitor socket.
+func (s *LocalObserverServer) HandleMonitorSocket(nodeName string) error {
+	return nil
+}

--- a/pkg/server/local_observer_test.go
+++ b/pkg/server/local_observer_test.go
@@ -1,0 +1,104 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/monitor"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/cilium/hubble/pkg/parser"
+	"github.com/cilium/hubble/pkg/testutils"
+)
+
+func TestNewLocalServer(t *testing.T) {
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, 10)
+	assert.NotNil(t, s.GetStopped())
+	assert.NotNil(t, s.GetPayloadParser())
+	assert.NotNil(t, s.GetRingBuffer())
+	assert.NotNil(t, s.GetLogger())
+	assert.NotNil(t, s.GetEventsChannel())
+}
+
+func TestLocalObserverServer_ServerStatus(t *testing.T) {
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, 1)
+	res, err := s.ServerStatus(context.Background(), &observer.ServerStatusRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, &observer.ServerStatusResponse{NumFlows: 0, MaxFlows: 2}, res)
+}
+
+func TestLocalObserverServer_GetFlows(t *testing.T) {
+	numFlows := 100
+	req := &observer.GetFlowsRequest{Number: uint64(10)}
+	i := 0
+	fakeServer := &FakeGetFlowsServer{
+		OnSend: func(response *observer.GetFlowsResponse) error {
+			i++
+			return nil
+		},
+		FakeGRPCServerStream: &FakeGRPCServerStream{
+			OnContext: func() context.Context {
+				return context.Background()
+			},
+		},
+	}
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, numFlows)
+	go s.Start()
+
+	m := s.GetEventsChannel()
+	for i := 0; i < numFlows; i++ {
+		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+		data := testutils.MustCreateL3L4Payload(tn)
+		pl := &pb.Payload{
+			Time: &types.Timestamp{Seconds: int64(i)},
+			Type: pb.EventType_EventSample,
+			Data: data,
+		}
+		m <- pl
+	}
+	close(s.GetEventsChannel())
+	<-s.GetStopped()
+	err = s.GetFlows(req, fakeServer)
+	assert.NoError(t, err)
+	assert.Equal(t, req.Number, uint64(i))
+}


### PR DESCRIPTION
Define an interface for the observer server, and add a new implementation
LocalObserverServer. It ignores all the state change events and does not
connect to Cilium's monitor socket. It's meant to be started embeeded in
Cilium process so that:

1. the parser can access Cilium state directly without making a copy, and
2. the server can receive monitor payloads by registering a listener.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>