### PR TITLE
api: Fix broken trailing space in make v4.3

### DIFF
--- a/api/v1/Makefile
+++ b/api/v1/Makefile
@@ -23,8 +23,9 @@ RAW_GO_MAPPINGS += observer/observer.proto=github.com/cilium/hubble/api/v1/obser
 
 # Add mapping separators and remove the trailing slash
 # but first create "/ " and ",M"
-file_sep := /
-file_sep +=
+null :=
+space := ${null} ${null}
+file_sep := /${space}
 map_sep := ,M
 GO_MAPPINGS := $(patsubst %/,%,$(map_sep)$(subst $(file_sep),$(map_sep),$(RAW_GO_MAPPINGS)))
 


### PR DESCRIPTION
GNU make v4.3 breaks our trailing space hack. This commit inserts the trailing space
in the api/v1/Makefile by introducing a `$space` variable containing a
single space.

Without this fix, generating the gRPC API fails with the following
error:

```console
$ make -C api/v1
[...]
google,Mprotobuf,Mduration.proto=github.com,Mgogo,Mprotobuf,Mtypes,M: No such file or directory
make: *** [Makefile:32: flow/flow.pb.go] Error 1
```

See also https://github.com/cilium/cilium/pull/10173

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>