### PR TITLE
getter: Change EndpointGetter to return a subset of Endpoint

### DIFF
--- a/pkg/api/v1/endpoint.go
+++ b/pkg/api/v1/endpoint.go
@@ -235,6 +235,23 @@ func (es *Endpoints) GetEndpoint(ip net.IP) (endpoint *Endpoint, ok bool) {
 	return
 }
 
+// GetEndpointInfo returns the endpoint info that has the given ip.
+func (es *Endpoints) GetEndpointInfo(ip net.IP) (info *EndpointInfo, ok bool) {
+	es.mutex.RLock()
+	defer es.mutex.RUnlock()
+	for _, ep := range es.eps {
+		if ep.Deleted == nil && (ep.IPv4.Equal(ip) || ep.IPv6.Equal(ip)) {
+			return &EndpointInfo{
+				ID:           ep.ID,
+				PodName:      ep.PodName,
+				PodNamespace: ep.PodNamespace,
+				Labels:       ep.Labels,
+			}, true
+		}
+	}
+	return nil, false
+}
+
 // GetEndpointByContainerID returns the endpoint that has the given container ID.
 func (es *Endpoints) GetEndpointByContainerID(id string) (*Endpoint, bool) {
 	es.mutex.RLock()

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -36,6 +36,16 @@ type Endpoint struct {
 	Labels       []string   `json:"labels"`
 }
 
+// EndpointInfo is a subset of Endpoint type that's used by EndpointGetter interface.
+// It strips out the fields used by EndpointHandler but not by EndpointGetter. In
+// embedded mode, we need EndpointInfo, but not Endpoint struct.
+type EndpointInfo struct {
+	ID           uint64
+	PodName      string
+	PodNamespace string
+	Labels       []string
+}
+
 // Event represents a single event observed and stored by Hubble
 type Event struct {
 	// Timestamp when event was observed in Hubble

--- a/pkg/cilium/ipcache.go
+++ b/pkg/cilium/ipcache.go
@@ -47,7 +47,7 @@ func (l *LegacyPodGetter) GetIPIdentity(ip net.IP) (identity ipcache.IPIdentity,
 	}
 
 	// fallback on local endpoints
-	if ep, ok := l.EndpointGetter.GetEndpoint(ip); ok {
+	if ep, ok := l.EndpointGetter.GetEndpointInfo(ip); ok {
 		return ipcache.IPIdentity{
 			Namespace: ep.PodNamespace,
 			PodName:   ep.PodName,

--- a/pkg/cilium/ipcache_test.go
+++ b/pkg/cilium/ipcache_test.go
@@ -147,8 +147,8 @@ func TestLegacyPodGetter_GetPodNameOf(t *testing.T) {
 						return ipcache.IPIdentity{Namespace: "default", PodName: "xwing"}, true
 					},
 				},
-				EndpointGetter: &testutils.FakeEndpointsHandler{
-					FakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
+				EndpointGetter: &testutils.FakeEndpointGetter{
+					OnGetEndpointInfo: func(_ net.IP) (*v1.EndpointInfo, bool) {
 						return nil, false
 					},
 				},
@@ -165,11 +165,10 @@ func TestLegacyPodGetter_GetPodNameOf(t *testing.T) {
 			name: "available in endpoints",
 			fields: fields{
 				IPGetter: &testutils.NoopIPGetter,
-				EndpointGetter: &testutils.FakeEndpointsHandler{
-					FakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
-						return &v1.Endpoint{
+				EndpointGetter: &testutils.FakeEndpointGetter{
+					OnGetEndpointInfo: func(_ net.IP) (*v1.EndpointInfo, bool) {
+						return &v1.EndpointInfo{
 							ID:           16,
-							IPv4:         net.ParseIP("1.1.1.15"),
 							PodName:      "deathstar",
 							PodNamespace: "default",
 						}, true
@@ -192,11 +191,10 @@ func TestLegacyPodGetter_GetPodNameOf(t *testing.T) {
 						return ipcache.IPIdentity{Namespace: "default", PodName: "xwing"}, true
 					},
 				},
-				EndpointGetter: &testutils.FakeEndpointsHandler{
-					FakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
-						return &v1.Endpoint{
+				EndpointGetter: &testutils.FakeEndpointGetter{
+					OnGetEndpointInfo: func(_ net.IP) (*v1.EndpointInfo, bool) {
+						return &v1.EndpointInfo{
 							ID:           16,
-							IPv4:         net.ParseIP("1.1.1.15"),
 							PodName:      "deathstar",
 							PodNamespace: "default",
 						}, true

--- a/pkg/parser/getters/getters.go
+++ b/pkg/parser/getters/getters.go
@@ -17,11 +17,10 @@ package getters
 import (
 	"net"
 
+	"github.com/cilium/cilium/api/v1/models"
 	pb "github.com/cilium/hubble/api/v1/flow"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
 	"github.com/cilium/hubble/pkg/ipcache"
-
-	"github.com/cilium/cilium/api/v1/models"
 )
 
 // DNSGetter ...
@@ -33,8 +32,8 @@ type DNSGetter interface {
 
 // EndpointGetter ...
 type EndpointGetter interface {
-	// GetEndpoint looks up endpoint by IP address.
-	GetEndpoint(ip net.IP) (endpoint *v1.Endpoint, ok bool)
+	// GetEndpointInfo looks up endpoint by IP address.
+	GetEndpointInfo(ip net.IP) (ep *v1.EndpointInfo, ok bool)
 }
 
 // IdentityGetter ...

--- a/pkg/parser/threefour/parser.go
+++ b/pkg/parser/threefour/parser.go
@@ -228,7 +228,7 @@ func sortAndFilterLabels(labels []string, securityIdentity uint64) []string {
 func (p *Parser) resolveEndpoint(ip net.IP, securityIdentity uint64) *pb.Endpoint {
 	// for local endpoints, use the available endpoint information
 	if p.endpointGetter != nil {
-		if ep, ok := p.endpointGetter.GetEndpoint(ip); ok {
+		if ep, ok := p.endpointGetter.GetEndpointInfo(ip); ok {
 			return &pb.Endpoint{
 				ID:        ep.ID,
 				Identity:  securityIdentity,

--- a/pkg/parser/threefour/parser_test.go
+++ b/pkg/parser/threefour/parser_test.go
@@ -51,9 +51,9 @@ func TestL34Decode(t *testing.T) {
 		98, 0, 90, 176, 97, 0, 0}
 
 	endpointGetter := &testutils.FakeEndpointGetter{
-		OnGetEndpoint: func(ip net.IP) (endpoint *v1.Endpoint, ok bool) {
+		OnGetEndpointInfo: func(ip net.IP) (endpoint *v1.EndpointInfo, ok bool) {
 			if ip.Equal(net.ParseIP("10.16.236.178")) {
-				return &v1.Endpoint{
+				return &v1.EndpointInfo{
 					ID:           1234,
 					PodName:      "pod-10.16.236.178",
 					PodNamespace: "default",
@@ -154,9 +154,9 @@ func TestL34Decode(t *testing.T) {
 		0, 0, 0, 0, 0}
 
 	endpointGetter = &testutils.FakeEndpointGetter{
-		OnGetEndpoint: func(ip net.IP) (endpoint *v1.Endpoint, ok bool) {
+		OnGetEndpointInfo: func(ip net.IP) (endpoint *v1.EndpointInfo, ok bool) {
 			if ip.Equal(net.ParseIP("ff02::1:ff00:b3e5")) {
-				return &v1.Endpoint{
+				return &v1.EndpointInfo{
 					ID: 1234,
 				}, true
 			}
@@ -520,15 +520,14 @@ func TestICMP(t *testing.T) {
 func TestTraceNotifyLocalEndpoint(t *testing.T) {
 	f := &pb.Flow{}
 
-	ep := &v1.Endpoint{
+	ep := &v1.EndpointInfo{
 		ID:           1234,
-		IPv4:         net.ParseIP("1.1.1.1"),
 		PodName:      "xwing",
 		PodNamespace: "default",
 		Labels:       []string{"a", "b", "c"},
 	}
 	endpointGetter := &testutils.FakeEndpointGetter{
-		OnGetEndpoint: func(ip net.IP) (endpoint *v1.Endpoint, ok bool) {
+		OnGetEndpointInfo: func(ip net.IP) (endpoint *v1.EndpointInfo, ok bool) {
 			return ep, true
 		},
 	}

--- a/pkg/testutils/fake.go
+++ b/pkg/testutils/fake.go
@@ -35,20 +35,20 @@ var NoopDNSGetter = FakeDNSGetter{
 
 // FakeEndpointGetter is used for unit tests that needs EndpointGetter.
 type FakeEndpointGetter struct {
-	OnGetEndpoint func(ip net.IP) (endpoint *v1.Endpoint, ok bool)
+	OnGetEndpointInfo func(ip net.IP) (endpoint *v1.EndpointInfo, ok bool)
 }
 
-// GetEndpoint implements EndpointGetter.GetEndpoint.
-func (f *FakeEndpointGetter) GetEndpoint(ip net.IP) (endpoint *v1.Endpoint, ok bool) {
-	if f.OnGetEndpoint != nil {
-		return f.OnGetEndpoint(ip)
+// GetEndpointInfo implements EndpointGetter.GetEndpointInfo.
+func (f *FakeEndpointGetter) GetEndpointInfo(ip net.IP) (endpoint *v1.EndpointInfo, ok bool) {
+	if f.OnGetEndpointInfo != nil {
+		return f.OnGetEndpointInfo(ip)
 	}
 	panic("OnGetEndpoint not set")
 }
 
 // NoopEndpointGetter always returns an empty response.
 var NoopEndpointGetter = FakeEndpointGetter{
-	OnGetEndpoint: func(ip net.IP) (endpoint *v1.Endpoint, ok bool) {
+	OnGetEndpointInfo: func(ip net.IP) (endpoint *v1.EndpointInfo, ok bool) {
 		return nil, false
 	},
 }


### PR DESCRIPTION
Define a struct EndpointInfo that contains endpoint ID, pod namespace,
pod name, and labels, and change EndpointGetter to return EndpointInfo
insted of the full Endpoint struct.

The main rationale for this change is to simplify the implementation of
the EndpointGetter in embedded mode. Since we don't need EndpointHandler
in embedded mode, EndpointGetter can return only the fields that are
used by the parser and LegacyPodGetter.

Ref #97

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>