### PR TITLE
refactor: Move endpointsHandler to pkg/api/v1/entpoints.go

### DIFF
--- a/pkg/api/v1/endpoint.go
+++ b/pkg/api/v1/endpoint.go
@@ -19,6 +19,17 @@ import (
 	"time"
 )
 
+// EndpointsHandler defines an interface for interacting with Cilium endpoints.
+type EndpointsHandler interface {
+	SyncEndpoints([]*Endpoint)
+	UpdateEndpoint(*Endpoint)
+	MarkDeleted(*Endpoint)
+	FindEPs(epID uint64, ns, pod string) []Endpoint
+	GetEndpoint(ip net.IP) (endpoint *Endpoint, ok bool)
+	GarbageCollect()
+	GetEndpointByContainerID(id string) (*Endpoint, bool)
+}
+
 // EqualsByID compares if the receiver's endpoint has the same ID, PodName and
 // PodNamespace.
 func (e *Endpoint) EqualsByID(o *Endpoint) bool {

--- a/pkg/server/endpoint_test.go
+++ b/pkg/server/endpoint_test.go
@@ -99,12 +99,13 @@ var fakeDummyCiliumClient = &fakeCiliumClient{
 }
 
 type fakeEndpointsHandler struct {
-	fakeSyncEndpoints  func([]*v1.Endpoint)
-	fakeUpdateEndpoint func(*v1.Endpoint)
-	fakeMarkDeleted    func(*v1.Endpoint)
-	fakeFindEPs        func(epID uint64, ns, pod string) []v1.Endpoint
-	fakeGetEndpoint    func(ip net.IP) (endpoint *v1.Endpoint, ok bool)
-	fakeGarbageCollect func()
+	fakeSyncEndpoints            func([]*v1.Endpoint)
+	fakeUpdateEndpoint           func(*v1.Endpoint)
+	fakeMarkDeleted              func(*v1.Endpoint)
+	fakeFindEPs                  func(epID uint64, ns, pod string) []v1.Endpoint
+	fakeGetEndpoint              func(ip net.IP) (endpoint *v1.Endpoint, ok bool)
+	fakeGarbageCollect           func()
+	fakeGetEndpointByContainerID func(id string) (endpoint *v1.Endpoint, ok bool)
 }
 
 func (f *fakeEndpointsHandler) SyncEndpoints(eps []*v1.Endpoint) {
@@ -143,6 +144,13 @@ func (f *fakeEndpointsHandler) GetEndpoint(ip net.IP) (ep *v1.Endpoint, ok bool)
 		return f.fakeGetEndpoint(ip)
 	}
 	panic("GetEndpoint(ip net.IP) (ep *v1.Endpoint, ok bool) should not have been called since it was not defined")
+}
+
+func (f *fakeEndpointsHandler) GetEndpointByContainerID(id string) (ep *v1.Endpoint, ok bool) {
+	if f.fakeGetEndpointByContainerID != nil {
+		return f.fakeGetEndpointByContainerID(id)
+	}
+	panic("GetEndpointByContainerID(id string) (ep *v1.Endpoint, ok bool) should not have been called since it was not defined")
 }
 
 func (f *fakeEndpointsHandler) GarbageCollect() {

--- a/pkg/server/observer.go
+++ b/pkg/server/observer.go
@@ -49,15 +49,6 @@ type ciliumClient interface {
 	GetServiceCache() ([]*models.Service, error)
 }
 
-type endpointsHandler interface {
-	SyncEndpoints([]*v1.Endpoint)
-	UpdateEndpoint(*v1.Endpoint)
-	MarkDeleted(*v1.Endpoint)
-	FindEPs(epID uint64, ns, pod string) []v1.Endpoint
-	GetEndpoint(ip net.IP) (endpoint *v1.Endpoint, ok bool)
-	GarbageCollect()
-}
-
 type fqdnCache interface {
 	InitializeFrom(entries []*models.DNSLookup)
 	AddDNSLookup(epID uint64, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32)
@@ -74,7 +65,7 @@ type ObserverServer struct {
 
 	// endpoints contains a slice of all endpoints running the node where
 	// hubble is running.
-	endpoints endpointsHandler
+	endpoints v1.EndpointsHandler
 
 	// fqdnCache contains the responses of all intercepted DNS lookups
 	// performed by local endpoints
@@ -100,7 +91,7 @@ type ObserverServer struct {
 // received.
 func NewServer(
 	ciliumClient ciliumClient,
-	endpoints endpointsHandler,
+	endpoints v1.EndpointsHandler,
 	ipCache *ipcache.IPCache,
 	fqdnCache fqdnCache,
 	serviceCache *servicecache.ServiceCache,


### PR DESCRIPTION
Move the endpointsHandler interface definition to pkg/api/v1/entpoints.go.
It seems like a natual place to define the interface since this is where
the Endpoint struct implements all the interface methods.

This patch also adds GetEndpointByContainerID method to the interface.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>