### PR TITLE
Add options to the flow metrics

### DIFF
--- a/pkg/metrics/flow/handler_test.go
+++ b/pkg/metrics/flow/handler_test.go
@@ -1,0 +1,66 @@
+package flow
+
+import (
+	"testing"
+
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/cilium/hubble/pkg/metrics/api"
+	"github.com/cilium/hubble/pkg/testutils"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlowHandler(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	opts := api.Options{"sourceContext": "namespace", "destinationContext": "namespace"}
+
+	h := &flowHandler{}
+
+	t.Run("Init", func(t *testing.T) {
+		require.NoError(t, h.Init(registry, opts))
+	})
+
+	t.Run("Status", func(t *testing.T) {
+		require.Equal(t, "destination=namespace,source=namespace", h.Status())
+	})
+
+	t.Run("ProcessFlow", func(t *testing.T) {
+		flow := &testutils.FakeFlow{
+			EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
+			L7: &pb.Layer7{
+				Record: &pb.Layer7_Http{Http: &pb.HTTP{}},
+			},
+			Source:      &pb.Endpoint{Namespace: "foo"},
+			Destination: &pb.Endpoint{Namespace: "bar"},
+			Verdict:     pb.Verdict_FORWARDED,
+		}
+		h.ProcessFlow(flow)
+
+		metricFamilies, err := registry.Gather()
+		require.NoError(t, err)
+		require.Len(t, metricFamilies, 1)
+
+		assert.Equal(t, "hubble_flows_processed_total", *metricFamilies[0].Name)
+		require.Len(t, metricFamilies[0].Metric, 1)
+		metric := metricFamilies[0].Metric[0]
+
+		assert.Equal(t, "destination", *metric.Label[0].Name)
+		assert.Equal(t, "bar", *metric.Label[0].Value)
+
+		assert.Equal(t, "source", *metric.Label[1].Name)
+		assert.Equal(t, "foo", *metric.Label[1].Value)
+
+		assert.Equal(t, "subtype", *metric.Label[2].Name)
+		assert.Equal(t, "HTTP", *metric.Label[2].Value)
+
+		assert.Equal(t, "type", *metric.Label[3].Name)
+		assert.Equal(t, "L7", *metric.Label[3].Value)
+
+		assert.Equal(t, "verdict", *metric.Label[4].Name)
+		assert.Equal(t, "FORWARDED", *metric.Label[4].Value)
+	})
+}

--- a/pkg/metrics/flow/plugin.go
+++ b/pkg/metrics/flow/plugin.go
@@ -30,7 +30,9 @@ Reports metrics related to flow processing
 
 Metrics:
   hubble_flows_processed_total  Number of flows processed
-`
+
+Options:` +
+		api.ContextOptionsHelp
 }
 
 func init() {

--- a/pkg/testutils/fake.go
+++ b/pkg/testutils/fake.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/gogo/protobuf/types"
 
 	pb "github.com/cilium/hubble/api/v1/flow"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
@@ -260,4 +261,125 @@ func (c *FakeCiliumClient) GetServiceCache() ([]*models.Service, error) {
 		return c.FakeGetServiceCache()
 	}
 	panic("GetServiceCache() should not have been called since it was not defined")
+}
+
+// FakeFlow implements v1.Flow for unit tests. All interface methods
+// return values exposed in the fields.
+type FakeFlow struct {
+	Time               *types.Timestamp
+	Verdict            pb.Verdict
+	DropReason         uint32
+	Ethernet           *pb.Ethernet
+	IP                 *pb.IP
+	L4                 *pb.Layer4
+	Source             *pb.Endpoint
+	Destination        *pb.Endpoint
+	Type               pb.FlowType
+	NodeName           string
+	SourceNames        []string
+	DestinationNames   []string
+	L7                 *pb.Layer7
+	Reply              bool
+	EventType          *pb.CiliumEventType
+	SourceService      *pb.Service
+	DestinationService *pb.Service
+}
+
+// Reset implements pb.Message for the FakeFlow.
+func (f *FakeFlow) Reset() {}
+
+// ProtoMessage implements pb.Message for the FakeFlow.
+func (f *FakeFlow) ProtoMessage() {}
+
+// String implements pb.Message for the FakeFlow.
+func (f *FakeFlow) String() string { return "fake flow message" }
+
+// GetTime implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetTime() *types.Timestamp {
+	return f.Time
+}
+
+// GetVerdict implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetVerdict() pb.Verdict {
+	return f.Verdict
+}
+
+// GetDropReason implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetDropReason() uint32 {
+	return f.DropReason
+}
+
+// GetEthernet implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetEthernet() *pb.Ethernet {
+	return f.Ethernet
+}
+
+// GetIP implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetIP() *pb.IP {
+	return f.IP
+}
+
+// GetL4 implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetL4() *pb.Layer4 {
+	return f.L4
+}
+
+// GetSource implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetSource() *pb.Endpoint {
+	return f.Source
+}
+
+// GetDestination implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetDestination() *pb.Endpoint {
+	return f.Destination
+}
+
+// GetType implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetType() pb.FlowType {
+	return f.Type
+}
+
+// GetNodeName implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetNodeName() string {
+	return f.NodeName
+}
+
+// GetSourceNames implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetSourceNames() []string {
+	return f.SourceNames
+}
+
+// GetDestinationNames implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetDestinationNames() []string {
+	return f.DestinationNames
+}
+
+// GetL7 implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetL7() *pb.Layer7 {
+	return f.L7
+}
+
+// GetReply implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetReply() bool {
+	return f.Reply
+}
+
+// GetEventType implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetEventType() *pb.CiliumEventType {
+	return f.EventType
+}
+
+// GetSourceService implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetSourceService() *pb.Service {
+	return f.SourceService
+}
+
+// GetDestinationService implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetDestinationService() *pb.Service {
+	return f.DestinationService
+}
+
+// GetSummary implements v1.Flow for the FakeFlow.
+func (f *FakeFlow) GetSummary() string {
+	return "deprecated"
 }


### PR DESCRIPTION
Flow plugins doesn't expose source and destination prometheus
labels. This patch will add support for the context options to support
additional prometheus labels.

Signed-off-by: Arthur Evstifeev <aevstifeev@gitlab.com>