### PR TITLE
container: add a priority queue implementation for events

### DIFF
--- a/pkg/container/priority_queue.go
+++ b/pkg/container/priority_queue.go
@@ -1,0 +1,95 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"container/heap"
+
+	"github.com/cilium/hubble/pkg/api/v1"
+)
+
+// PriorityQueue is a priority queue of events that implements heap.Interface.
+// Events are ordered based on their timestamp value, the oldest event having
+// the higher priority.
+//
+// This implementation is loosely based on the priority queue example in
+// "container/heap".
+type PriorityQueue struct {
+	h minHeap
+}
+
+type minHeap []*v1.Event
+
+// Ensure that minHeap implements heap.Interface.
+var _ heap.Interface = (*minHeap)(nil)
+
+// NewPriorityQueue creates a new PriorityQueue with initial capacity n.
+func NewPriorityQueue(n int) *PriorityQueue {
+	h := make(minHeap, 0, n)
+	heap.Init(&h)
+	return &PriorityQueue{h}
+}
+
+// Len is the number of events in the queue.
+func (pq PriorityQueue) Len() int {
+	return pq.h.Len()
+}
+
+// Push adds event e to the queue.
+func (pq *PriorityQueue) Push(e *v1.Event) {
+	heap.Push(&pq.h, e)
+}
+
+// Pop removes and returns the oldest event in the queue. Pop returns nil if
+// the queue is empty.
+func (pq *PriorityQueue) Pop() *v1.Event {
+	event := heap.Pop(&pq.h).(*v1.Event)
+	return event
+}
+
+func (h minHeap) Len() int {
+	return len(h)
+}
+
+func (h minHeap) Less(i, j int) bool {
+	if h[i].Timestamp.GetSeconds() == h[j].Timestamp.GetSeconds() {
+		return h[i].Timestamp.GetNanos() < h[j].Timestamp.GetNanos()
+	}
+	return h[i].Timestamp.GetSeconds() < h[j].Timestamp.GetSeconds()
+}
+
+func (h minHeap) Swap(i, j int) {
+	n := len(h)
+	if (i >= 0 && i <= n-1) && (j >= 0 && j <= n-1) {
+		h[i], h[j] = h[j], h[i]
+	}
+}
+
+func (h *minHeap) Push(x interface{}) {
+	event := x.(*v1.Event)
+	*h = append(*h, event)
+}
+
+func (h *minHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	if n == 0 {
+		return (*v1.Event)(nil)
+	}
+	event := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	*h = old[0 : n-1]
+	return event
+}

--- a/pkg/container/priority_queue_test.go
+++ b/pkg/container/priority_queue_test.go
@@ -1,0 +1,98 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"testing"
+
+	"github.com/cilium/hubble/pkg/api/v1"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	e0 = &v1.Event{Timestamp: &types.Timestamp{Seconds: 1}}
+	e1 = &v1.Event{Timestamp: &types.Timestamp{Seconds: 1, Nanos: 1}}
+	e2 = &v1.Event{Timestamp: &types.Timestamp{Seconds: 2}}
+	e3 = &v1.Event{Timestamp: &types.Timestamp{Seconds: 3}}
+	e4 = &v1.Event{Timestamp: &types.Timestamp{Seconds: 4}}
+	e5 = &v1.Event{Timestamp: &types.Timestamp{Seconds: 5}}
+)
+
+func TestPriorityQueue(t *testing.T) {
+	pq := NewPriorityQueue(42)
+	assert.Equal(t, pq.Len(), 0)
+
+	// push some events to the queue
+	pq.Push(e1)
+	pq.Push(e2)
+
+	// try poping out these 2 events, the oldest one should pop out first
+	event := pq.Pop()
+	assert.Equal(t, event, e1)
+	event = pq.Pop()
+	assert.Equal(t, event, e2)
+
+	// calling pop on an empty priority queue should return nil
+	assert.Equal(t, pq.Len(), 0)
+	event = pq.Pop()
+	assert.Nil(t, event)
+
+	// let's push some events in seemingly random order
+	pq.Push(e5)
+	pq.Push(e3)
+	pq.Push(e1)
+	pq.Push(e4)
+	pq.Push(e2)
+	assert.Equal(t, pq.Len(), 5)
+
+	// now, when popped out, they should pop out in chronological order
+	event = pq.Pop()
+	assert.Equal(t, event, e1)
+	event = pq.Pop()
+	assert.Equal(t, event, e2)
+	event = pq.Pop()
+	assert.Equal(t, event, e3)
+	event = pq.Pop()
+	assert.Equal(t, event, e4)
+	event = pq.Pop()
+	assert.Equal(t, event, e5)
+	assert.Equal(t, pq.Len(), 0)
+}
+
+func TestPriorityQueue_WithEventsInTheSameSecond(t *testing.T) {
+	pq := NewPriorityQueue(2)
+	pq.Push(e1)
+	pq.Push(e0)
+	assert.Equal(t, pq.Len(), 2)
+	event := pq.Pop()
+	assert.Equal(t, event, e0)
+	event = pq.Pop()
+	assert.Equal(t, event, e1)
+}
+
+func TestPriorityQueue_WithInitialCapacity0(t *testing.T) {
+	pq := NewPriorityQueue(0)
+	assert.Equal(t, pq.Len(), 0)
+}
+
+func TestPriorityQueue_GrowingOverInitialCapacity(t *testing.T) {
+	pq := NewPriorityQueue(1)
+	assert.Equal(t, pq.Len(), 0)
+	pq.Push(e1)
+	pq.Push(e2)
+	assert.Equal(t, pq.Len(), 2)
+}

--- a/pkg/container/ring.go
+++ b/pkg/container/ring.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package container implements a ring buffer that can be accessed by multiple
-// RingReader readers.
 package container
 
 import (


### PR DESCRIPTION
This priority queue will be used for multi-node support in order to be able to re-order events in chronological order as they arrive.

Updates #89 