### PR TITLE
logger: Avoid calling logger.GetLogger()

### DIFF
--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 
-	"github.com/cilium/hubble/pkg/logger"
+	"github.com/sirupsen/logrus"
 )
 
 // Look at the set observe flags, and optionally enable cpu, memory, or both,
@@ -27,10 +27,9 @@ import (
 //
 // Returns a function which should be deferred to the end of the execution so
 // profiles can be finalized.
-func maybeProfile() func() {
+func maybeProfile(log *logrus.Entry) func() {
 	var cf, mf *os.File
 	var err error
-	log := logger.GetLogger()
 	if cpuprofile != "" {
 		cf, err = os.Create(cpuprofile)
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/hubble/cmd/serve"
 	"github.com/cilium/hubble/cmd/status"
 	"github.com/cilium/hubble/pkg/logger"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,6 +31,7 @@ import (
 var (
 	cfgFile                string
 	cpuprofile, memprofile string
+	log                    *logrus.Entry
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -42,7 +44,7 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	fin := maybeProfile()
+	fin := maybeProfile(log)
 	defer fin() // make sure update memory profile is written in the end
 
 	if err := rootCmd.Execute(); err != nil {
@@ -69,11 +71,11 @@ func init() {
 	rootCmd.PersistentFlags().Lookup("cpuprofile").Hidden = true
 	rootCmd.PersistentFlags().Lookup("memprofile").Hidden = true
 
-	l := logger.GetLogger()
+	log = logger.GetLogger()
 
 	// initialize all subcommands
 	rootCmd.AddCommand(status.New())
-	rootCmd.AddCommand(serve.New(l))
+	rootCmd.AddCommand(serve.New(log))
 	rootCmd.AddCommand(observe.New())
 }
 

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -86,7 +86,7 @@ func New(log *logrus.Entry) *cobra.Command {
 				PodGetter:      ipCache,
 				EndpointGetter: endpoints,
 			}
-			payloadParser, err := parser.New(endpoints, ciliumClient, fqdnCache, podGetter, serviceCache)
+			payloadParser, err := parser.New(endpoints, ciliumClient, fqdnCache, podGetter, serviceCache, log)
 			if err != nil {
 				log.WithError(err).Fatal("failed to get parser")
 			}
@@ -153,7 +153,7 @@ const (
 
 // EnableMetrics starts the metrics server with a given list of metrics.
 func EnableMetrics(log *logrus.Entry, metricsServer string, m []string) {
-	errChan, err := metrics.Init(metricsServer, metricsAPI.ParseMetricList(m))
+	errChan, err := metrics.Init(metricsServer, metricsAPI.ParseMetricList(m), log)
 	if err != nil {
 		log.WithError(err).Fatal("Unable to setup metrics")
 	}

--- a/pkg/metrics/api/api_test.go
+++ b/pkg/metrics/api/api_test.go
@@ -17,6 +17,7 @@ package api
 import (
 	"testing"
 
+	"github.com/cilium/hubble/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,7 +28,7 @@ func TestDefaultRegistry(t *testing.T) {
 
 	assert.NotNil(t, registry)
 
-	registry.ConfigureHandlers(prometheusRegistry, Map{"drop": Options{}})
+	registry.ConfigureHandlers(prometheusRegistry, Map{"drop": Options{}}, logger.GetLogger())
 }
 
 func TestParseMetricOptions(t *testing.T) {

--- a/pkg/metrics/api/registry.go
+++ b/pkg/metrics/api/registry.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cilium/hubble/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
@@ -49,10 +48,9 @@ func (r *Registry) Register(name string, p Plugin) {
 // ConfigureHandlers enables a set of metric handlers and initializes them.
 // Only metrics handlers which have been previously registered via the
 // Register() function can be configured.
-func (r *Registry) ConfigureHandlers(registry *prometheus.Registry, enabled Map) (Handlers, error) {
+func (r *Registry) ConfigureHandlers(registry *prometheus.Registry, enabled Map, log *logrus.Entry) (Handlers, error) {
 	var (
 		initialized Handlers
-		log         = logger.GetLogger()
 	)
 
 	r.mutex.Lock()

--- a/pkg/metrics/api/registry_test.go
+++ b/pkg/metrics/api/registry_test.go
@@ -17,8 +17,8 @@ package api
 import (
 	"testing"
 
-	"github.com/cilium/hubble/pkg/api/v1"
-
+	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/hubble/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
@@ -56,11 +56,11 @@ func TestRegister(t *testing.T) {
 
 	r.Register("test", &testPlugin{})
 
-	handlers, err := r.ConfigureHandlers(nil, Map{})
+	handlers, err := r.ConfigureHandlers(nil, Map{}, logger.GetLogger())
 	assert.EqualValues(t, err, nil)
 	assert.EqualValues(t, len(handlers), 0)
 
-	handlers, err = r.ConfigureHandlers(nil, Map{"test": Options{}})
+	handlers, err = r.ConfigureHandlers(nil, Map{"test": Options{}}, logger.GetLogger())
 	assert.EqualValues(t, err, nil)
 	assert.EqualValues(t, len(handlers), 1)
 	assert.EqualValues(t, handlers[0].(*testHandler).InitCalled, 1)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,7 +17,7 @@ package metrics
 import (
 	"net/http"
 
-	"github.com/cilium/hubble/pkg/api/v1"
+	v1 "github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/metrics/api"
 	_ "github.com/cilium/hubble/pkg/metrics/dns"               // invoke init
 	_ "github.com/cilium/hubble/pkg/metrics/drop"              // invoke init
@@ -26,9 +26,9 @@ import (
 	_ "github.com/cilium/hubble/pkg/metrics/icmp"              // invoke init
 	_ "github.com/cilium/hubble/pkg/metrics/port-distribution" // invoke init
 	_ "github.com/cilium/hubble/pkg/metrics/tcp"               // invoke init
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -44,8 +44,8 @@ func ProcessFlow(flow v1.Flow) {
 }
 
 // Init initialies the metrics system
-func Init(address string, enabled api.Map) (<-chan error, error) {
-	e, err := api.DefaultRegistry().ConfigureHandlers(registry, enabled)
+func Init(address string, enabled api.Map, log *logrus.Entry) (<-chan error, error) {
+	e, err := api.DefaultRegistry().ConfigureHandlers(registry, enabled, log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parser/new.go
+++ b/pkg/parser/new.go
@@ -16,13 +16,13 @@ package parser
 
 import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-
 	pb "github.com/cilium/hubble/api/v1/flow"
 	"github.com/cilium/hubble/pkg/parser/errors"
 	"github.com/cilium/hubble/pkg/parser/getters"
 	"github.com/cilium/hubble/pkg/parser/options"
 	"github.com/cilium/hubble/pkg/parser/seven"
 	"github.com/cilium/hubble/pkg/parser/threefour"
+	"github.com/sirupsen/logrus"
 )
 
 // Parser for all flows
@@ -38,10 +38,11 @@ func New(
 	dnsGetter getters.DNSGetter,
 	ipGetter getters.IPGetter,
 	serviceGetter getters.ServiceGetter,
+	log *logrus.Entry,
 	opts ...options.Option,
 ) (*Parser, error) {
 
-	l34, err := threefour.New(endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter)
+	l34, err := threefour.New(endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter, log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/local_observer_test.go
+++ b/pkg/server/local_observer_test.go
@@ -36,7 +36,8 @@ func TestNewLocalServer(t *testing.T) {
 		&testutils.NoopIdentityGetter,
 		&testutils.NoopDNSGetter,
 		&testutils.NoopIPGetter,
-		&testutils.NoopServiceGetter)
+		&testutils.NoopServiceGetter,
+		logger.GetLogger())
 	require.NoError(t, err)
 	s := NewLocalServer(pp, 10, logger.GetLogger())
 	assert.NotNil(t, s.GetStopped())
@@ -52,7 +53,8 @@ func TestLocalObserverServer_ServerStatus(t *testing.T) {
 		&testutils.NoopIdentityGetter,
 		&testutils.NoopDNSGetter,
 		&testutils.NoopIPGetter,
-		&testutils.NoopServiceGetter)
+		&testutils.NoopServiceGetter,
+		logger.GetLogger())
 	require.NoError(t, err)
 	s := NewLocalServer(pp, 1, logger.GetLogger())
 	res, err := s.ServerStatus(context.Background(), &observer.ServerStatusRequest{})
@@ -80,7 +82,8 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 		&testutils.NoopIdentityGetter,
 		&testutils.NoopDNSGetter,
 		&testutils.NoopIPGetter,
-		&testutils.NoopServiceGetter)
+		&testutils.NoopServiceGetter,
+		logger.GetLogger())
 	require.NoError(t, err)
 	s := NewLocalServer(pp, numFlows, logger.GetLogger())
 	go s.Start()

--- a/pkg/server/observer_test.go
+++ b/pkg/server/observer_test.go
@@ -132,7 +132,7 @@ func TestObserverServer_GetLastNFlows(t *testing.T) {
 	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc, logger.GetLogger())
 	assert.NoError(t, err)
 
 	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff, logger.GetLogger())
@@ -202,7 +202,7 @@ func TestObserverServer_GetLastNFlows_MustNotBlock(t *testing.T) {
 	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc, logger.GetLogger())
 	assert.NoError(t, err)
 
 	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0x4, logger.GetLogger())
@@ -268,7 +268,7 @@ func TestObserverServer_GetLastNFlows_With_Follow(t *testing.T) {
 	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc, logger.GetLogger())
 	assert.NoError(t, err)
 
 	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff, logger.GetLogger())
@@ -370,7 +370,7 @@ func TestObserverServer_GetFlowsBetween(t *testing.T) {
 	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc, logger.GetLogger())
 	assert.NoError(t, err)
 
 	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff, logger.GetLogger())
@@ -465,7 +465,7 @@ func TestObserverServer_GetFlows(t *testing.T) {
 	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc, logger.GetLogger())
 	assert.NoError(t, err)
 
 	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30, logger.GetLogger())
@@ -530,7 +530,7 @@ func TestObserverServer_GetFlowsWithFilters(t *testing.T) {
 	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc, logger.GetLogger())
 	assert.NoError(t, err)
 
 	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30, logger.GetLogger())
@@ -609,7 +609,7 @@ func TestObserverServer_GetFlowsOfANonLocalPod(t *testing.T) {
 	svcc := servicecache.New()
 	fqdnc := fqdncache.New()
 
-	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, fakeIPGetter, svcc)
+	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, fakeIPGetter, svcc, logger.GetLogger())
 	assert.NoError(t, err)
 
 	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30, logger.GetLogger())


### PR DESCRIPTION
Typically logger gets configured externally (e.g. by Cilium) in embeded
mode. Hubble needs to use this logger across all the components instead
of using logger.GetLogger().

Ref #97

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>