### PR TITLE
endpoint: Add a function to lookup by pod name

### DIFF
--- a/pkg/api/v1/endpoint.go
+++ b/pkg/api/v1/endpoint.go
@@ -28,6 +28,7 @@ type EndpointsHandler interface {
 	GetEndpoint(ip net.IP) (endpoint *Endpoint, ok bool)
 	GarbageCollect()
 	GetEndpointByContainerID(id string) (*Endpoint, bool)
+	GetEndpointByPodName(namespace string, name string) (*Endpoint, bool)
 }
 
 // EqualsByID compares if the receiver's endpoint has the same ID, PodName and
@@ -246,6 +247,21 @@ func (es *Endpoints) GetEndpointByContainerID(id string) (*Endpoint, bool) {
 			if id == containerID {
 				return ep.DeepCopy(), true
 			}
+		}
+	}
+	return nil, false
+}
+
+// GetEndpointByPodName returns the endpoint with the given pod name.
+func (es *Endpoints) GetEndpointByPodName(namespace string, name string) (*Endpoint, bool) {
+	es.mutex.RLock()
+	defer es.mutex.RUnlock()
+	for _, ep := range es.eps {
+		if ep.Deleted != nil {
+			continue
+		}
+		if ep.PodNamespace == namespace && ep.PodName == name {
+			return ep.DeepCopy(), true
 		}
 	}
 	return nil, false

--- a/pkg/testutils/fake.go
+++ b/pkg/testutils/fake.go
@@ -133,6 +133,7 @@ type FakeEndpointsHandler struct {
 	FakeGetEndpoint              func(ip net.IP) (endpoint *v1.Endpoint, ok bool)
 	FakeGarbageCollect           func()
 	FakeGetEndpointByContainerID func(id string) (endpoint *v1.Endpoint, ok bool)
+	FakeGetEndpointByPodName     func(namespace string, name string) (*v1.Endpoint, bool)
 }
 
 // SyncEndpoints calls FakeSyncEndpoints.
@@ -184,6 +185,14 @@ func (f *FakeEndpointsHandler) GetEndpointByContainerID(id string) (ep *v1.Endpo
 		return f.FakeGetEndpointByContainerID(id)
 	}
 	panic("GetEndpointByContainerID(id string) (ep *v1.Endpoint, ok bool) should not have been called since it was not defined")
+}
+
+// GetEndpointByPodName calls FakeGetEndpointByPodName.
+func (f *FakeEndpointsHandler) GetEndpointByPodName(namespace string, name string) (ep *v1.Endpoint, ok bool) {
+	if f.FakeGetEndpointByPodName != nil {
+		return f.FakeGetEndpointByPodName(namespace, name)
+	}
+	panic("GetEndpointByPodName(namespace string, name string) (ep *v1.Endpoint, ok bool) should not have been called since it was not defined")
 }
 
 // GarbageCollect calls FakeGarbageCollect.


### PR DESCRIPTION
Similar to 2d3e85e, but this function looks up cilium endpoint by
pod name instead of container ID.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>