### PR TITLE
socket: Make the default server for status/observe configurable

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -109,7 +109,7 @@ programs attached to endpoints and devices. This includes:
 		},
 	}
 	observerCmd.Flags().StringVarP(&serverURL,
-		"server", "", api.DefaultSocketPath,
+		"server", "", api.GetDefaultSocketPath(),
 		"URL to connect to server")
 	observerCmd.Flags().StringVar(&serverTimeoutVar,
 		"timeout", "5s",

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -45,7 +45,7 @@ func New() *cobra.Command {
 	}
 
 	statusCmd.Flags().StringVarP(&serverURL,
-		"server", "", api.DefaultSocketPath, "URL to connect to server")
+		"server", "", api.GetDefaultSocketPath(), "URL to connect to server")
 	viper.BindEnv("server", "HUBBLE_SOCK")
 
 	return statusCmd

--- a/install/kubernetes/hubble/templates/daemonset.yaml
+++ b/install/kubernetes/hubble/templates/daemonset.yaml
@@ -84,6 +84,10 @@ spec:
           - name: HUBBLE_GROUP_NAME
             value: {{ .Values.groupName | quote }}
 {{- end }}
+{{- if .Values.defaultServer }}
+          - name: HUBBLE_DEFAULT_SOCKET_PATH
+            value: {{ .Values.defaultServer | quote }}
+{{- end }}
         ports:
 {{- if .Values.metrics.enabled }}
         - containerPort: {{ regexReplaceAll ":([0-9]+)$" .Values.metrics.address "${1}" }}

--- a/install/kubernetes/hubble/values.yaml
+++ b/install/kubernetes/hubble/values.yaml
@@ -19,6 +19,10 @@ groupName: ~
 # it defaults to using unix domain socket.
 server: ~
 
+# Specify the default server for observe and status commands when the --server
+# option is not specified. It defaults to "unix:///var/run/hubble.sock".
+defaultServer: ~
+
 # maxFlows the server will store in memory
 maxFlows: ~
 

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -34,6 +34,9 @@ const (
 
 	// DefaultSocketPath which hubble listens to
 	DefaultSocketPath = "unix:///var/run/hubble.sock"
+	// DefaultSocketPathKey is the environment variable name to override the default socket path for
+	// observe and status commands.
+	DefaultSocketPathKey = "HUBBLE_DEFAULT_SOCKET_PATH"
 
 	// ConnectionTimeout ...
 	ConnectionTimeout = 12 * time.Second

--- a/pkg/api/socket.go
+++ b/pkg/api/socket.go
@@ -75,3 +75,11 @@ func getGroupName() string {
 	}
 	return HubbleGroupName
 }
+
+// GetDefaultSocketPath returns the default server for status and observe command.
+func GetDefaultSocketPath() string {
+	if path, ok := os.LookupEnv(DefaultSocketPathKey); ok {
+		return path
+	}
+	return DefaultSocketPath
+}

--- a/pkg/api/socket_test.go
+++ b/pkg/api/socket_test.go
@@ -27,3 +27,10 @@ func Test_getGroupName(t *testing.T) {
 	assert.NoError(t, os.Unsetenv(HubbleGroupNameKey))
 	assert.Equal(t, getGroupName(), HubbleGroupName)
 }
+
+func Test_GetDefaultSocketPath(t *testing.T) {
+	assert.NoError(t, os.Setenv(DefaultSocketPathKey, "unix:///socket/path"))
+	assert.Equal(t, GetDefaultSocketPath(), "unix:///socket/path")
+	assert.NoError(t, os.Unsetenv(DefaultSocketPathKey))
+	assert.Equal(t, GetDefaultSocketPath(), DefaultSocketPath)
+}


### PR DESCRIPTION
Set HUBBLE_DEFAULT_SOCKET_PATH environment variable to override the
default server for status and observe commands.

Closes #124

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>