### PR TITLE
socket: Make the unix domain socket group configurable

### DIFF
--- a/install/kubernetes/hubble/templates/daemonset.yaml
+++ b/install/kubernetes/hubble/templates/daemonset.yaml
@@ -80,6 +80,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+{{- if .Values.groupName }}
+          - name: HUBBLE_GROUP_NAME
+            value: {{ .Values.groupName | quote }}
+{{- end }}
         ports:
 {{- if .Values.metrics.enabled }}
         - containerPort: {{ regexReplaceAll ":([0-9]+)$" .Values.metrics.address "${1}" }}

--- a/install/kubernetes/hubble/values.yaml
+++ b/install/kubernetes/hubble/values.yaml
@@ -11,6 +11,10 @@ image:
 # defaults to using unix domain socket.
 listenClientUrls: ~
 
+# groupName specifies the group to use for unix domain socket Hubble uses for
+# the gRPC server. Defaults to "hubble".
+groupName: ~
+
 # Server URL to connect to hubble server. If this parameter is not specified,
 # it defaults to using unix domain socket.
 server: ~

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -22,8 +22,11 @@ import (
 const (
 	// GroupFilePath is the unix group file path.
 	GroupFilePath = "/etc/group"
-	// HubbleGroupName is the hubble's unix group name.
+	// HubbleGroupName is the hubble's default unix group name. Set HUBBLE_GROUP_NAME environment
+	// variable to override.
 	HubbleGroupName = "hubble"
+	// HubbleGroupNameKey is the environment variable name to override the group for unix domain socket.
+	HubbleGroupNameKey = "HUBBLE_GROUP_NAME"
 	// SocketFileMode is the default file mode for the sockets.
 	SocketFileMode os.FileMode = 0660
 	// ClientTimeout specifies timeout to be used by clients

--- a/pkg/api/socket.go
+++ b/pkg/api/socket.go
@@ -50,20 +50,28 @@ func GetGroupIDByName(grpName string) (int, error) {
 // SetDefaultPermissions sets the given socket to with cilium's default
 // group and mode permissions. Group `HubbleGroupName` and mode `0660`
 func SetDefaultPermissions(socketPath string) error {
-	gid, err := GetGroupIDByName(HubbleGroupName)
+	group := getGroupName()
+	gid, err := GetGroupIDByName(group)
 	if err != nil {
-		return fmt.Errorf("group %s not found", HubbleGroupName)
+		return fmt.Errorf("group %s not found", group)
 	}
 
 	if err := os.Chown(socketPath, 0, gid); err != nil {
 		return fmt.Errorf("failed while setting up %s's group ID"+
-			" in %q: %s", HubbleGroupName, socketPath, err)
+			" in %q: %s", group, socketPath, err)
 	}
 
 	if err := os.Chmod(socketPath, SocketFileMode); err != nil {
 		return fmt.Errorf("failed while setting up %s's file"+
-			" permissions in %q: %s", HubbleGroupName, socketPath, err)
+			" permissions in %q: %s", group, socketPath, err)
 	}
 
 	return nil
+}
+
+func getGroupName() string {
+	if name, ok := os.LookupEnv(HubbleGroupNameKey); ok {
+		return name
+	}
+	return HubbleGroupName
 }

--- a/pkg/api/socket_test.go
+++ b/pkg/api/socket_test.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getGroupName(t *testing.T) {
+	assert.NoError(t, os.Setenv(HubbleGroupNameKey, "mygroup"))
+	assert.Equal(t, getGroupName(), "mygroup")
+	assert.NoError(t, os.Unsetenv(HubbleGroupNameKey))
+	assert.Equal(t, getGroupName(), HubbleGroupName)
+}


### PR DESCRIPTION
Set HUBBLE_GROUP_NAME environment variable to override the group name.

Closes #122

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>