### PR TITLE
vendor: mark goleak as explicit

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -239,6 +239,7 @@ go.mongodb.org/mongo-driver/bson/bsontype
 go.mongodb.org/mongo-driver/bson/primitive
 go.mongodb.org/mongo-driver/x/bsonx/bsoncore
 # go.uber.org/goleak v1.0.0
+## explicit
 go.uber.org/goleak
 go.uber.org/goleak/internal/stack
 # golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586


### PR DESCRIPTION
Essentially, this means running `go mod vendor` with Go 1.14 (I should have re-sync #146 before merging). This fixes the current test failure on master.