### PR TITLE
ensure building fails on unsupported versions of Go

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Ensure build fails on versions of Go that are not supported by Hubble.
+// This build tag should be kept in sync with the version specified in go.mod.
+// +build go1.14
+
 package main
 
 import (


### PR DESCRIPTION
Every Go release brings its set of new features and other changes. When using these new features, the appropriate Go version should be used.

In some cases, using newly introduced features simply means that the code will no longer compile on older versions of Go. This would be the case if one starts using error wrapping introduced in Go 1.13 and trying to compile the code with an older version of Go for instance.

However, it is also possible that a new functionality change still compiles fine with an older version of Go, thus possibly introducing subtle bugs if the software is compiled with an older version of Go.
Transparent monotonic clock support introduced in Go 1.9 would fall into this category for example.

In summary, it is hard to guarantee support for multiple versions of Go without much effort.  Thus, if one tries to compile Hubble with an unsupported version of Go, it should fail. This commit introduces a build tag in package main to ensure the code does not compile with unsupported Go versions.

As an example, this is now what happens if one attempts to compile Hubble with Go 1.13 :

    $ go version
    go version go1.13.8 linux/amd64
    $ go build -mod=vendor -o hubble
    can't load package: package .: build constraints exclude all Go files in $GOPATH/src/github.com/cilium/hubble

Whereas with Go 1.14:

    $ go version
    go version go1.14 linux/amd6
    $ go build -mod=vendor -o hubble
    $ // compiled fine