### PR TITLE
 parser: Use numeric security identity from endpoint

### DIFF
--- a/pkg/api/v1/interface.go
+++ b/pkg/api/v1/interface.go
@@ -15,6 +15,7 @@
 package v1
 
 import (
+	"github.com/cilium/cilium/pkg/identity"
 	pb "github.com/cilium/hubble/api/v1/flow"
 
 	"github.com/gogo/protobuf/types"
@@ -50,6 +51,7 @@ var _ Flow = &pb.Flow{}
 // EndpointInfo defines readable fields of a Cilium endpoint.
 type EndpointInfo interface {
 	GetID() uint64
+	GetIdentity() identity.NumericIdentity
 	GetK8sPodName() string
 	GetK8sNamespace() string
 	GetLabels() []string

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -19,26 +19,33 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/pkg/identity"
 	pb "github.com/cilium/hubble/api/v1/flow"
 	"github.com/gogo/protobuf/types"
 )
 
 // Endpoint is the representation of an endpoint running in the Cilium agent
 type Endpoint struct {
-	Created      time.Time  `json:"created"`
-	Deleted      *time.Time `json:"deleted"`
-	ContainerIDs []string   `json:"container-ids"`
-	ID           uint64     `json:"id"`
-	IPv4         net.IP     `json:"ipv4"`
-	IPv6         net.IP     `json:"ipv6"`
-	PodName      string     `json:"pod-name"`
-	PodNamespace string     `json:"pod-namespace"`
-	Labels       []string   `json:"labels"`
+	Created      time.Time                `json:"created"`
+	Deleted      *time.Time               `json:"deleted"`
+	ContainerIDs []string                 `json:"container-ids"`
+	ID           uint64                   `json:"id"`
+	Identity     identity.NumericIdentity `json:"identity"`
+	IPv4         net.IP                   `json:"ipv4"`
+	IPv6         net.IP                   `json:"ipv6"`
+	PodName      string                   `json:"pod-name"`
+	PodNamespace string                   `json:"pod-namespace"`
+	Labels       []string                 `json:"labels"`
 }
 
 // GetID returns the ID of the endpoint.
 func (e *Endpoint) GetID() uint64 {
 	return e.ID
+}
+
+// GetIdentity returns the numerical security identity of the endpoint.
+func (e *Endpoint) GetIdentity() identity.NumericIdentity {
+	return e.Identity
 }
 
 // GetK8sPodName returns the pod name of the endpoint.

--- a/pkg/parser/endpoint/endpoint.go
+++ b/pkg/parser/endpoint/endpoint.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/identity"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 
 	v1 "github.com/cilium/hubble/pkg/api/v1"
@@ -29,6 +30,7 @@ import (
 // ParseEndpointFromModel parses all elements from modelEP into a Endpoint.
 func ParseEndpointFromModel(modelEP *models.Endpoint) *v1.Endpoint {
 	var ns, podName, containerID string
+	var securityIdentity identity.NumericIdentity
 	var labels []string
 	if modelEP.Status != nil {
 		if modelEP.Status.ExternalIdentifiers != nil {
@@ -36,12 +38,14 @@ func ParseEndpointFromModel(modelEP *models.Endpoint) *v1.Endpoint {
 			ns, podName = k8s.ParseNamespaceName(modelEP.Status.ExternalIdentifiers.PodName)
 		}
 		if modelEP.Status.Identity != nil {
+			securityIdentity = identity.NumericIdentity(modelEP.Status.Identity.ID)
 			labels = modelEP.Status.Identity.Labels
 			sort.Strings(labels)
 		}
 	}
 	ep := &v1.Endpoint{
 		ID:           uint64(modelEP.ID),
+		Identity:     securityIdentity,
 		PodName:      podName,
 		PodNamespace: ns,
 		Created:      time.Now(),

--- a/pkg/parser/endpoint/endpoint_test.go
+++ b/pkg/parser/endpoint/endpoint_test.go
@@ -104,14 +104,16 @@ func TestParseEndpointFromModel(t *testing.T) {
 					ID: 1,
 					Status: &models.EndpointStatus{
 						Identity: &models.Identity{
+							ID:     1234,
 							Labels: []string{"a=b", "c=d"},
 						},
 					},
 				},
 			},
 			want: &v1.Endpoint{
-				ID:     1,
-				Labels: []string{"a=b", "c=d"},
+				ID:       1,
+				Identity: 1234,
+				Labels:   []string{"a=b", "c=d"},
 			},
 		},
 	}

--- a/pkg/parser/threefour/parser.go
+++ b/pkg/parser/threefour/parser.go
@@ -231,7 +231,7 @@ func (p *Parser) resolveEndpoint(ip net.IP, securityIdentity uint64) *pb.Endpoin
 		if ep, ok := p.endpointGetter.GetEndpointInfo(ip); ok {
 			return &pb.Endpoint{
 				ID:        ep.GetID(),
-				Identity:  securityIdentity,
+				Identity:  uint64(ep.GetIdentity()),
 				Namespace: ep.GetK8sNamespace(),
 				Labels:    sortAndFilterLabels(ep.GetLabels(), securityIdentity),
 				PodName:   ep.GetK8sPodName(),

--- a/pkg/parser/threefour/parser_test.go
+++ b/pkg/parser/threefour/parser_test.go
@@ -522,6 +522,7 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 
 	ep := &v1.Endpoint{
 		ID:           1234,
+		Identity:     4567,
 		IPv4:         net.ParseIP("1.1.1.1"),
 		PodName:      "xwing",
 		PodNamespace: "default",
@@ -538,7 +539,7 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 
 	v0 := monitor.TraceNotifyV0{
 		Type:     byte(api.MessageTypeTrace),
-		SrcLabel: 456,
+		SrcLabel: 456, // overwritten by ep.Identity
 		Version:  monitor.TraceNotifyVersion0,
 	}
 
@@ -559,7 +560,7 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, ep.ID, f.Source.ID)
-	assert.Equal(t, uint64(v0.SrcLabel), f.Source.Identity)
+	assert.Equal(t, uint64(ep.Identity), f.Source.Identity)
 	assert.Equal(t, ep.PodNamespace, f.Source.Namespace)
 	assert.Equal(t, ep.Labels, f.Source.Labels)
 	assert.Equal(t, ep.PodName, f.Source.PodName)


### PR DESCRIPTION
This adds the numerical security identity to `v1.Endpoint` and the `EndpointInfo` interface. The `GetIdentity` function is also implemented by Cilium's `endpoint.Endpoint` struct (required for embedding).

The parser is modified use this newly available numeric security identity from the endpoint getter instead of relying on information from the `TraceNotify` struct.

This fixes a bug where the security identity was missing, because `TraceNotify` does not always contain the actual security identity (for example for `TRACE_FROM_LXC` events).

Fixes: #155