### PR TITLE
logging: Use logrus.Entry

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cilium/hubble/pkg/cilium/client"
 	"github.com/cilium/hubble/pkg/fqdncache"
 	"github.com/cilium/hubble/pkg/ipcache"
-	"github.com/cilium/hubble/pkg/logger"
 	"github.com/cilium/hubble/pkg/metrics"
 	metricsAPI "github.com/cilium/hubble/pkg/metrics/api"
 	"github.com/cilium/hubble/pkg/parser"
@@ -47,7 +46,7 @@ import (
 )
 
 // New ...
-func New(log *logrus.Logger) *cobra.Command {
+func New(log *logrus.Entry) *cobra.Command {
 	serverCmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Start gRPC server",
@@ -99,7 +98,7 @@ func New(log *logrus.Logger) *cobra.Command {
 				serviceCache,
 				payloadParser,
 				int(maxFlows),
-				logger.GetLogger(),
+				log,
 			)
 			s.Start()
 			err = Serve(log, listenClientUrls, s.GetGRPCServer())
@@ -152,7 +151,7 @@ const (
 	envNodeName      = "HUBBLE_NODE_NAME"
 )
 
-func enableMetrics(log *logrus.Logger, m []string) {
+func enableMetrics(log *logrus.Entry, m []string) {
 	errChan, err := metrics.Init(metricsServer, metricsAPI.ParseMetricList(m))
 	if err != nil {
 		log.WithError(err).Fatal("Unable to setup metrics")
@@ -167,7 +166,7 @@ func enableMetrics(log *logrus.Logger, m []string) {
 
 }
 
-func validateArgs(log *logrus.Logger) error {
+func validateArgs(log *logrus.Entry) error {
 	if serveDurationVar != "" {
 		d, err := time.ParseDuration(serveDurationVar)
 		if err != nil {
@@ -233,7 +232,7 @@ func setupListeners(listenClientUrls []string) (listeners map[string]net.Listene
 
 // Serve starts the GRPC server on the provided socketPath. If the port is non-zero, it listens
 // to the TCP port instead of the unix domain socket.
-func Serve(log *logrus.Logger, listenClientUrls []string, s server.GRPCServer) error {
+func Serve(log *logrus.Entry, listenClientUrls []string, s server.GRPCServer) error {
 	clientListeners, err := setupListeners(listenClientUrls)
 	if err != nil {
 		return err

--- a/pkg/cilium/state.go
+++ b/pkg/cilium/state.go
@@ -47,7 +47,7 @@ type State struct {
 	// logRecord is a channel used to exchange L7 DNS requests seens from the
 	// monitor
 	logRecord chan monitor.LogRecordNotify
-	log       *logrus.Logger
+	log       *logrus.Entry
 
 	// epAdd is a channel used to exchange endpoint events from Cilium
 	endpointEvents chan monitorAPI.AgentNotify
@@ -60,7 +60,7 @@ func NewCiliumState(
 	ipCache *ipcache.IPCache,
 	fqdnCache FqdnCache,
 	serviceCache *servicecache.ServiceCache,
-	logger *logrus.Logger,
+	logger *logrus.Entry,
 ) *State {
 	return &State{
 		ciliumClient: ciliumClient,

--- a/pkg/logger/log.go
+++ b/pkg/logger/log.go
@@ -22,17 +22,18 @@ import (
 )
 
 var (
-	log  *logrus.Logger
+	log  *logrus.Entry
 	once sync.Once
 )
 
 // GetLogger returns the logger properly set up accordingly with the debug flag.
-func GetLogger() *logrus.Logger {
+func GetLogger() *logrus.Entry {
 	once.Do(func() {
-		log = logrus.New()
+		logger := logrus.New()
 		if viper.GetBool("debug") {
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetLevel(logrus.DebugLevel)
 		}
+		log = logrus.NewEntry(logger)
 	})
 	return log
 }

--- a/pkg/server/local_observer.go
+++ b/pkg/server/local_observer.go
@@ -50,7 +50,7 @@ type GRPCServer interface {
 	// in unit testing.
 	GetStopped() chan struct{}
 	// GetLogger returns the logger assigned to this gRPC server.
-	GetLogger() *logrus.Logger
+	GetLogger() *logrus.Entry
 }
 
 // LocalObserverServer is an implementation of the server.Observer interface
@@ -68,7 +68,7 @@ type LocalObserverServer struct {
 	// channel is empty, once it's closed.
 	stopped chan struct{}
 
-	log *logrus.Logger
+	log *logrus.Entry
 
 	// channel to receive events from observer server.
 	eventschan chan *observer.GetFlowsResponse
@@ -81,7 +81,7 @@ type LocalObserverServer struct {
 func NewLocalServer(
 	payloadParser *parser.Parser,
 	maxFlows int,
-	logger *logrus.Logger,
+	logger *logrus.Entry,
 ) *LocalObserverServer {
 	return &LocalObserverServer{
 		log:  logger,
@@ -130,7 +130,7 @@ func (s *LocalObserverServer) GetRingBuffer() *container.Ring {
 }
 
 // GetLogger implements GRPCServer.GetLogger.
-func (s *LocalObserverServer) GetLogger() *logrus.Logger {
+func (s *LocalObserverServer) GetLogger() *logrus.Entry {
 	return s.log
 }
 
@@ -254,7 +254,7 @@ type flowsReader struct {
 // newFlowsReader creates a new flowsReader that uses the given RingReader to
 // read through the ring buffer. Only flows that match the request criterias
 // are returned.
-func newFlowsReader(r *container.RingReader, req *observer.GetFlowsRequest, log *logrus.Logger) (*flowsReader, error) {
+func newFlowsReader(r *container.RingReader, req *observer.GetFlowsRequest, log *logrus.Entry) (*flowsReader, error) {
 	whitelist, err := filters.BuildFilterList(req.Whitelist)
 	if err != nil {
 		return nil, err

--- a/pkg/server/observer.go
+++ b/pkg/server/observer.go
@@ -47,7 +47,7 @@ type ObserverServer struct {
 
 	ciliumState *cilium.State
 
-	log *logrus.Logger
+	log *logrus.Entry
 }
 
 // NewServer returns a server that can store up to the given of maxFlows
@@ -60,7 +60,7 @@ func NewServer(
 	serviceCache *servicecache.ServiceCache,
 	payloadParser *parser.Parser,
 	maxFlows int,
-	logger *logrus.Logger,
+	logger *logrus.Entry,
 ) *ObserverServer {
 	ciliumState := cilium.NewCiliumState(ciliumClient, endpoints, ipCache, fqdnCache, serviceCache, logger)
 	return &ObserverServer{


### PR DESCRIPTION
Cilium uses logrus field to specify subsystems like this:

https://github.com/cilium/cilium/blob/b6f2e75d5b98bc200817da41f96c6522866cdd4a/daemon/daemon_main.go#L89

This PR modifies observer server and serve command to accept Entry
instead of Logger so that Cilium can configure the subsystem field
for Hubble.

Ref #97

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>