### PR TITLE
Fix misplaced 'resources' field.

### DIFF
--- a/install/kubernetes/hubble/Chart.yaml
+++ b/install/kubernetes/hubble/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hubble
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for the Hubble server

--- a/install/kubernetes/hubble/templates/daemonset.yaml
+++ b/install/kubernetes/hubble/templates/daemonset.yaml
@@ -99,6 +99,8 @@ spec:
           periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 5
+        resources:
+          {{- toYaml .Values.resources | trim | nindent 10 }}
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
@@ -108,8 +110,6 @@ spec:
       terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
-      resources:
-        {{- toYaml .Values.resources | trim | nindent 8 }}
       volumes:
       - hostPath:
           # We need to access Cilium's monitor socket


### PR DESCRIPTION
In #105 I had accidentally misplaced the `resources` field for the Hubble daemonset (apologies for that). This PR fixes that issue.