### PR TITLE
parser: Fix parameters to DNSGetter.GetNamesOf

### DIFF
--- a/pkg/parser/seven/parser.go
+++ b/pkg/parser/seven/parser.go
@@ -113,8 +113,8 @@ func (p *Parser) Decode(payload *pb.Payload, decoded *pb.Flow) error {
 	var sourceNames, destinationNames []string
 	var sourceNamespace, sourcePod, destinationNamespace, destinationPod string
 	if p.dnsGetter != nil {
-		sourceNames = p.dnsGetter.GetNamesOf(sourceEndpoint.ID, sourceIP)
-		destinationNames = p.dnsGetter.GetNamesOf(destinationEndpoint.ID, destinationIP)
+		sourceNames = p.dnsGetter.GetNamesOf(destinationEndpoint.ID, sourceIP)
+		destinationNames = p.dnsGetter.GetNamesOf(sourceEndpoint.ID, destinationIP)
 	}
 	if p.ipGetter != nil {
 		if id, ok := p.ipGetter.GetIPIdentity(sourceIP); ok {

--- a/pkg/parser/seven/parser_test.go
+++ b/pkg/parser/seven/parser_test.go
@@ -103,9 +103,9 @@ func TestDecodeL7HTTPRecord(t *testing.T) {
 		OnGetNamesOf: func(epID uint64, ip net.IP) (names []string) {
 			ipStr := ip.String()
 			switch {
-			case epID == fakeDestinationEndpoint.ID && ipStr == fakeDestinationEndpoint.IPv4:
+			case epID == fakeSourceEndpoint.ID && ipStr == fakeDestinationEndpoint.IPv4:
 				return []string{"endpoint-1234"}
-			case epID == fakeSourceEndpoint.ID && ipStr == fakeSourceEndpoint.IPv4:
+			case epID == fakeDestinationEndpoint.ID && ipStr == fakeSourceEndpoint.IPv4:
 				return []string{"endpoint-4321"}
 			}
 			return nil


### PR DESCRIPTION
DNSGetter.GetNamesOf looks up DNS names of an IP address from the FQDN
cache of a given endpoint, so we need to pass:

- (source endpoint ID, destination IP) for destination names
- (destination endpoint ID, source IP) for source names

Unit test was passing because the fake implementation of DNSGetter
implemented GetNamesOf incorrectly.

I also tested the CLI manually. Before the fix:

    default/tiefighter:52768 -> 72.30.35.9:80(http) http-request FORWARDED (HTTP/1.1 GET http://yahoo.com/)
    72.30.35.9:80(http) -> default/tiefighter:52768 http-response FORWARDED (HTTP/1.1 301 196ms (GET http://yahoo.com/))

After the fix:

    default/tiefighter:44530 -> yahoo.com:80(http) http-request FORWARDED (HTTP/1.1 GET http://yahoo.com/)
    yahoo.com:80(http) -> default/tiefighter:44530 http-response FORWARDED (HTTP/1.1 301 114ms (GET http://yahoo.com/))

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>