### PR TITLE
server: Refactor LocalObserverServer and ObserverServer

### DIFF
--- a/pkg/server/dns_test.go
+++ b/pkg/server/dns_test.go
@@ -99,9 +99,10 @@ func TestObserverServer_consumeLogRecordNotifyChannel(t *testing.T) {
 	}
 
 	s := &ObserverServer{
-		fqdnCache: fakeFQDNCache,
-		logRecord: make(chan monitorAPI.LogRecordNotify, 1),
-		log:       zap.L(),
+		fqdnCache:  fakeFQDNCache,
+		logRecord:  make(chan monitorAPI.LogRecordNotify, 1),
+		log:        zap.L(),
+		grpcServer: getNoopGRPCServer(),
 	}
 	go s.consumeLogRecordNotifyChannel()
 

--- a/pkg/server/endpoint_test.go
+++ b/pkg/server/endpoint_test.go
@@ -25,10 +25,11 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/hubble/pkg/parser"
+	"github.com/cilium/hubble/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-
-	v1 "github.com/cilium/hubble/pkg/api/v1"
 )
 
 type fakeCiliumClient struct {
@@ -152,6 +153,16 @@ func (f *fakeEndpointsHandler) GarbageCollect() {
 	panic("GarbageCollect() should not have been called since it was not defined")
 }
 
+func getNoopGRPCServer() GRPCServer {
+	pp, _ := parser.New(
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter)
+	return NewLocalServer(pp, 10, zap.NewNop())
+}
+
 func TestObserverServer_syncAllEndpoints(t *testing.T) {
 	refreshEndpointList = 50 * time.Millisecond
 	var (
@@ -227,6 +238,7 @@ func TestObserverServer_syncAllEndpoints(t *testing.T) {
 		ciliumClient: fakeClient,
 		endpoints:    fakeHandler,
 		log:          zap.L(),
+		grpcServer:   getNoopGRPCServer(),
 	}
 	go s.syncEndpoints()
 
@@ -350,6 +362,7 @@ func TestObserverServer_EndpointAddEvent(t *testing.T) {
 		endpoints:      fakeHandler,
 		endpointEvents: epEventsCh,
 		log:            zap.L(),
+		grpcServer:     getNoopGRPCServer(),
 	}
 	go s.consumeEndpointEvents()
 
@@ -374,6 +387,7 @@ func TestObserverServer_EndpointAddEvent(t *testing.T) {
 		endpoints:      fakeHandler,
 		endpointEvents: epEventsCh,
 		log:            zap.L(),
+		grpcServer:     getNoopGRPCServer(),
 	}
 	go s.consumeEndpointEvents()
 
@@ -415,6 +429,7 @@ func TestObserverServer_EndpointDeleteEvent(t *testing.T) {
 		endpoints:      fakeHandler,
 		endpointEvents: epEventsCh,
 		log:            zap.L(),
+		grpcServer:     getNoopGRPCServer(),
 	}
 	go s.consumeEndpointEvents()
 
@@ -479,6 +494,7 @@ func TestObserverServer_EndpointRegenEvent(t *testing.T) {
 		endpoints:      fakeHandler,
 		endpointEvents: epEventsCh,
 		log:            zap.L(),
+		grpcServer:     getNoopGRPCServer(),
 	}
 	go s.consumeEndpointEvents()
 

--- a/pkg/server/ipcache_test.go
+++ b/pkg/server/ipcache_test.go
@@ -60,6 +60,7 @@ func TestObserverServer_syncIPCache(t *testing.T) {
 		ciliumClient: fakeClient,
 		ipcache:      ipc,
 		log:          zap.L(),
+		grpcServer:   getNoopGRPCServer(),
 	}
 
 	ipCacheEvents := make(chan monitorAPI.AgentNotify, 100)

--- a/pkg/server/local_observer.go
+++ b/pkg/server/local_observer.go
@@ -16,14 +16,42 @@ package server
 
 import (
 	"context"
+	"io"
+	"strings"
+	"time"
 
 	"github.com/cilium/cilium/pkg/math"
 	pb "github.com/cilium/hubble/api/v1/flow"
 	"github.com/cilium/hubble/api/v1/observer"
+	v1 "github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/container"
+	"github.com/cilium/hubble/pkg/filters"
+	"github.com/cilium/hubble/pkg/metrics"
 	"github.com/cilium/hubble/pkg/parser"
+	"github.com/cilium/hubble/pkg/parser/errors"
+	"github.com/gogo/protobuf/types"
 	"go.uber.org/zap"
 )
+
+// GRPCServer defines the interface for Hubble gRPC server, extending the
+// auto-generated ObserverServer interface from the protobuf definition.
+type GRPCServer interface {
+	observer.ObserverServer
+	// Start starts the server and blocks.
+	Start()
+	// GetEventsChannel returns the channel to push monitor events to.
+	GetEventsChannel() chan *pb.Payload
+	// SetEventsChannel sets the events channel. For unit testing only.
+	SetEventsChannel(chan *pb.Payload)
+	///GetRingBuffer returns the underlying ring buffer to parsed events.
+	GetRingBuffer() *container.Ring
+	// GetStopped returns a channel that gets closed at the end of the
+	// main server loop after all the events have been processes. Used
+	// in unit testing.
+	GetStopped() chan struct{}
+	// GetLogger returns the logger assigned to this gRPC server.
+	GetLogger() *zap.Logger
+}
 
 // LocalObserverServer is an implementation of the server.Observer interface
 // that's meant to be run embedded inside the Cilium process. It ignores all
@@ -66,10 +94,24 @@ func NewLocalServer(
 	}
 }
 
-// Start starts the server to handle the events sent to the events channel as
-// well as handle events to the EpAdd and EpDel channels.
+// Start implements GRPCServer.Start.
 func (s *LocalObserverServer) Start() {
-	processEvents(s)
+	for pl := range s.GetEventsChannel() {
+		flow, err := decodeFlow(s.payloadParser, pl)
+		if err != nil {
+			if !errors.IsErrInvalidType(err) {
+				s.log.Debug("failed to decode payload", zap.ByteString("data", pl.Data), zap.Error(err))
+			}
+			continue
+		}
+
+		metrics.ProcessFlow(flow)
+		s.GetRingBuffer().Write(&v1.Event{
+			Timestamp: pl.Time,
+			Event:     flow,
+		})
+	}
+	close(s.GetStopped())
 }
 
 // GetEventsChannel returns the event channel to receive pb.Payload events.
@@ -77,22 +119,27 @@ func (s *LocalObserverServer) GetEventsChannel() chan *pb.Payload {
 	return s.events
 }
 
-// GetRingBuffer implements Observer.GetRingBuffer.
+// SetEventsChannel implements GRPCServer.SetEventsChannel.
+func (s *LocalObserverServer) SetEventsChannel(events chan *pb.Payload) {
+	s.events = events
+}
+
+// GetRingBuffer implements GRPCServer.GetRingBuffer.
 func (s *LocalObserverServer) GetRingBuffer() *container.Ring {
 	return s.ring
 }
 
-// GetLogger implements Observer.GetLogger.
+// GetLogger implements GRPCServer.GetLogger.
 func (s *LocalObserverServer) GetLogger() *zap.Logger {
 	return s.log
 }
 
-// GetStopped implements Observer.GetStopped.
+// GetStopped implements GRPCServer.GetStopped.
 func (s *LocalObserverServer) GetStopped() chan struct{} {
 	return s.stopped
 }
 
-// GetPayloadParser implements Observer.GetPayloadParser.
+// GetPayloadParser implements GRPCServer.GetPayloadParser.
 func (s *LocalObserverServer) GetPayloadParser() *parser.Parser {
 	return s.payloadParser
 }
@@ -101,7 +148,10 @@ func (s *LocalObserverServer) GetPayloadParser() *parser.Parser {
 func (s *LocalObserverServer) ServerStatus(
 	ctx context.Context, req *observer.ServerStatusRequest,
 ) (*observer.ServerStatusResponse, error) {
-	return getServerStatusFromObserver(s)
+	return &observer.ServerStatusResponse{
+		MaxFlows: s.GetRingBuffer().Cap(),
+		NumFlows: s.GetRingBuffer().Len(),
+	}, nil
 }
 
 // GetFlows implements the proto method for client requests.
@@ -112,7 +162,229 @@ func (s *LocalObserverServer) GetFlows(
 	return getFlows(req, server, s)
 }
 
-// HandleMonitorSocket is a noop for local server since it doesn't connect to the monitor socket.
-func (s *LocalObserverServer) HandleMonitorSocket(nodeName string) error {
-	return nil
+func getFlows(
+	req *observer.GetFlowsRequest,
+	server observer.Observer_GetFlowsServer,
+	obs GRPCServer,
+) (err error) {
+	start := time.Now()
+	log := obs.GetLogger()
+	ring := obs.GetRingBuffer()
+
+	i := uint64(0)
+	defer func() {
+		log.Debug(
+			"GetFlows finished",
+			zap.Uint64("number_of_flows", i),
+			zap.Uint64("buffer_size", ring.Cap()),
+			zap.String("whitelist", logFilters(req.Whitelist)),
+			zap.String("blacklist", logFilters(req.Blacklist)),
+			zap.Duration("took", time.Now().Sub(start)),
+		)
+	}()
+
+	ringReader, err := newRingReader(server.Context(), ring, req)
+	if err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return err
+	}
+	flowsReader, err := newFlowsReader(ringReader, req, log)
+	if err != nil {
+		return err
+	}
+
+	for ; ; i++ {
+		flow, err := flowsReader.Next(server.Context())
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		err = server.Send(&observer.GetFlowsResponse{
+			ResponseTypes: &observer.GetFlowsResponse_Flow{
+				Flow: flow,
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func getUntil(req *observer.GetFlowsRequest, defaultTime *types.Timestamp) (time.Time, error) {
+	until := req.GetUntil()
+	if until == nil {
+		until = defaultTime
+	}
+	return types.TimestampFromProto(until)
+}
+
+func logFilters(filters []*pb.FlowFilter) string {
+	var s []string
+	for _, f := range filters {
+		s = append(s, f.String())
+	}
+	return "{" + strings.Join(s, ",") + "}"
+}
+
+func decodeFlow(payloadParser *parser.Parser, pl *pb.Payload) (*pb.Flow, error) {
+	// TODO: Pool these instead of allocating new flows each time.
+	f := &pb.Flow{}
+	err := payloadParser.Decode(pl, f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+// flowsReader reads flows using a RingReader. It applies the flow request
+// criterias (blacklist, whitelist, follow, ...) before returning flows.
+type flowsReader struct {
+	ringReader           *container.RingReader
+	whitelist, blacklist filters.FilterFuncs
+	maxFlows             uint64
+	follow, timeRange    bool
+	flowsCount           uint64
+	start, end           time.Time
+}
+
+// newFlowsReader creates a new flowsReader that uses the given RingReader to
+// read through the ring buffer. Only flows that match the request criterias
+// are returned.
+func newFlowsReader(r *container.RingReader, req *observer.GetFlowsRequest, log *zap.Logger) (*flowsReader, error) {
+	whitelist, err := filters.BuildFilterList(req.Whitelist)
+	if err != nil {
+		return nil, err
+	}
+	blacklist, err := filters.BuildFilterList(req.Blacklist)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug("creating a new flowsReader",
+		zap.Any("req", req),
+		zap.Any("whitelist", whitelist),
+		zap.Any("blacklist", blacklist),
+	)
+
+	reader := &flowsReader{
+		ringReader: r,
+		whitelist:  whitelist,
+		blacklist:  blacklist,
+		maxFlows:   req.Number,
+		follow:     req.Follow,
+		timeRange:  !req.Follow && req.Number == 0,
+	}
+	if reader.timeRange { // apply time range filtering
+		reader.start, err = types.TimestampFromProto(req.GetSince())
+		if err != nil {
+			return nil, err
+		}
+		reader.end, err = getUntil(req, types.TimestampNow())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return reader, nil
+}
+
+// Next returns the next flow that matches the request criterias.
+func (r *flowsReader) Next(ctx context.Context) (*pb.Flow, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		if r.maxFlows > 0 && !r.follow && (r.flowsCount >= r.maxFlows) {
+			return nil, io.EOF
+		}
+		e := r.ringReader.Next(ctx)
+		if e == nil {
+			// if the buffer is not full, we might receive nil values
+			// just keep reading then
+			continue
+		}
+		flow, ok := e.Event.(*pb.Flow)
+		if ok && filters.Apply(r.whitelist, r.blacklist, e) {
+			if r.timeRange {
+				ts, err := types.TimestampFromProto(e.GetFlow().GetTime())
+				if err != nil {
+					return nil, err
+				}
+				if ts.After(r.end) {
+					return nil, io.EOF
+				}
+				if ts.Before(r.start) {
+					continue
+				}
+			}
+			r.flowsCount++
+			return flow, nil
+		}
+	}
+}
+
+// newRingReader creates a new RingReader that starts at the correct ring
+// offset to match the flow request.
+func newRingReader(ctx context.Context, ring *container.Ring, req *observer.GetFlowsRequest) (*container.RingReader, error) {
+	if req.Follow && req.Number == 0 { // no need to rewind
+		return container.NewRingReader(ring, ring.LastWriteParallel()), nil
+	}
+
+	var err error
+	var start time.Time
+	since := req.GetSince()
+	if since != nil {
+		start, err = types.TimestampFromProto(since)
+		if err != nil {
+			return nil, err
+		}
+	}
+	whitelist, err := filters.BuildFilterList(req.Whitelist)
+	if err != nil {
+		return nil, err
+	}
+	blacklist, err := filters.BuildFilterList(req.Blacklist)
+	if err != nil {
+		return nil, err
+	}
+
+	idx := ring.LastWriteParallel()
+	reader := container.NewRingReader(ring, idx)
+
+	var flowsCount uint64
+	// We need to find out what the right index is; that is the index with the
+	// oldest entry that is within time range boundaries (if any is defined)
+	// or until we find enough events.
+	// In order to avoid buffering events, we have to rewind first to find the
+	// correct index, then create a new reader that starts from there
+	for i := ring.Len(); i > 0; i, idx = i-1, idx-1 {
+		e := reader.Previous(ctx)
+		if e == nil {
+			continue
+		}
+		_, ok := e.Event.(*pb.Flow)
+		if !ok || !filters.Apply(whitelist, blacklist, e) {
+			continue
+		}
+		flowsCount++
+		if since != nil {
+			ts, err := types.TimestampFromProto(e.GetFlow().GetTime())
+			if err != nil {
+				return nil, err
+			}
+			if ts.Before(start) {
+				idx++ // we went backward 1 too far
+				break
+			}
+		} else if flowsCount == req.Number {
+			break // we went backward far enough
+		}
+	}
+	return container.NewRingReader(ring, idx), nil
 }

--- a/pkg/server/observer.go
+++ b/pkg/server/observer.go
@@ -16,7 +16,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"encoding/gob"
 	"fmt"
 	"io"
@@ -27,38 +26,19 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/math"
 	"github.com/cilium/cilium/pkg/monitor"
 	"github.com/cilium/cilium/pkg/monitor/agent/listener"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/monitor/payload"
 	pb "github.com/cilium/hubble/api/v1/flow"
-	"github.com/cilium/hubble/api/v1/observer"
 	"github.com/cilium/hubble/pkg/api"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
-	"github.com/cilium/hubble/pkg/container"
-	"github.com/cilium/hubble/pkg/filters"
 	"github.com/cilium/hubble/pkg/ipcache"
-	"github.com/cilium/hubble/pkg/logger"
-	"github.com/cilium/hubble/pkg/metrics"
 	"github.com/cilium/hubble/pkg/parser"
-	parserErrors "github.com/cilium/hubble/pkg/parser/errors"
 	"github.com/cilium/hubble/pkg/servicecache"
 	"github.com/gogo/protobuf/types"
 	"go.uber.org/zap"
 )
-
-// Observer defines the interface for observer server.
-type Observer interface {
-	observer.ObserverServer
-	Start()
-	GetEventsChannel() chan *pb.Payload
-	GetRingBuffer() *container.Ring
-	GetLogger() *zap.Logger
-	GetStopped() chan struct{}
-	GetPayloadParser() *parser.Parser
-	HandleMonitorSocket(nodeName string) error
-}
 
 type ciliumClient interface {
 	EndpointList() ([]*models.Endpoint, error)
@@ -86,16 +66,8 @@ type fqdnCache interface {
 
 // ObserverServer is a server that can store events in memory
 type ObserverServer struct {
-	// ring buffer that contains the references of all flows
-	ring *container.Ring
-
-	// events is the channel used by the writer(s) to send the flow data
-	// into the observer server.
-	events chan *pb.Payload
-
-	// stopped is mostly used in unit tests to signalize when the events
-	// channel is empty, once it's closed.
-	stopped chan struct{}
+	// grpcServer is responsible for caching events and serving gRPC requests.
+	grpcServer GRPCServer
 
 	// ciliumClient will connect to Cilium to pool cilium endpoint information
 	ciliumClient ciliumClient
@@ -122,12 +94,6 @@ type ObserverServer struct {
 	logRecord chan monitor.LogRecordNotify
 
 	log *zap.Logger
-
-	// channel to receive events from observer server.
-	eventschan chan *observer.GetFlowsResponse
-
-	// payloadParser decodes pb.Payload into pb.Flow
-	payloadParser *parser.Parser
 }
 
 // NewServer returns a server that can store up to the given of maxFlows
@@ -140,14 +106,11 @@ func NewServer(
 	serviceCache *servicecache.ServiceCache,
 	payloadParser *parser.Parser,
 	maxFlows int,
+	logger *zap.Logger,
 ) *ObserverServer {
-
 	return &ObserverServer{
-		log:  logger.GetLogger(),
-		ring: container.NewRing(maxFlows),
-		// have a channel with 1% of the max flows that we can receive
-		events:         make(chan *pb.Payload, uint64(math.IntMin(maxFlows/100, 100))),
-		stopped:        make(chan struct{}),
+		log:            logger,
+		grpcServer:     NewLocalServer(payloadParser, maxFlows, logger),
 		ciliumClient:   ciliumClient,
 		endpoints:      endpoints,
 		ipcache:        ipCache,
@@ -155,8 +118,6 @@ func NewServer(
 		serviceCache:   serviceCache,
 		endpointEvents: make(chan monitorAPI.AgentNotify, 100),
 		logRecord:      make(chan monitor.LogRecordNotify, 100),
-		eventschan:     make(chan *observer.GetFlowsResponse, 100),
-		payloadParser:  payloadParser,
 	}
 }
 
@@ -167,27 +128,7 @@ func (s *ObserverServer) Start() {
 	go s.syncFQDNCache()
 	go s.consumeEndpointEvents()
 	go s.consumeLogRecordNotifyChannel()
-
-	processEvents(s)
-}
-
-func processEvents(s Observer) {
-	for pl := range s.GetEventsChannel() {
-		flow, err := decodeFlow(s.GetPayloadParser(), pl)
-		if err != nil {
-			if !parserErrors.IsErrInvalidType(err) {
-				s.GetLogger().Debug("failed to decode payload", zap.ByteString("data", pl.Data), zap.Error(err))
-			}
-			continue
-		}
-
-		metrics.ProcessFlow(flow)
-		s.GetRingBuffer().Write(&v1.Event{
-			Timestamp: pl.Time,
-			Event:     flow,
-		})
-	}
-	close(s.GetStopped())
+	go s.GetGRPCServer().Start()
 }
 
 // startMirroringIPCache will obtain an initial IPCache snapshot from Cilium
@@ -218,286 +159,11 @@ func (s *ObserverServer) getLogRecordNotifyChannel() chan<- monitor.LogRecordNot
 	return s.logRecord
 }
 
-// GetEventsChannel returns the event channel to receive pb.Payload events.
-func (s *ObserverServer) GetEventsChannel() chan *pb.Payload {
-	return s.events
-}
-
 // getEndpointEventsChannel returns a channel that should be used to send
 // AgentNotifyEndpoint* events when an endpoint is added, deleted or updated
 // in Cilium.
 func (s *ObserverServer) getEndpointEventsChannel() chan<- monitorAPI.AgentNotify {
 	return s.endpointEvents
-}
-
-// GetRingBuffer implements Observer.GetRingBuffer.
-func (s *ObserverServer) GetRingBuffer() *container.Ring {
-	return s.ring
-}
-
-// GetLogger implements Observer.GetLogger.
-func (s *ObserverServer) GetLogger() *zap.Logger {
-	return s.log
-}
-
-// GetStopped implements Observer.GetStopped.
-func (s *ObserverServer) GetStopped() chan struct{} {
-	return s.stopped
-}
-
-// GetPayloadParser implements Observer.GetPayloadParser.
-func (s *ObserverServer) GetPayloadParser() *parser.Parser {
-	return s.payloadParser
-}
-
-func decodeFlow(payloadParser *parser.Parser, pl *pb.Payload) (*pb.Flow, error) {
-	// TODO: Pool these instead of allocating new flows each time.
-	f := &pb.Flow{}
-	err := payloadParser.Decode(pl, f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f, nil
-}
-
-// ServerStatus should have a comment, apparently. It returns the server status.
-func (s *ObserverServer) ServerStatus(
-	ctx context.Context, req *observer.ServerStatusRequest,
-) (*observer.ServerStatusResponse, error) {
-	return getServerStatusFromObserver(s)
-}
-
-func getServerStatusFromObserver(obs Observer) (*observer.ServerStatusResponse, error) {
-	res := &observer.ServerStatusResponse{
-		MaxFlows: obs.GetRingBuffer().Cap(),
-		NumFlows: obs.GetRingBuffer().Len(),
-	}
-	return res, nil
-}
-
-func logFilters(filters []*pb.FlowFilter) string {
-	var s []string
-	for _, f := range filters {
-		s = append(s, f.String())
-	}
-	return "{" + strings.Join(s, ",") + "}"
-}
-
-// GetFlows implements the proto method for client requests.
-func (s *ObserverServer) GetFlows(
-	req *observer.GetFlowsRequest,
-	server observer.Observer_GetFlowsServer,
-) (err error) {
-	return getFlows(req, server, s)
-}
-
-func getFlows(
-	req *observer.GetFlowsRequest,
-	server observer.Observer_GetFlowsServer,
-	obs Observer,
-) (err error) {
-	start := time.Now()
-	log := obs.GetLogger()
-	ring := obs.GetRingBuffer()
-
-	i := uint64(0)
-	defer func() {
-		log.Debug(
-			"GetFlows finished",
-			zap.Uint64("number_of_flows", i),
-			zap.Uint64("buffer_size", ring.Cap()),
-			zap.String("whitelist", logFilters(req.Whitelist)),
-			zap.String("blacklist", logFilters(req.Blacklist)),
-			zap.Duration("took", time.Now().Sub(start)),
-		)
-	}()
-
-	ringReader, err := newRingReader(server.Context(), ring, req)
-	if err != nil {
-		if err == io.EOF {
-			return nil
-		}
-		return err
-	}
-	flowsReader, err := newFlowsReader(ringReader, req, log)
-	if err != nil {
-		return err
-	}
-
-	for ; ; i++ {
-		flow, err := flowsReader.Next(server.Context())
-		if err != nil {
-			if err == io.EOF {
-				return nil
-			}
-			return err
-		}
-		err = server.Send(&observer.GetFlowsResponse{
-			ResponseTypes: &observer.GetFlowsResponse_Flow{
-				Flow: flow,
-			},
-		})
-		if err != nil {
-			return err
-		}
-	}
-}
-
-// flowsReader reads flows using a RingReader. It applies the flow request
-// criterias (blacklist, whitelist, follow, ...) before returning flows.
-type flowsReader struct {
-	ringReader           *container.RingReader
-	whitelist, blacklist filters.FilterFuncs
-	maxFlows             uint64
-	follow, timeRange    bool
-	flowsCount           uint64
-	start, end           time.Time
-}
-
-// newFlowsReader creates a new flowsReader that uses the given RingReader to
-// read through the ring buffer. Only flows that match the request criterias
-// are returned.
-func newFlowsReader(r *container.RingReader, req *observer.GetFlowsRequest, log *zap.Logger) (*flowsReader, error) {
-	whitelist, err := filters.BuildFilterList(req.Whitelist)
-	if err != nil {
-		return nil, err
-	}
-	blacklist, err := filters.BuildFilterList(req.Blacklist)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Debug("creating a new flowsReader",
-		zap.Any("req", req),
-		zap.Any("whitelist", whitelist),
-		zap.Any("blacklist", blacklist),
-	)
-
-	reader := &flowsReader{
-		ringReader: r,
-		whitelist:  whitelist,
-		blacklist:  blacklist,
-		maxFlows:   req.Number,
-		follow:     req.Follow,
-		timeRange:  !req.Follow && req.Number == 0,
-	}
-	if reader.timeRange { // apply time range filtering
-		reader.start, err = types.TimestampFromProto(req.GetSince())
-		if err != nil {
-			return nil, err
-		}
-		reader.end, err = getUntil(req, types.TimestampNow())
-		if err != nil {
-			return nil, err
-		}
-	}
-	return reader, nil
-}
-
-// Next returns the next flow that matches the request criterias.
-func (r *flowsReader) Next(ctx context.Context) (*pb.Flow, error) {
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-		if r.maxFlows > 0 && !r.follow && (r.flowsCount >= r.maxFlows) {
-			return nil, io.EOF
-		}
-		e := r.ringReader.Next(ctx)
-		if e == nil {
-			// if the buffer is not full, we might receive nil values
-			// just keep reading then
-			continue
-		}
-		flow, ok := e.Event.(*pb.Flow)
-		if ok && filters.Apply(r.whitelist, r.blacklist, e) {
-			if r.timeRange {
-				ts, err := types.TimestampFromProto(e.GetFlow().GetTime())
-				if err != nil {
-					return nil, err
-				}
-				if ts.After(r.end) {
-					return nil, io.EOF
-				}
-				if ts.Before(r.start) {
-					continue
-				}
-			}
-			r.flowsCount++
-			return flow, nil
-		}
-	}
-}
-
-func getUntil(req *observer.GetFlowsRequest, defaultTime *types.Timestamp) (time.Time, error) {
-	until := req.GetUntil()
-	if until == nil {
-		until = defaultTime
-	}
-	return types.TimestampFromProto(until)
-}
-
-// newRingReader creates a new RingReader that starts at the correct ring
-// offset to match the flow request.
-func newRingReader(ctx context.Context, ring *container.Ring, req *observer.GetFlowsRequest) (*container.RingReader, error) {
-	if req.Follow && req.Number == 0 { // no need to rewind
-		return container.NewRingReader(ring, ring.LastWriteParallel()), nil
-	}
-
-	var err error
-	var start time.Time
-	since := req.GetSince()
-	if since != nil {
-		start, err = types.TimestampFromProto(since)
-		if err != nil {
-			return nil, err
-		}
-	}
-	whitelist, err := filters.BuildFilterList(req.Whitelist)
-	if err != nil {
-		return nil, err
-	}
-	blacklist, err := filters.BuildFilterList(req.Blacklist)
-	if err != nil {
-		return nil, err
-	}
-
-	idx := ring.LastWriteParallel()
-	reader := container.NewRingReader(ring, idx)
-
-	var flowsCount uint64
-	// We need to find out what the right index is; that is the index with the
-	// oldest entry that is within time range boundaries (if any is defined)
-	// or until we find enough events.
-	// In order to avoid buffering events, we have to rewind first to find the
-	// correct index, then create a new reader that starts from there
-	for i := ring.Len(); i > 0; i, idx = i-1, idx-1 {
-		e := reader.Previous(ctx)
-		if e == nil {
-			continue
-		}
-		_, ok := e.Event.(*pb.Flow)
-		if !ok || !filters.Apply(whitelist, blacklist, e) {
-			continue
-		}
-		flowsCount++
-		if since != nil {
-			ts, err := types.TimestampFromProto(e.GetFlow().GetTime())
-			if err != nil {
-				return nil, err
-			}
-			if ts.Before(start) {
-				idx++ // we went backward 1 too far
-				break
-			}
-		} else if flowsCount == req.Number {
-			break // we went backward far enough
-		}
-	}
-	return container.NewRingReader(ring, idx), nil
 }
 
 // HandleMonitorSocket connects to the monitor socket and consumes monitor events.
@@ -568,7 +234,7 @@ func getMonitorParser(conn net.Conn, version listener.Version, nodeName string) 
 // It closes conn on return, and returns on error, including io.EOF
 func (s *ObserverServer) consumeMonitorEvents(conn net.Conn, version listener.Version, nodeName string) error {
 	defer conn.Close()
-	ch := s.GetEventsChannel()
+	ch := s.GetGRPCServer().GetEventsChannel()
 	endpointEvents := s.getEndpointEventsChannel()
 
 	dnsAdd := s.getLogRecordNotifyChannel()
@@ -652,4 +318,9 @@ func openMonitorSock() (conn net.Conn, version listener.Version, err error) {
 	errors = append(errors, defaults.MonitorSockPath1_2+": "+err.Error())
 
 	return nil, listener.VersionUnsupported, fmt.Errorf("cannot find or open a supported node-monitor serverSocketPath. %s", strings.Join(errors, ","))
+}
+
+// GetGRPCServer returns the GRPCServer embedded in this ObserverServer.
+func (s *ObserverServer) GetGRPCServer() GRPCServer {
+	return s.grpcServer
 }

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -66,6 +66,7 @@ func TestObserverServer_syncServiceCache(t *testing.T) {
 		ciliumClient: fakeClient,
 		serviceCache: svcc,
 		log:          zap.L(),
+		grpcServer:   getNoopGRPCServer(),
 	}
 
 	serviceCacheEvents := make(chan monitorAPI.AgentNotify, 100)


### PR DESCRIPTION
Use LocalObserverServer in ObserverServer instead of duplicating the
same code, and move the gRPC server code to LocalObserverServer. Define
an interface GRPCServer so that we can use different implementation for
unit tests etc..

With this change, there is a clear split between LocalObserverServer
and ObserverServer. LocalObserverServer is responsible for maintaining
the ring buffer and implementing gRPC API, while ObserverServer is
responsible for consuming monitor events and syncing Cilium state.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>