### PR TITLE
container/ring_reader: never return nil events on NextFollow()

### DIFF
--- a/pkg/container/ring_reader_test.go
+++ b/pkg/container/ring_reader_test.go
@@ -219,3 +219,20 @@ func TestRingReader_NextFollow(t *testing.T) {
 		})
 	}
 }
+
+func TestRingReader_NextFollow_WithEmptyRing(t *testing.T) {
+	ring := NewRing(15)
+	reader := NewRingReader(ring, ring.LastWriteParallel())
+	ctx, cancel := context.WithCancel(context.Background())
+	c := make(chan *v1.Event)
+	go func() {
+		c <- reader.NextFollow(ctx)
+	}()
+	select {
+	case <-c:
+		t.Fail()
+	case <-time.After(1 * time.Millisecond):
+		// the call blocked, we're good
+	}
+	cancel()
+}


### PR DESCRIPTION
By contract, RingReader should only return <nil> when no event can be read. In the case of NextFollow(), one should block until an event is read or the context is cancelled.
However, it appears that under certain circumstances, typically when the ring buffer is empty, <nil> events may be sent to the channel by Ring.readFrom(). In such a case, one should ignore the <nil> event and keep reading/waiting until a non-nil event is being sent to the channel or the context is cancelled.

Fixes #134 

/cc @michi-covalent Can you please confirm that if fixes the issue you reported?