### PR TITLE
refactor: Move Cilium state caches to cilium package

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/hubble/api/v1/observer"
 	"github.com/cilium/hubble/pkg/api"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/hubble/pkg/cilium"
 	"github.com/cilium/hubble/pkg/cilium/client"
 	"github.com/cilium/hubble/pkg/fqdncache"
 	"github.com/cilium/hubble/pkg/ipcache"
@@ -82,7 +83,7 @@ func New(log *zap.Logger) *cobra.Command {
 			fqdnCache := fqdncache.New()
 			serviceCache := servicecache.New()
 			endpoints := v1.NewEndpoints()
-			podGetter := &server.LegacyPodGetter{
+			podGetter := &cilium.LegacyPodGetter{
 				PodGetter:      ipCache,
 				EndpointGetter: endpoints,
 			}

--- a/pkg/cilium/client/client.go
+++ b/pkg/cilium/client/client.go
@@ -24,6 +24,16 @@ import (
 	clientPkg "github.com/cilium/cilium/pkg/client"
 )
 
+// Client is the interface for Cilium API.
+type Client interface {
+	EndpointList() ([]*models.Endpoint, error)
+	GetEndpoint(id uint64) (*models.Endpoint, error)
+	GetIdentity(id uint64) (*models.Identity, error)
+	GetFqdnCache() ([]*models.DNSLookup, error)
+	GetIPCache() ([]*models.IPListEntry, error)
+	GetServiceCache() ([]*models.Service, error)
+}
+
 // Cilium is an abstraction to communicate with the cilium-agent.
 type Cilium struct {
 	*clientPkg.Client

--- a/pkg/cilium/dns_test.go
+++ b/pkg/cilium/dns_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package cilium
 
 import (
 	"net"
@@ -98,14 +98,13 @@ func TestObserverServer_consumeLogRecordNotifyChannel(t *testing.T) {
 		},
 	}
 
-	s := &ObserverServer{
-		fqdnCache:  fakeFQDNCache,
-		logRecord:  make(chan monitorAPI.LogRecordNotify, 1),
-		log:        zap.L(),
-		grpcServer: getNoopGRPCServer(),
+	c := &State{
+		fqdnCache: fakeFQDNCache,
+		logRecord: make(chan monitorAPI.LogRecordNotify, 1),
+		log:       zap.L(),
 	}
-	go s.consumeLogRecordNotifyChannel()
+	go c.consumeLogRecordNotifyChannel()
 
-	s.getLogRecordNotifyChannel() <- lr
+	c.GetLogRecordNotifyChannel() <- lr
 	wg.Wait()
 }

--- a/pkg/cilium/endpoint.go
+++ b/pkg/cilium/endpoint.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package cilium
 
 import (
 	"encoding/json"
@@ -34,7 +34,7 @@ var (
 )
 
 // syncEndpoints sync all endpoints of Cilium with the hubble.
-func (s *ObserverServer) syncEndpoints() {
+func (s *State) syncEndpoints() {
 	for {
 		eps, err := s.ciliumClient.EndpointList()
 		if err != nil {
@@ -67,7 +67,7 @@ func (s *ObserverServer) syncEndpoints() {
 	}
 }
 
-func (s *ObserverServer) consumeEndpointEvents() {
+func (s *State) consumeEndpointEvents() {
 	for an := range s.endpointEvents {
 		switch an.Type {
 		case monitorAPI.AgentNotifyEndpointCreated, monitorAPI.AgentNotifyEndpointRegenerateSuccess:

--- a/pkg/cilium/ipcache.go
+++ b/pkg/cilium/ipcache.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package cilium
 
 import (
 	"encoding/json"
@@ -59,7 +59,7 @@ func (l *LegacyPodGetter) GetIPIdentity(ip net.IP) (identity ipcache.IPIdentity,
 }
 
 // fetchIPCache copies over the IP cache from cilium agent
-func (s *ObserverServer) fetchIPCache() error {
+func (s *State) fetchIPCache() error {
 	entries, err := s.ciliumClient.GetIPCache()
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (s *ObserverServer) fetchIPCache() error {
 
 // processIPCacheEvent decodes and applies an IPCache update, returns true if
 // it was applied to the local IPCache mirror.
-func (s *ObserverServer) processIPCacheEvent(an monitorAPI.AgentNotify) bool {
+func (s *State) processIPCacheEvent(an monitorAPI.AgentNotify) bool {
 	n := monitorAPI.IPCacheNotification{}
 	err := json.Unmarshal([]byte(an.Text), &n)
 	if err != nil {
@@ -105,7 +105,7 @@ func (s *ObserverServer) processIPCacheEvent(an monitorAPI.AgentNotify) bool {
 
 // syncIPCache initializes the IPCache by fetching an initial version from
 // Cilium and then starts reading IPCacheNotification from the channel.
-func (s *ObserverServer) syncIPCache(ipcacheEvents <-chan monitorAPI.AgentNotify) {
+func (s *State) syncIPCache(ipcacheEvents <-chan monitorAPI.AgentNotify) {
 	for {
 		err := s.fetchIPCache()
 		if err != nil {

--- a/pkg/cilium/ipcache_test.go
+++ b/pkg/cilium/ipcache_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package cilium
 
 import (
 	"net"
@@ -56,11 +56,10 @@ func TestObserverServer_syncIPCache(t *testing.T) {
 		},
 	}
 
-	s := &ObserverServer{
+	c := &State{
 		ciliumClient: fakeClient,
 		ipcache:      ipc,
 		log:          zap.L(),
-		grpcServer:   getNoopGRPCServer(),
 	}
 
 	ipCacheEvents := make(chan monitorAPI.AgentNotify, 100)
@@ -97,7 +96,7 @@ func TestObserverServer_syncIPCache(t *testing.T) {
 	}()
 
 	// blocks until channel is closed
-	s.syncIPCache(ipCacheEvents)
+	c.syncIPCache(ipCacheEvents)
 	assert.Equal(t, 0, len(ipCacheEvents))
 
 	id100 := identity.NumericIdentity(100)

--- a/pkg/cilium/service.go
+++ b/pkg/cilium/service.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package cilium
 
 import (
 	"encoding/json"
@@ -29,7 +29,7 @@ const (
 
 // fetchServiceCache fetches the service cache from cilium and initializes the
 // local service cache.
-func (s *ObserverServer) fetchServiceCache() error {
+func (s *State) fetchServiceCache() error {
 	entries, err := s.ciliumClient.GetServiceCache()
 	if err != nil {
 		return err
@@ -43,7 +43,7 @@ func (s *ObserverServer) fetchServiceCache() error {
 
 // processServiceEvent decodes and applies a service update. It returns true
 // when successful.
-func (s *ObserverServer) processServiceEvent(an monitorAPI.AgentNotify) bool {
+func (s *State) processServiceEvent(an monitorAPI.AgentNotify) bool {
 	switch an.Type {
 	case monitorAPI.AgentNotifyServiceUpserted:
 		n := monitorAPI.ServiceUpsertNotification{}
@@ -67,7 +67,7 @@ func (s *ObserverServer) processServiceEvent(an monitorAPI.AgentNotify) bool {
 	}
 }
 
-func (s *ObserverServer) syncServiceCache(serviceEvents <-chan monitorAPI.AgentNotify) {
+func (s *State) syncServiceCache(serviceEvents <-chan monitorAPI.AgentNotify) {
 	for err := s.fetchServiceCache(); err != nil; err = s.fetchServiceCache() {
 		s.log.Error("Failed to fetch service cache from Cilium", zap.Error(err))
 		time.Sleep(serviceCacheInitRetryInterval)

--- a/pkg/cilium/service_test.go
+++ b/pkg/cilium/service_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package cilium
 
 import (
 	"net"
@@ -64,11 +64,10 @@ func TestObserverServer_syncServiceCache(t *testing.T) {
 		},
 	}
 
-	s := &ObserverServer{
+	c := &State{
 		ciliumClient: fakeClient,
 		serviceCache: svcc,
 		log:          zap.L(),
-		grpcServer:   getNoopGRPCServer(),
 	}
 
 	serviceCacheEvents := make(chan monitorAPI.AgentNotify, 100)
@@ -126,7 +125,7 @@ func TestObserverServer_syncServiceCache(t *testing.T) {
 	}()
 
 	// blocks until channel is closed
-	s.syncServiceCache(serviceCacheEvents)
+	c.syncServiceCache(serviceCacheEvents)
 	assert.Equal(t, 0, len(serviceCacheEvents))
 
 	tests := []struct {

--- a/pkg/cilium/state.go
+++ b/pkg/cilium/state.go
@@ -1,0 +1,118 @@
+// Copyright 2019-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"github.com/cilium/cilium/pkg/monitor"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/hubble/pkg/cilium/client"
+	"github.com/cilium/hubble/pkg/ipcache"
+	"github.com/cilium/hubble/pkg/servicecache"
+	"go.uber.org/zap"
+)
+
+// State contains various caches for Cilium state and channels to notify
+// state changes.
+type State struct {
+	// Client will connect to Cilium to pool cilium endpoint information
+	ciliumClient client.Client
+
+	// endpoints contains a slice of all endpoints running the node where
+	// hubble is running.
+	endpoints v1.EndpointsHandler
+
+	// FqdnCache contains the responses of all intercepted DNS lookups
+	// performed by local endpoints
+	fqdnCache FqdnCache
+
+	// ipcache is a mirror of Cilium's IPCache
+	ipcache *ipcache.IPCache
+
+	// serviceCache is a cache that contains information about services.
+	serviceCache *servicecache.ServiceCache
+
+	// logRecord is a channel used to exchange L7 DNS requests seens from the
+	// monitor
+	logRecord chan monitor.LogRecordNotify
+	log       *zap.Logger
+
+	// epAdd is a channel used to exchange endpoint events from Cilium
+	endpointEvents chan monitorAPI.AgentNotify
+}
+
+// NewCiliumState returns a pointer to an initialized State struct.
+func NewCiliumState(
+	ciliumClient client.Client,
+	endpoints v1.EndpointsHandler,
+	ipCache *ipcache.IPCache,
+	fqdnCache FqdnCache,
+	serviceCache *servicecache.ServiceCache,
+	logger *zap.Logger,
+) *State {
+	return &State{
+		ciliumClient: ciliumClient,
+		endpoints:    endpoints,
+		ipcache:      ipCache,
+		fqdnCache:    fqdnCache, serviceCache: serviceCache,
+		logRecord:      make(chan monitor.LogRecordNotify, 100),
+		endpointEvents: make(chan monitorAPI.AgentNotify, 100),
+		log:            logger,
+	}
+}
+
+// Start starts the server to handle the events sent to the events channel as
+// well as handle events to the EpAdd and EpDel channels.
+func (s *State) Start() {
+	go s.syncEndpoints()
+	go s.syncFQDNCache()
+	go s.consumeEndpointEvents()
+	go s.consumeLogRecordNotifyChannel()
+}
+
+// StartMirroringIPCache will obtain an initial IPCache snapshot from Cilium
+// and then start mirroring IPCache events based on IPCacheNotification sent
+// through the ipCacheEvents channels. Only messages of type
+// `AgentNotifyIPCacheUpserted` and `AgentNotifyIPCacheDeleted` should be sent
+// through that channel. This function assumes that the caller is already
+// connected to Cilium Monitor, i.e. no IPCacheNotification must be lost after
+// calling this method.
+func (s *State) StartMirroringIPCache(ipCacheEvents <-chan monitorAPI.AgentNotify) {
+	go s.syncIPCache(ipCacheEvents)
+}
+
+// StartMirroringServiceCache initially caches service information from Cilium
+// and then starts to mirror service information based on events that are sent
+// to the serviceEvents channel. Only messages of type
+// `AgentNotifyServiceUpserted` and `AgentNotifyServiceDeleted` should be sent
+// to this channel.  This function assumes that the caller is already connected
+// to Cilium Monitor, i.e. no Service notification must be lost after calling
+// this method.
+func (s *State) StartMirroringServiceCache(serviceEvents <-chan monitorAPI.AgentNotify) {
+	go s.syncServiceCache(serviceEvents)
+}
+
+// GetLogRecordNotifyChannel returns the event channel to receive
+// monitorAPI.LogRecordNotify events.
+func (s *State) GetLogRecordNotifyChannel() chan<- monitor.LogRecordNotify {
+	return s.logRecord
+}
+
+// GetEndpointEventsChannel returns a channel that should be used to send
+// AgentNotifyEndpoint* events when an endpoint is added, deleted or updated
+// in Cilium.
+func (s *State) GetEndpointEventsChannel() chan<- monitorAPI.AgentNotify {
+	return s.endpointEvents
+}

--- a/pkg/server/observer.go
+++ b/pkg/server/observer.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/monitor"
 	"github.com/cilium/cilium/pkg/monitor/agent/listener"
@@ -33,6 +32,8 @@ import (
 	pb "github.com/cilium/hubble/api/v1/flow"
 	"github.com/cilium/hubble/pkg/api"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/hubble/pkg/cilium"
+	"github.com/cilium/hubble/pkg/cilium/client"
 	"github.com/cilium/hubble/pkg/ipcache"
 	"github.com/cilium/hubble/pkg/parser"
 	"github.com/cilium/hubble/pkg/servicecache"
@@ -40,49 +41,12 @@ import (
 	"go.uber.org/zap"
 )
 
-type ciliumClient interface {
-	EndpointList() ([]*models.Endpoint, error)
-	GetEndpoint(id uint64) (*models.Endpoint, error)
-	GetIdentity(id uint64) (*models.Identity, error)
-	GetFqdnCache() ([]*models.DNSLookup, error)
-	GetIPCache() ([]*models.IPListEntry, error)
-	GetServiceCache() ([]*models.Service, error)
-}
-
-type fqdnCache interface {
-	InitializeFrom(entries []*models.DNSLookup)
-	AddDNSLookup(epID uint64, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32)
-	GetNamesOf(epID uint64, ip net.IP) []string
-}
-
 // ObserverServer is a server that can store events in memory
 type ObserverServer struct {
 	// grpcServer is responsible for caching events and serving gRPC requests.
 	grpcServer GRPCServer
 
-	// ciliumClient will connect to Cilium to pool cilium endpoint information
-	ciliumClient ciliumClient
-
-	// endpoints contains a slice of all endpoints running the node where
-	// hubble is running.
-	endpoints v1.EndpointsHandler
-
-	// fqdnCache contains the responses of all intercepted DNS lookups
-	// performed by local endpoints
-	fqdnCache fqdnCache
-
-	// ipcache is a mirror of Cilium's IPCache
-	ipcache *ipcache.IPCache
-
-	// serviceCache is a cache that contains information about services.
-	serviceCache *servicecache.ServiceCache
-
-	// epAdd is a channel used to exchange endpoint events from Cilium
-	endpointEvents chan monitorAPI.AgentNotify
-
-	// logRecord is a channel used to exchange L7 DNS requests seens from the
-	// monitor
-	logRecord chan monitor.LogRecordNotify
+	ciliumState *cilium.State
 
 	log *zap.Logger
 }
@@ -90,71 +54,28 @@ type ObserverServer struct {
 // NewServer returns a server that can store up to the given of maxFlows
 // received.
 func NewServer(
-	ciliumClient ciliumClient,
+	ciliumClient client.Client,
 	endpoints v1.EndpointsHandler,
 	ipCache *ipcache.IPCache,
-	fqdnCache fqdnCache,
+	fqdnCache cilium.FqdnCache,
 	serviceCache *servicecache.ServiceCache,
 	payloadParser *parser.Parser,
 	maxFlows int,
 	logger *zap.Logger,
 ) *ObserverServer {
+	ciliumState := cilium.NewCiliumState(ciliumClient, endpoints, ipCache, fqdnCache, serviceCache, logger)
 	return &ObserverServer{
-		log:            logger,
-		grpcServer:     NewLocalServer(payloadParser, maxFlows, logger),
-		ciliumClient:   ciliumClient,
-		endpoints:      endpoints,
-		ipcache:        ipCache,
-		fqdnCache:      fqdnCache,
-		serviceCache:   serviceCache,
-		endpointEvents: make(chan monitorAPI.AgentNotify, 100),
-		logRecord:      make(chan monitor.LogRecordNotify, 100),
+		log:         logger,
+		grpcServer:  NewLocalServer(payloadParser, maxFlows, logger),
+		ciliumState: ciliumState,
 	}
 }
 
 // Start starts the server to handle the events sent to the events channel as
 // well as handle events to the EpAdd and EpDel channels.
 func (s *ObserverServer) Start() {
-	go s.syncEndpoints()
-	go s.syncFQDNCache()
-	go s.consumeEndpointEvents()
-	go s.consumeLogRecordNotifyChannel()
+	go s.ciliumState.Start()
 	go s.GetGRPCServer().Start()
-}
-
-// startMirroringIPCache will obtain an initial IPCache snapshot from Cilium
-// and then start mirroring IPCache events based on IPCacheNotification sent
-// through the ipCacheEvents channels. Only messages of type
-// `AgentNotifyIPCacheUpserted` and `AgentNotifyIPCacheDeleted` should be sent
-// through that channel. This function assumes that the caller is already
-// connected to Cilium Monitor, i.e. no IPCacheNotification must be lost after
-// calling this method.
-func (s *ObserverServer) startMirroringIPCache(ipCacheEvents <-chan monitorAPI.AgentNotify) {
-	go s.syncIPCache(ipCacheEvents)
-}
-
-// startMirroringServiceCache initially caches service information from Cilium
-// and then starts to mirror service information based on events that are sent
-// to the serviceEvents channel. Only messages of type
-// `AgentNotifyServiceUpserted` and `AgentNotifyServiceDeleted` should be sent
-// to this channel.  This function assumes that the caller is already connected
-// to Cilium Monitor, i.e. no Service notification must be lost after calling
-// this method.
-func (s *ObserverServer) startMirroringServiceCache(serviceEvents <-chan monitorAPI.AgentNotify) {
-	go s.syncServiceCache(serviceEvents)
-}
-
-// getLogRecordNotifyChannel returns the event channel to receive
-// monitorAPI.LogRecordNotify events.
-func (s *ObserverServer) getLogRecordNotifyChannel() chan<- monitor.LogRecordNotify {
-	return s.logRecord
-}
-
-// getEndpointEventsChannel returns a channel that should be used to send
-// AgentNotifyEndpoint* events when an endpoint is added, deleted or updated
-// in Cilium.
-func (s *ObserverServer) getEndpointEventsChannel() chan<- monitorAPI.AgentNotify {
-	return s.endpointEvents
 }
 
 // HandleMonitorSocket connects to the monitor socket and consumes monitor events.
@@ -226,15 +147,15 @@ func getMonitorParser(conn net.Conn, version listener.Version, nodeName string) 
 func (s *ObserverServer) consumeMonitorEvents(conn net.Conn, version listener.Version, nodeName string) error {
 	defer conn.Close()
 	ch := s.GetGRPCServer().GetEventsChannel()
-	endpointEvents := s.getEndpointEventsChannel()
+	endpointEvents := s.ciliumState.GetEndpointEventsChannel()
 
-	dnsAdd := s.getLogRecordNotifyChannel()
+	dnsAdd := s.ciliumState.GetLogRecordNotifyChannel()
 
 	ipCacheEvents := make(chan monitorAPI.AgentNotify, 100)
-	s.startMirroringIPCache(ipCacheEvents)
+	s.ciliumState.StartMirroringIPCache(ipCacheEvents)
 
 	serviceEvents := make(chan monitorAPI.AgentNotify, 100)
-	s.startMirroringServiceCache(serviceEvents)
+	s.ciliumState.StartMirroringServiceCache(serviceEvents)
 
 	getParsedPayload, err := getMonitorParser(conn, version, nodeName)
 	if err != nil {

--- a/pkg/server/observer_test.go
+++ b/pkg/server/observer_test.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	pb "github.com/cilium/hubble/api/v1/flow"
@@ -36,6 +37,21 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 )
+
+var fakeDummyCiliumClient = &testutils.FakeCiliumClient{
+	FakeEndpointList: func() (endpoints []*models.Endpoint, e error) {
+		return nil, nil
+	},
+	FakeGetEndpoint: func(u uint64) (endpoint *models.Endpoint, e error) {
+		return nil, nil
+	},
+	FakeGetIdentity: func(u uint64) (endpoint *models.Identity, e error) {
+		return &models.Identity{}, nil
+	},
+	FakeGetFqdnCache: func() ([]*models.DNSLookup, error) {
+		return nil, nil
+	},
+}
 
 var allTypes = []*pb.EventTypeFilter{
 	{Type: 1},


### PR DESCRIPTION
Following up on https://github.com/cilium/hubble/pull/69, introduce
cilium.State struct that encapsulates caches and channels for managing
Cilium state. After this refactoring, there are 3 components to hubble
server:

- CiliumState: Maintains various states from Cilium.
- GRPCServer: Keeps recent flows in a buffer and exposes a gRPC endpoint
  for serving flows.
- ObserverServer: Connects to Cilium's monitor socket and sends monitor
  events to GRPCServer and CiliumState.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>