### PR TITLE
serve: Remove printf

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -106,7 +106,6 @@ func New(log *zap.Logger) *cobra.Command {
 			if err != nil {
 				log.Fatal("", zap.Error(err))
 			}
-			fmt.Printf("Press Ctrl-C to quit\n")
 			if err := s.HandleMonitorSocket(nodeName); err != nil {
 				log.Fatal("HandleMonitorSocket failed", zap.Error(err))
 			}


### PR DESCRIPTION
Hubble server typically runs inside a container, so this message is
not very useful.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>