### PR TITLE
cmd/observe: deprecate --compact, --dict, --json flags, add --output

### DIFF
--- a/pkg/printer/options.go
+++ b/pkg/printer/options.go
@@ -70,6 +70,13 @@ func Dict() Option {
 	}
 }
 
+// Tab prints flows in even tab-aligned columns.
+func Tab() Option {
+	return func(opts *Options) {
+		opts.output = TabOutput
+	}
+}
+
 // Writer sets the custom destination for where the bytes are sent.
 func Writer(w io.Writer) Option {
 	return func(opts *Options) {


### PR DESCRIPTION
This makes it more easy to find out about all available out formatting options. Furthermore, when old formatting flags will be removed, providing flags that are incompatible, such as `--json --compact`, will not be possible anymore. For now however, just deprecate the old formatting flags in order to not to break compatibility.

This also fixes a bug where `--follow --dict` was incorrectly defaulting to the compact output.

Fixes #121 