### PR TITLE
fqdncache: remove unnecessary nil check

### DIFF
--- a/pkg/fqdncache/fqdncache.go
+++ b/pkg/fqdncache/fqdncache.go
@@ -104,9 +104,7 @@ func (f *FQDNCache) InitializeFrom(entries []*models.DNSLookup) {
 
 	for _, entry := range entries {
 		ep := endpoints.createOrGetEndpoint(uint64(entry.EndpointID))
-		if entry != nil {
-			ep.insertDNSLookup(entry)
-		}
+		ep.insertDNSLookup(entry)
 	}
 
 	// replace existing map


### PR DESCRIPTION
(*endpoint).insertDNSLookup already checks for the passed entry being
nil, so the nil check before the call can be omitted.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>