### PR TITLE
make: remove -mod=vendor from go commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TARGET=hubble
 all: hubble
 
 hubble:
-	$(GO) build -mod=vendor -o $(TARGET)
+	$(GO) build -o $(TARGET)
 
 install:
 	groupadd -f hubble
@@ -19,7 +19,7 @@ clean:
 	rm -f $(TARGET)
 
 test:
-	go test -timeout=30s -cover -mod=vendor $$(go list ./...)
+	go test -timeout=30s -cover $$(go list ./...)
 
 lint: check-fmt ineffassign
 ifeq (, $(shell which golint))


### PR DESCRIPTION
From the [Go 1.14 release notes](https://golang.org/doc/go1.14):

> When the main module contains a top-level vendor directory and its go.mod file specifies go 1.14 or higher, the go command now defaults to -mod=vendor for operations that accept that flag

Since the go.mod file now specifies go 1.14, it is no longer necessary to manually add the `-mod=vendor` flag to go commands.