### PR TITLE
update Go to v1.14.0

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,7 +15,7 @@ jobs:
         path: go/src/github.com/cilium/hubble
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.13'
+        go-version: '1.14'
     - name: Run unit tests
       env:
         GOPATH: /home/runner/work/hubble/go

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,6 +21,6 @@ jobs:
         GOPATH: /home/runner/work/hubble/go
       run: |
         export PATH=${PATH}:${GOPATH}/bin
-        go get -u github.com/gordonklaus/ineffassign
-        go get -u golang.org/x/lint/golint
+        GO111MODULE=off go get -u github.com/gordonklaus/ineffassign
+        GO111MODULE=off go get -u golang.org/x/lint/golint
         make check-fmt lint test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.13.8-alpine3.11 as builder
+FROM docker.io/library/golang:1.14.0-alpine3.11 as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache binutils git make \
  && go get -d github.com/google/gops \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/hubble
 
-go 1.13
+go 1.14
 
 require (
 	github.com/cilium/cilium v1.7.0-rc2.0.20200225155839-f0d65d667e33

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,6 +9,7 @@ github.com/beorn7/perks/quantile
 # github.com/cespare/xxhash/v2 v2.1.0
 github.com/cespare/xxhash/v2
 # github.com/cilium/cilium v1.7.0-rc2.0.20200225155839-f0d65d667e33
+## explicit
 github.com/cilium/cilium/api/v1/client
 github.com/cilium/cilium/api/v1/client/daemon
 github.com/cilium/cilium/api/v1/client/endpoint
@@ -61,6 +62,7 @@ github.com/davecgh/go-spew/spew
 # github.com/fatih/color v1.7.0
 github.com/fatih/color
 # github.com/francoispqt/gojay v1.2.13
+## explicit
 github.com/francoispqt/gojay
 # github.com/fsnotify/fsnotify v1.4.7
 github.com/fsnotify/fsnotify
@@ -89,6 +91,7 @@ github.com/go-openapi/runtime/security
 # github.com/go-openapi/spec v0.19.3
 github.com/go-openapi/spec
 # github.com/go-openapi/strfmt v0.19.3
+## explicit
 github.com/go-openapi/strfmt
 # github.com/go-openapi/swag v0.19.5
 github.com/go-openapi/swag
@@ -97,12 +100,14 @@ github.com/go-openapi/validate
 # github.com/go-stack/stack v1.8.0
 github.com/go-stack/stack
 # github.com/gogo/protobuf v1.3.0
+## explicit
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
 github.com/gogo/protobuf/types
 # github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 github.com/golang/glog
 # github.com/golang/protobuf v1.3.2
+## explicit
 github.com/golang/protobuf/jsonpb
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/protoc-gen-go
@@ -117,9 +122,11 @@ github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/struct
 github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/gopacket v1.1.17
+## explicit
 github.com/google/gopacket
 github.com/google/gopacket/layers
 # github.com/google/gops v0.3.6
+## explicit
 github.com/google/gops/agent
 github.com/google/gops/internal
 github.com/google/gops/signal
@@ -129,6 +136,7 @@ github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor
 github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule
 github.com/grpc-ecosystem/grpc-gateway/utilities
 # github.com/hashicorp/golang-lru v0.5.1
+## explicit
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/hashicorp/hcl v1.0.0
@@ -165,6 +173,7 @@ github.com/miekg/dns
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/protoc-gen-go-json v0.0.0-20200113165135-fd297ce346f1
+## explicit
 github.com/mitchellh/protoc-gen-go-json
 github.com/mitchellh/protoc-gen-go-json/gen
 # github.com/pelletier/go-toml v1.2.0
@@ -174,6 +183,7 @@ github.com/petermattis/goid
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.2.0
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
@@ -191,6 +201,7 @@ github.com/prometheus/procfs/internal/util
 # github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa
 github.com/sasha-s/go-deadlock
 # github.com/sirupsen/logrus v1.4.2
+## explicit
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
 # github.com/spf13/afero v1.2.2
@@ -199,14 +210,18 @@ github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.0
 github.com/spf13/cast
 # github.com/spf13/cobra v0.0.5
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/jwalterweatherman v1.0.0
 github.com/spf13/jwalterweatherman
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/spf13/viper v1.6.1
+## explicit
 github.com/spf13/viper
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0
@@ -254,6 +269,7 @@ golang.org/x/text/width
 google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.23.1
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/balancer
 google.golang.org/grpc/balancer/base
@@ -294,6 +310,7 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
 # k8s.io/apimachinery v0.17.3
+## explicit
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/errors
@@ -302,3 +319,6 @@ k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/util/validation/field
 # k8s.io/klog v1.0.0
 k8s.io/klog
+# github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3
+# github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
+# k8s.io/client-go => github.com/cilium/client-go v0.0.0-20200217141255-96fd08586691


### PR DESCRIPTION
Note that `go mod vendor` had to be re-run to sync `vendor/modules.txt` as Go v1.14 reported inconsistent vendoring (missing `explicit` and `replaced` directives in `vendor/modules.txt`).

/cc @michi-covalent 