### PR TITLE
refactor: Move fake{CiliumClient,EndpointsHandler} to testutils

### DIFF
--- a/pkg/server/ipcache_test.go
+++ b/pkg/server/ipcache_test.go
@@ -39,8 +39,8 @@ func TestObserverServer_syncIPCache(t *testing.T) {
 	cidr4444 := "4.4.4.4/32"
 
 	ipc := ipcache.New()
-	fakeClient := &fakeCiliumClient{
-		fakeGetIPCache: func() ([]*models.IPListEntry, error) {
+	fakeClient := &testutils.FakeCiliumClient{
+		FakeGetIPCache: func() ([]*models.IPListEntry, error) {
 			id100 := int64(100)
 
 			return []*models.IPListEntry{
@@ -149,8 +149,8 @@ func TestLegacyPodGetter_GetPodNameOf(t *testing.T) {
 						return ipcache.IPIdentity{Namespace: "default", PodName: "xwing"}, true
 					},
 				},
-				EndpointGetter: &fakeEndpointsHandler{
-					fakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
+				EndpointGetter: &testutils.FakeEndpointsHandler{
+					FakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
 						return nil, false
 					},
 				},
@@ -167,8 +167,8 @@ func TestLegacyPodGetter_GetPodNameOf(t *testing.T) {
 			name: "available in endpoints",
 			fields: fields{
 				IPGetter: &testutils.NoopIPGetter,
-				EndpointGetter: &fakeEndpointsHandler{
-					fakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
+				EndpointGetter: &testutils.FakeEndpointsHandler{
+					FakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
 						return &v1.Endpoint{
 							ID:           16,
 							IPv4:         net.ParseIP("1.1.1.15"),
@@ -194,8 +194,8 @@ func TestLegacyPodGetter_GetPodNameOf(t *testing.T) {
 						return ipcache.IPIdentity{Namespace: "default", PodName: "xwing"}, true
 					},
 				},
-				EndpointGetter: &fakeEndpointsHandler{
-					fakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
+				EndpointGetter: &testutils.FakeEndpointsHandler{
+					FakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
 						return &v1.Endpoint{
 							ID:           16,
 							IPv4:         net.ParseIP("1.1.1.15"),

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -18,6 +18,8 @@ import (
 	"net"
 	"testing"
 
+	"github.com/cilium/hubble/pkg/testutils"
+
 	"github.com/cilium/cilium/api/v1/models"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	pb "github.com/cilium/hubble/api/v1/flow"
@@ -30,8 +32,8 @@ import (
 
 func TestObserverServer_syncServiceCache(t *testing.T) {
 	svcc := servicecache.New()
-	fakeClient := &fakeCiliumClient{
-		fakeGetServiceCache: func() ([]*models.Service, error) {
+	fakeClient := &testutils.FakeCiliumClient{
+		FakeGetServiceCache: func() ([]*models.Service, error) {
 			return []*models.Service{
 				{
 					Spec: &models.ServiceSpec{

--- a/pkg/testutils/fake.go
+++ b/pkg/testutils/fake.go
@@ -123,3 +123,132 @@ var NoopIdentityGetter = FakeIdentityGetter{
 		return &models.Identity{}, nil
 	},
 }
+
+// FakeEndpointsHandler implements EndpointsHandler interface for unit testing.
+type FakeEndpointsHandler struct {
+	FakeSyncEndpoints            func([]*v1.Endpoint)
+	FakeUpdateEndpoint           func(*v1.Endpoint)
+	FakeMarkDeleted              func(*v1.Endpoint)
+	FakeFindEPs                  func(epID uint64, ns, pod string) []v1.Endpoint
+	FakeGetEndpoint              func(ip net.IP) (endpoint *v1.Endpoint, ok bool)
+	FakeGarbageCollect           func()
+	FakeGetEndpointByContainerID func(id string) (endpoint *v1.Endpoint, ok bool)
+}
+
+// SyncEndpoints calls FakeSyncEndpoints.
+func (f *FakeEndpointsHandler) SyncEndpoints(eps []*v1.Endpoint) {
+	if f.FakeSyncEndpoints != nil {
+		f.FakeSyncEndpoints(eps)
+		return
+	}
+	panic("SyncEndpoints([]*v1.Endpoint) should not have been called since it was not defined")
+}
+
+// UpdateEndpoint calls FakeUpdateEndpoint.
+func (f *FakeEndpointsHandler) UpdateEndpoint(ep *v1.Endpoint) {
+	if f.FakeUpdateEndpoint != nil {
+		f.FakeUpdateEndpoint(ep)
+		return
+	}
+	panic("UpdateEndpoint(*v1.Endpoint) should not have been called since it was not defined")
+}
+
+// MarkDeleted calls FakeMarkDeleted.
+func (f *FakeEndpointsHandler) MarkDeleted(ep *v1.Endpoint) {
+	if f.FakeMarkDeleted != nil {
+		f.FakeMarkDeleted(ep)
+		return
+	}
+	panic("MarkDeleted(ep *v1.Endpoint) should not have been called since it was not defined")
+}
+
+// FindEPs calls FakeFindEPs.
+func (f *FakeEndpointsHandler) FindEPs(epID uint64, ns, pod string) []v1.Endpoint {
+	if f.FakeFindEPs != nil {
+		return f.FakeFindEPs(epID, ns, pod)
+	}
+	panic(" FindEPs(epID uint64, ns, pod string) should not have been called since it was not defined")
+}
+
+// GetEndpoint calls FakeGetEndpoint.
+func (f *FakeEndpointsHandler) GetEndpoint(ip net.IP) (ep *v1.Endpoint, ok bool) {
+	if f.FakeGetEndpoint != nil {
+		return f.FakeGetEndpoint(ip)
+	}
+	panic("GetEndpoint(ip net.IP) (ep *v1.Endpoint, ok bool) should not have been called since it was not defined")
+}
+
+// GetEndpointByContainerID calls FakeGetEndpointByContainerID.
+func (f *FakeEndpointsHandler) GetEndpointByContainerID(id string) (ep *v1.Endpoint, ok bool) {
+	if f.FakeGetEndpointByContainerID != nil {
+		return f.FakeGetEndpointByContainerID(id)
+	}
+	panic("GetEndpointByContainerID(id string) (ep *v1.Endpoint, ok bool) should not have been called since it was not defined")
+}
+
+// GarbageCollect calls FakeGarbageCollect.
+func (f *FakeEndpointsHandler) GarbageCollect() {
+	if f.FakeGarbageCollect != nil {
+		f.FakeGarbageCollect()
+		return
+	}
+	panic("GarbageCollect() should not have been called since it was not defined")
+}
+
+// FakeCiliumClient implements CliliumClient interface for unit testing.
+type FakeCiliumClient struct {
+	FakeEndpointList    func() ([]*models.Endpoint, error)
+	FakeGetEndpoint     func(uint64) (*models.Endpoint, error)
+	FakeGetIdentity     func(uint64) (*models.Identity, error)
+	FakeGetFqdnCache    func() ([]*models.DNSLookup, error)
+	FakeGetIPCache      func() ([]*models.IPListEntry, error)
+	FakeGetServiceCache func() ([]*models.Service, error)
+}
+
+// EndpointList calls FakeEndpointList.
+func (c *FakeCiliumClient) EndpointList() ([]*models.Endpoint, error) {
+	if c.FakeEndpointList != nil {
+		return c.FakeEndpointList()
+	}
+	panic("EndpointList() should not have been called since it was not defined")
+}
+
+// GetEndpoint calls FakeGetEndpoint.
+func (c *FakeCiliumClient) GetEndpoint(id uint64) (*models.Endpoint, error) {
+	if c.FakeGetEndpoint != nil {
+		return c.FakeGetEndpoint(id)
+	}
+	panic("GetEndpoint(uint64) should not have been called since it was not defined")
+}
+
+// GetIdentity calls FakeGetIdentity.
+func (c *FakeCiliumClient) GetIdentity(id uint64) (*models.Identity, error) {
+	if c.FakeGetIdentity != nil {
+		return c.FakeGetIdentity(id)
+	}
+	panic("GetIdentity(uint64) should not have been called since it was not defined")
+}
+
+// GetFqdnCache calls FakeGetFqdnCache.
+func (c *FakeCiliumClient) GetFqdnCache() ([]*models.DNSLookup, error) {
+	if c.FakeGetFqdnCache != nil {
+		return c.FakeGetFqdnCache()
+	}
+	panic("GetFqdnCache() should not have been called since it was not defined")
+}
+
+// GetIPCache calls FakeGetIPCache.
+func (c *FakeCiliumClient) GetIPCache() ([]*models.IPListEntry, error) {
+	if c.FakeGetIPCache != nil {
+		return c.FakeGetIPCache()
+	}
+	panic("GetIPCache() should not have been called since it was not defined")
+}
+
+// GetServiceCache calls FakeGetServiceCache.
+func (c *FakeCiliumClient) GetServiceCache() ([]*models.Service, error) {
+	if c.FakeGetServiceCache != nil {
+		return c.FakeGetServiceCache()
+	}
+	panic("GetServiceCache() should not have been called since it was not defined")
+}


### PR DESCRIPTION
Move fake{CiliumClient,EndpointsHandler} to fake.go to be consistent
with other fake implementations.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>