### PR TITLE
endpoint: Define an interface to access endpoint fields

### DIFF
--- a/pkg/api/v1/endpoint.go
+++ b/pkg/api/v1/endpoint.go
@@ -235,6 +235,11 @@ func (es *Endpoints) GetEndpoint(ip net.IP) (endpoint *Endpoint, ok bool) {
 	return
 }
 
+// GetEndpointInfo returns the endpoint info that has the given ip.
+func (es *Endpoints) GetEndpointInfo(ip net.IP) (endpoint EndpointInfo, ok bool) {
+	return es.GetEndpoint(ip)
+}
+
 // GetEndpointByContainerID returns the endpoint that has the given container ID.
 func (es *Endpoints) GetEndpointByContainerID(id string) (*Endpoint, bool) {
 	es.mutex.RLock()

--- a/pkg/api/v1/interface.go
+++ b/pkg/api/v1/interface.go
@@ -46,3 +46,11 @@ type Flow interface {
 
 // This ensures that the protobuf definition implements the interface
 var _ Flow = &pb.Flow{}
+
+// EndpointInfo defines readable fields of a Cilium endpoint.
+type EndpointInfo interface {
+	GetID() uint64
+	GetK8sPodName() string
+	GetK8sNamespace() string
+	GetLabels() []string
+}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -36,6 +36,26 @@ type Endpoint struct {
 	Labels       []string   `json:"labels"`
 }
 
+// GetID returns the ID of the endpoint.
+func (e *Endpoint) GetID() uint64 {
+	return e.ID
+}
+
+// GetK8sPodName returns the pod name of the endpoint.
+func (e *Endpoint) GetK8sPodName() string {
+	return e.PodName
+}
+
+// GetK8sNamespace returns the pod namespace of the endpoint.
+func (e *Endpoint) GetK8sNamespace() string {
+	return e.PodNamespace
+}
+
+// GetLabels returns the labels of the endpoint.
+func (e *Endpoint) GetLabels() []string {
+	return e.Labels
+}
+
 // Event represents a single event observed and stored by Hubble
 type Event struct {
 	// Timestamp when event was observed in Hubble

--- a/pkg/cilium/ipcache.go
+++ b/pkg/cilium/ipcache.go
@@ -47,10 +47,10 @@ func (l *LegacyPodGetter) GetIPIdentity(ip net.IP) (identity ipcache.IPIdentity,
 	}
 
 	// fallback on local endpoints
-	if ep, ok := l.EndpointGetter.GetEndpoint(ip); ok {
+	if ep, ok := l.EndpointGetter.GetEndpointInfo(ip); ok {
 		return ipcache.IPIdentity{
-			Namespace: ep.PodNamespace,
-			PodName:   ep.PodName,
+			Namespace: ep.GetK8sNamespace(),
+			PodName:   ep.GetK8sPodName(),
 		}, true
 	}
 

--- a/pkg/cilium/ipcache_test.go
+++ b/pkg/cilium/ipcache_test.go
@@ -147,11 +147,7 @@ func TestLegacyPodGetter_GetPodNameOf(t *testing.T) {
 						return ipcache.IPIdentity{Namespace: "default", PodName: "xwing"}, true
 					},
 				},
-				EndpointGetter: &testutils.FakeEndpointsHandler{
-					FakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
-						return nil, false
-					},
-				},
+				EndpointGetter: &testutils.NoopEndpointGetter,
 			},
 			args: args{
 				ip: net.ParseIP("1.1.1.15"),
@@ -165,8 +161,8 @@ func TestLegacyPodGetter_GetPodNameOf(t *testing.T) {
 			name: "available in endpoints",
 			fields: fields{
 				IPGetter: &testutils.NoopIPGetter,
-				EndpointGetter: &testutils.FakeEndpointsHandler{
-					FakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
+				EndpointGetter: &testutils.FakeEndpointGetter{
+					OnGetEndpointInfo: func(_ net.IP) (v1.EndpointInfo, bool) {
 						return &v1.Endpoint{
 							ID:           16,
 							IPv4:         net.ParseIP("1.1.1.15"),
@@ -192,8 +188,8 @@ func TestLegacyPodGetter_GetPodNameOf(t *testing.T) {
 						return ipcache.IPIdentity{Namespace: "default", PodName: "xwing"}, true
 					},
 				},
-				EndpointGetter: &testutils.FakeEndpointsHandler{
-					FakeGetEndpoint: func(_ net.IP) (*v1.Endpoint, bool) {
+				EndpointGetter: &testutils.FakeEndpointGetter{
+					OnGetEndpointInfo: func(_ net.IP) (v1.EndpointInfo, bool) {
 						return &v1.Endpoint{
 							ID:           16,
 							IPv4:         net.ParseIP("1.1.1.15"),

--- a/pkg/parser/getters/getters.go
+++ b/pkg/parser/getters/getters.go
@@ -33,8 +33,8 @@ type DNSGetter interface {
 
 // EndpointGetter ...
 type EndpointGetter interface {
-	// GetEndpoint looks up endpoint by IP address.
-	GetEndpoint(ip net.IP) (endpoint *v1.Endpoint, ok bool)
+	// GetEndpointInfo looks up endpoint by IP address.
+	GetEndpointInfo(ip net.IP) (endpoint v1.EndpointInfo, ok bool)
 }
 
 // IdentityGetter ...

--- a/pkg/parser/threefour/parser.go
+++ b/pkg/parser/threefour/parser.go
@@ -228,13 +228,13 @@ func sortAndFilterLabels(labels []string, securityIdentity uint64) []string {
 func (p *Parser) resolveEndpoint(ip net.IP, securityIdentity uint64) *pb.Endpoint {
 	// for local endpoints, use the available endpoint information
 	if p.endpointGetter != nil {
-		if ep, ok := p.endpointGetter.GetEndpoint(ip); ok {
+		if ep, ok := p.endpointGetter.GetEndpointInfo(ip); ok {
 			return &pb.Endpoint{
-				ID:        ep.ID,
+				ID:        ep.GetID(),
 				Identity:  securityIdentity,
-				Namespace: ep.PodNamespace,
-				Labels:    sortAndFilterLabels(ep.Labels, securityIdentity),
-				PodName:   ep.PodName,
+				Namespace: ep.GetK8sNamespace(),
+				Labels:    sortAndFilterLabels(ep.GetLabels(), securityIdentity),
+				PodName:   ep.GetK8sPodName(),
 			}
 		}
 	}

--- a/pkg/parser/threefour/parser_test.go
+++ b/pkg/parser/threefour/parser_test.go
@@ -51,7 +51,7 @@ func TestL34Decode(t *testing.T) {
 		98, 0, 90, 176, 97, 0, 0}
 
 	endpointGetter := &testutils.FakeEndpointGetter{
-		OnGetEndpoint: func(ip net.IP) (endpoint *v1.Endpoint, ok bool) {
+		OnGetEndpointInfo: func(ip net.IP) (endpoint v1.EndpointInfo, ok bool) {
 			if ip.Equal(net.ParseIP("10.16.236.178")) {
 				return &v1.Endpoint{
 					ID:           1234,
@@ -154,7 +154,7 @@ func TestL34Decode(t *testing.T) {
 		0, 0, 0, 0, 0}
 
 	endpointGetter = &testutils.FakeEndpointGetter{
-		OnGetEndpoint: func(ip net.IP) (endpoint *v1.Endpoint, ok bool) {
+		OnGetEndpointInfo: func(ip net.IP) (endpoint v1.EndpointInfo, ok bool) {
 			if ip.Equal(net.ParseIP("ff02::1:ff00:b3e5")) {
 				return &v1.Endpoint{
 					ID: 1234,
@@ -528,7 +528,7 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 		Labels:       []string{"a", "b", "c"},
 	}
 	endpointGetter := &testutils.FakeEndpointGetter{
-		OnGetEndpoint: func(ip net.IP) (endpoint *v1.Endpoint, ok bool) {
+		OnGetEndpointInfo: func(ip net.IP) (endpoint v1.EndpointInfo, ok bool) {
 			return ep, true
 		},
 	}

--- a/pkg/testutils/fake.go
+++ b/pkg/testutils/fake.go
@@ -35,20 +35,20 @@ var NoopDNSGetter = FakeDNSGetter{
 
 // FakeEndpointGetter is used for unit tests that needs EndpointGetter.
 type FakeEndpointGetter struct {
-	OnGetEndpoint func(ip net.IP) (endpoint *v1.Endpoint, ok bool)
+	OnGetEndpointInfo func(ip net.IP) (endpoint v1.EndpointInfo, ok bool)
 }
 
-// GetEndpoint implements EndpointGetter.GetEndpoint.
-func (f *FakeEndpointGetter) GetEndpoint(ip net.IP) (endpoint *v1.Endpoint, ok bool) {
-	if f.OnGetEndpoint != nil {
-		return f.OnGetEndpoint(ip)
+// GetEndpointInfo implements EndpointGetter.GetEndpointInfo.
+func (f *FakeEndpointGetter) GetEndpointInfo(ip net.IP) (endpoint v1.EndpointInfo, ok bool) {
+	if f.OnGetEndpointInfo != nil {
+		return f.OnGetEndpointInfo(ip)
 	}
-	panic("OnGetEndpoint not set")
+	panic("OnGetEndpointInfo not set")
 }
 
 // NoopEndpointGetter always returns an empty response.
 var NoopEndpointGetter = FakeEndpointGetter{
-	OnGetEndpoint: func(ip net.IP) (endpoint *v1.Endpoint, ok bool) {
+	OnGetEndpointInfo: func(ip net.IP) (endpoint v1.EndpointInfo, ok bool) {
 		return nil, false
 	},
 }


### PR DESCRIPTION
This allows the embedded mode to use a different underlying endpoint
structure without having to convert to v1.Endpoint.

Ref #150

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>