### PR TITLE
serve: Add a "local" server

### DIFF
--- a/pkg/server/dns_test.go
+++ b/pkg/server/dns_test.go
@@ -105,6 +105,6 @@ func TestObserverServer_consumeLogRecordNotifyChannel(t *testing.T) {
 	}
 	go s.consumeLogRecordNotifyChannel()
 
-	s.GetLogRecordNotifyChannel() <- lr
+	s.getLogRecordNotifyChannel() <- lr
 	wg.Wait()
 }

--- a/pkg/server/endpoint_test.go
+++ b/pkg/server/endpoint_test.go
@@ -353,7 +353,7 @@ func TestObserverServer_EndpointAddEvent(t *testing.T) {
 	}
 	go s.consumeEndpointEvents()
 
-	s.GetEndpointEventsChannel() <- monitorAPI.AgentNotify{
+	s.getEndpointEventsChannel() <- monitorAPI.AgentNotify{
 		Type: monitorAPI.AgentNotifyEndpointCreated,
 		Text: string(ecnMarshal),
 	}
@@ -377,7 +377,7 @@ func TestObserverServer_EndpointAddEvent(t *testing.T) {
 	}
 	go s.consumeEndpointEvents()
 
-	s.GetEndpointEventsChannel() <- monitorAPI.AgentNotify{
+	s.getEndpointEventsChannel() <- monitorAPI.AgentNotify{
 		Type: monitorAPI.AgentNotifyEndpointCreated,
 		Text: string(ecnMarshal),
 	}
@@ -418,7 +418,7 @@ func TestObserverServer_EndpointDeleteEvent(t *testing.T) {
 	}
 	go s.consumeEndpointEvents()
 
-	s.GetEndpointEventsChannel() <- monitorAPI.AgentNotify{
+	s.getEndpointEventsChannel() <- monitorAPI.AgentNotify{
 		Type: monitorAPI.AgentNotifyEndpointDeleted,
 		Text: string(ednMarshal),
 	}
@@ -482,7 +482,7 @@ func TestObserverServer_EndpointRegenEvent(t *testing.T) {
 	}
 	go s.consumeEndpointEvents()
 
-	s.GetEndpointEventsChannel() <- monitorAPI.AgentNotify{
+	s.getEndpointEventsChannel() <- monitorAPI.AgentNotify{
 		Type: monitorAPI.AgentNotifyEndpointRegenerateSuccess,
 		Text: string(ednMarshal),
 	}

--- a/pkg/server/local_observer.go
+++ b/pkg/server/local_observer.go
@@ -1,0 +1,118 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/math"
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/cilium/hubble/pkg/container"
+	"github.com/cilium/hubble/pkg/parser"
+	"go.uber.org/zap"
+)
+
+// LocalObserverServer is an implementation of the server.Observer interface
+// that's meant to be run embedded inside the Cilium process. It ignores all
+// the state change events since the state is available locally.
+type LocalObserverServer struct {
+	// ring buffer that contains the references of all flows
+	ring *container.Ring
+
+	// events is the channel used by the writer(s) to send the flow data
+	// into the observer server.
+	events chan *pb.Payload
+
+	// stopped is mostly used in unit tests to signalize when the events
+	// channel is empty, once it's closed.
+	stopped chan struct{}
+
+	log *zap.Logger
+
+	// channel to receive events from observer server.
+	eventschan chan *observer.GetFlowsResponse
+
+	// payloadParser decodes pb.Payload into pb.Flow
+	payloadParser *parser.Parser
+}
+
+// NewLocalServer returns a new local observer server.
+func NewLocalServer(
+	payloadParser *parser.Parser,
+	maxFlows int,
+	logger *zap.Logger,
+) *LocalObserverServer {
+	return &LocalObserverServer{
+		log:  logger,
+		ring: container.NewRing(maxFlows),
+		// have a channel with 1% of the max flows that we can receive
+		events:        make(chan *pb.Payload, uint64(math.IntMin(maxFlows/100, 100))),
+		stopped:       make(chan struct{}),
+		eventschan:    make(chan *observer.GetFlowsResponse, 100),
+		payloadParser: payloadParser,
+	}
+}
+
+// Start starts the server to handle the events sent to the events channel as
+// well as handle events to the EpAdd and EpDel channels.
+func (s *LocalObserverServer) Start() {
+	processEvents(s)
+}
+
+// GetEventsChannel returns the event channel to receive pb.Payload events.
+func (s *LocalObserverServer) GetEventsChannel() chan *pb.Payload {
+	return s.events
+}
+
+// GetRingBuffer implements Observer.GetRingBuffer.
+func (s *LocalObserverServer) GetRingBuffer() *container.Ring {
+	return s.ring
+}
+
+// GetLogger implements Observer.GetLogger.
+func (s *LocalObserverServer) GetLogger() *zap.Logger {
+	return s.log
+}
+
+// GetStopped implements Observer.GetStopped.
+func (s *LocalObserverServer) GetStopped() chan struct{} {
+	return s.stopped
+}
+
+// GetPayloadParser implements Observer.GetPayloadParser.
+func (s *LocalObserverServer) GetPayloadParser() *parser.Parser {
+	return s.payloadParser
+}
+
+// ServerStatus should have a comment, apparently. It returns the server status.
+func (s *LocalObserverServer) ServerStatus(
+	ctx context.Context, req *observer.ServerStatusRequest,
+) (*observer.ServerStatusResponse, error) {
+	return getServerStatusFromObserver(s)
+}
+
+// GetFlows implements the proto method for client requests.
+func (s *LocalObserverServer) GetFlows(
+	req *observer.GetFlowsRequest,
+	server observer.Observer_GetFlowsServer,
+) (err error) {
+	return getFlowsFromObserver(req, server, s)
+}
+
+// HandleMonitorSocket is a noop for local server since it doesn't connect to the monitor socket.
+func (s *LocalObserverServer) HandleMonitorSocket(nodeName string) error {
+	return nil
+}

--- a/pkg/server/local_observer_test.go
+++ b/pkg/server/local_observer_test.go
@@ -1,0 +1,104 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/monitor"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/cilium/hubble/pkg/parser"
+	"github.com/cilium/hubble/pkg/testutils"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestNewLocalServer(t *testing.T) {
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, 10, zap.L())
+	assert.NotNil(t, s.GetStopped())
+	assert.NotNil(t, s.GetPayloadParser())
+	assert.NotNil(t, s.GetRingBuffer())
+	assert.NotNil(t, s.GetLogger())
+	assert.NotNil(t, s.GetEventsChannel())
+}
+
+func TestLocalObserverServer_ServerStatus(t *testing.T) {
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, 1, zap.L())
+	res, err := s.ServerStatus(context.Background(), &observer.ServerStatusRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, &observer.ServerStatusResponse{NumFlows: 0, MaxFlows: 2}, res)
+}
+
+func TestLocalObserverServer_GetFlows(t *testing.T) {
+	numFlows := 100
+	req := &observer.GetFlowsRequest{Number: uint64(10)}
+	i := 0
+	fakeServer := &FakeGetFlowsServer{
+		OnSend: func(response *observer.GetFlowsResponse) error {
+			i++
+			return nil
+		},
+		FakeGRPCServerStream: &FakeGRPCServerStream{
+			OnContext: func() context.Context {
+				return context.Background()
+			},
+		},
+	}
+	pp, err := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter)
+	require.NoError(t, err)
+	s := NewLocalServer(pp, numFlows, zap.L())
+	go s.Start()
+
+	m := s.GetEventsChannel()
+	for i := 0; i < numFlows; i++ {
+		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+		data := testutils.MustCreateL3L4Payload(tn)
+		pl := &pb.Payload{
+			Time: &types.Timestamp{Seconds: int64(i)},
+			Type: pb.EventType_EventSample,
+			Data: data,
+		}
+		m <- pl
+	}
+	close(s.GetEventsChannel())
+	<-s.GetStopped()
+	err = s.GetFlows(req, fakeServer)
+	assert.NoError(t, err)
+	assert.Equal(t, req.Number, uint64(i))
+}

--- a/pkg/server/observer.go
+++ b/pkg/server/observer.go
@@ -15,14 +15,26 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/gob"
 	"fmt"
+	"io"
+	"log"
 	"net"
 	"strings"
 	"time"
 
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/math"
+	"github.com/cilium/cilium/pkg/monitor"
+	"github.com/cilium/cilium/pkg/monitor/agent/listener"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/monitor/payload"
 	pb "github.com/cilium/hubble/api/v1/flow"
 	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/cilium/hubble/pkg/api"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/container"
 	"github.com/cilium/hubble/pkg/filters"
@@ -32,14 +44,21 @@ import (
 	"github.com/cilium/hubble/pkg/parser"
 	parserErrors "github.com/cilium/hubble/pkg/parser/errors"
 	"github.com/cilium/hubble/pkg/servicecache"
-
-	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/math"
-	"github.com/cilium/cilium/pkg/monitor"
-	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/gogo/protobuf/types"
 	"go.uber.org/zap"
 )
+
+// Observer defines the interface for observer server.
+type Observer interface {
+	observer.ObserverServer
+	Start()
+	GetEventsChannel() chan *pb.Payload
+	GetRingBuffer() *container.Ring
+	GetLogger() *zap.Logger
+	GetStopped() chan struct{}
+	GetPayloadParser() *parser.Parser
+	HandleMonitorSocket(nodeName string) error
+}
 
 type ciliumClient interface {
 	EndpointList() ([]*models.Endpoint, error)
@@ -149,68 +168,92 @@ func (s *ObserverServer) Start() {
 	go s.consumeEndpointEvents()
 	go s.consumeLogRecordNotifyChannel()
 
-	for pl := range s.events {
-		flow, err := s.decodeFlow(pl)
+	processEvents(s)
+}
+
+func processEvents(s Observer) {
+	for pl := range s.GetEventsChannel() {
+		flow, err := decodeFlow(s.GetPayloadParser(), pl)
 		if err != nil {
 			if !parserErrors.IsErrInvalidType(err) {
-				s.log.Debug("failed to decode payload", zap.ByteString("data", pl.Data), zap.Error(err))
+				s.GetLogger().Debug("failed to decode payload", zap.ByteString("data", pl.Data), zap.Error(err))
 			}
 			continue
 		}
 
 		metrics.ProcessFlow(flow)
-		s.ring.Write(&v1.Event{
+		s.GetRingBuffer().Write(&v1.Event{
 			Timestamp: pl.Time,
 			Event:     flow,
 		})
 	}
-	close(s.stopped)
+	close(s.GetStopped())
 }
 
-// StartMirroringIPCache will obtain an initial IPCache snapshot from Cilium
+// startMirroringIPCache will obtain an initial IPCache snapshot from Cilium
 // and then start mirroring IPCache events based on IPCacheNotification sent
 // through the ipCacheEvents channels. Only messages of type
 // `AgentNotifyIPCacheUpserted` and `AgentNotifyIPCacheDeleted` should be sent
 // through that channel. This function assumes that the caller is already
 // connected to Cilium Monitor, i.e. no IPCacheNotification must be lost after
 // calling this method.
-func (s *ObserverServer) StartMirroringIPCache(ipCacheEvents <-chan monitorAPI.AgentNotify) {
+func (s *ObserverServer) startMirroringIPCache(ipCacheEvents <-chan monitorAPI.AgentNotify) {
 	go s.syncIPCache(ipCacheEvents)
 }
 
-// StartMirroringServiceCache initially caches service information from Cilium
+// startMirroringServiceCache initially caches service information from Cilium
 // and then starts to mirror service information based on events that are sent
 // to the serviceEvents channel. Only messages of type
 // `AgentNotifyServiceUpserted` and `AgentNotifyServiceDeleted` should be sent
 // to this channel.  This function assumes that the caller is already connected
 // to Cilium Monitor, i.e. no Service notification must be lost after calling
 // this method.
-func (s *ObserverServer) StartMirroringServiceCache(serviceEvents <-chan monitorAPI.AgentNotify) {
+func (s *ObserverServer) startMirroringServiceCache(serviceEvents <-chan monitorAPI.AgentNotify) {
 	go s.syncServiceCache(serviceEvents)
 }
 
-// GetLogRecordNotifyChannel returns the event channel to receive
+// getLogRecordNotifyChannel returns the event channel to receive
 // monitorAPI.LogRecordNotify events.
-func (s *ObserverServer) GetLogRecordNotifyChannel() chan<- monitor.LogRecordNotify {
+func (s *ObserverServer) getLogRecordNotifyChannel() chan<- monitor.LogRecordNotify {
 	return s.logRecord
 }
 
 // GetEventsChannel returns the event channel to receive pb.Payload events.
-func (s *ObserverServer) GetEventsChannel() chan<- *pb.Payload {
+func (s *ObserverServer) GetEventsChannel() chan *pb.Payload {
 	return s.events
 }
 
-// GetEndpointEventsChannel returns a channel that should be used to send
+// getEndpointEventsChannel returns a channel that should be used to send
 // AgentNotifyEndpoint* events when an endpoint is added, deleted or updated
 // in Cilium.
-func (s *ObserverServer) GetEndpointEventsChannel() chan<- monitorAPI.AgentNotify {
+func (s *ObserverServer) getEndpointEventsChannel() chan<- monitorAPI.AgentNotify {
 	return s.endpointEvents
 }
 
-func (s *ObserverServer) decodeFlow(pl *pb.Payload) (*pb.Flow, error) {
+// GetRingBuffer implements Observer.GetRingBuffer.
+func (s *ObserverServer) GetRingBuffer() *container.Ring {
+	return s.ring
+}
+
+// GetLogger implements Observer.GetLogger.
+func (s *ObserverServer) GetLogger() *zap.Logger {
+	return s.log
+}
+
+// GetStopped implements Observer.GetStopped.
+func (s *ObserverServer) GetStopped() chan struct{} {
+	return s.stopped
+}
+
+// GetPayloadParser implements Observer.GetPayloadParser.
+func (s *ObserverServer) GetPayloadParser() *parser.Parser {
+	return s.payloadParser
+}
+
+func decodeFlow(payloadParser *parser.Parser, pl *pb.Payload) (*pb.Flow, error) {
 	// TODO: Pool these instead of allocating new flows each time.
 	f := &pb.Flow{}
-	err := s.payloadParser.Decode(pl, f)
+	err := payloadParser.Decode(pl, f)
 	if err != nil {
 		return nil, err
 	}
@@ -222,9 +265,13 @@ func (s *ObserverServer) decodeFlow(pl *pb.Payload) (*pb.Flow, error) {
 func (s *ObserverServer) ServerStatus(
 	ctx context.Context, req *observer.ServerStatusRequest,
 ) (*observer.ServerStatusResponse, error) {
+	return getServerStatusFromObserver(s)
+}
+
+func getServerStatusFromObserver(obs Observer) (*observer.ServerStatusResponse, error) {
 	res := &observer.ServerStatusResponse{
-		MaxFlows: s.ring.Cap(),
-		NumFlows: s.ring.Len(),
+		MaxFlows: obs.GetRingBuffer().Cap(),
+		NumFlows: obs.GetRingBuffer().Len(),
 	}
 	return res, nil
 }
@@ -242,7 +289,15 @@ func (s *ObserverServer) GetFlows(
 	req *observer.GetFlowsRequest,
 	server observer.Observer_GetFlowsServer,
 ) (err error) {
-	reply, err := getFlows(server.Context(), s.log, s.ring, req)
+	return getFlowsFromObserver(req, server, s)
+}
+
+func getFlowsFromObserver(
+	req *observer.GetFlowsRequest,
+	server observer.Observer_GetFlowsServer,
+	obs Observer,
+) (err error) {
+	reply, err := getFlows(server.Context(), obs.GetLogger(), obs.GetRingBuffer(), req)
 	if err != nil {
 		return err
 	}
@@ -407,4 +462,158 @@ func getFlows(
 		}
 	}()
 	return reply, nil
+}
+
+// HandleMonitorSocket connects to the monitor socket and consumes monitor events.
+func (s *ObserverServer) HandleMonitorSocket(nodeName string) error {
+	// On EOF, retry
+	// On other errors, exit
+	// always wait connTimeout when retrying
+	for ; ; time.Sleep(api.ConnectionTimeout) {
+		conn, version, err := openMonitorSock()
+		if err != nil {
+			s.log.Error("Cannot open monitor serverSocketPath", zap.Error(err))
+			return err
+		}
+
+		err = s.consumeMonitorEvents(conn, version, nodeName)
+		switch {
+		case err == nil:
+			// no-op
+
+		case err == io.EOF, err == io.ErrUnexpectedEOF:
+			s.log.Warn("connection closed", zap.Error(err))
+			continue
+
+		default:
+			log.Fatal("decoding error", zap.Error(err))
+		}
+	}
+}
+
+// getMonitorParser constructs and returns an eventParserFunc. It is
+// appropriate for the monitor API version passed in.
+func getMonitorParser(conn net.Conn, version listener.Version, nodeName string) (parser eventParserFunc, err error) {
+	switch version {
+	case listener.Version1_2:
+		var (
+			pl  payload.Payload
+			dec = gob.NewDecoder(conn)
+		)
+		// This implements the newer 1.2 API. Each listener maintains its own gob
+		// session, and type information is only ever sent once.
+		return func() (*pb.Payload, error) {
+			if err := pl.DecodeBinary(dec); err != nil {
+				return nil, err
+			}
+			b := make([]byte, len(pl.Data))
+			copy(b, pl.Data)
+
+			// TODO: Eventually, the monitor will add these timestaps to events.
+			// For now, we add them in hubble server.
+			grpcPl := &pb.Payload{
+				Data:     b,
+				CPU:      int32(pl.CPU),
+				Lost:     pl.Lost,
+				Type:     pb.EventType(pl.Type),
+				Time:     types.TimestampNow(),
+				HostName: nodeName,
+			}
+			return grpcPl, nil
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported version %s", version)
+	}
+}
+
+// consumeMonitorEvents handles and prints events on a monitor connection. It
+// calls getMonitorParsed to construct a monitor-version appropriate parser.
+// It closes conn on return, and returns on error, including io.EOF
+func (s *ObserverServer) consumeMonitorEvents(conn net.Conn, version listener.Version, nodeName string) error {
+	defer conn.Close()
+	ch := s.GetEventsChannel()
+	endpointEvents := s.getEndpointEventsChannel()
+
+	dnsAdd := s.getLogRecordNotifyChannel()
+
+	ipCacheEvents := make(chan monitorAPI.AgentNotify, 100)
+	s.startMirroringIPCache(ipCacheEvents)
+
+	serviceEvents := make(chan monitorAPI.AgentNotify, 100)
+	s.startMirroringServiceCache(serviceEvents)
+
+	getParsedPayload, err := getMonitorParser(conn, version, nodeName)
+	if err != nil {
+		return err
+	}
+
+	for {
+		pl, err := getParsedPayload()
+		if err != nil {
+			return err
+		}
+
+		ch <- pl
+		// we don't expect to have many MessageTypeAgent so we
+		// can "decode" this messages as they come.
+		switch pl.Data[0] {
+		case monitorAPI.MessageTypeAgent:
+			buf := bytes.NewBuffer(pl.Data[1:])
+			dec := gob.NewDecoder(buf)
+
+			an := monitorAPI.AgentNotify{}
+			if err := dec.Decode(&an); err != nil {
+				fmt.Printf("Error while decoding agent notification message: %s\n", err)
+				continue
+			}
+			switch an.Type {
+			case monitorAPI.AgentNotifyEndpointCreated,
+				monitorAPI.AgentNotifyEndpointRegenerateSuccess,
+				monitorAPI.AgentNotifyEndpointDeleted:
+				endpointEvents <- an
+			case monitorAPI.AgentNotifyIPCacheUpserted,
+				monitorAPI.AgentNotifyIPCacheDeleted:
+				ipCacheEvents <- an
+			case monitorAPI.AgentNotifyServiceUpserted,
+				monitorAPI.AgentNotifyServiceDeleted:
+				serviceEvents <- an
+			}
+		case monitorAPI.MessageTypeAccessLog:
+			// TODO re-think the way this is being done. We are dissecting/
+			//      TypeAccessLog messages here *and* when we are dumping
+			//      them into JSON.
+			buf := bytes.NewBuffer(pl.Data[1:])
+			dec := gob.NewDecoder(buf)
+
+			lr := monitor.LogRecordNotify{}
+
+			if err := dec.Decode(&lr); err != nil {
+				fmt.Printf("Error while decoding access log message type: %s\n", err)
+				continue
+			}
+			if lr.DNS != nil {
+				dnsAdd <- lr
+			}
+		}
+	}
+}
+
+// eventParseFunc is a convenience function type used as a version-specific
+// parser of monitor events
+type eventParserFunc func() (*pb.Payload, error)
+
+// openMonitorSock attempts to open a version specific monitor serverSocketPath It
+// returns a connection, with a version, or an error.
+func openMonitorSock() (conn net.Conn, version listener.Version, err error) {
+	errors := make([]string, 0)
+
+	// try the 1.2 serverSocketPath
+	conn, err = net.Dial("unix", defaults.MonitorSockPath1_2)
+	if err == nil {
+		return conn, listener.Version1_2, nil
+	}
+	errors = append(errors, defaults.MonitorSockPath1_2+": "+err.Error())
+
+	return nil, listener.VersionUnsupported, fmt.Errorf("cannot find or open a supported node-monitor serverSocketPath. %s", strings.Join(errors, ","))
 }


### PR DESCRIPTION
Define an interface for the observer server, and add a new implementation
LocalObserverServer. It ignores all the state change events and does not
connect to Cilium's monitor socket. It's meant to be started embeeded in
Cilium process so that:

1. the parser can access Cilium state directly without making a copy, and
2. the server can receive monitor payloads by registering a listener.

The observer server interface adds a new method HandleMonitorSocket() that
encapsulates the logic for connecting to the monitor socket and handling
monitor events instead of exposing the logic in cmd/serve.go.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>