### PR TITLE
server: Make event queue size configurable

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -98,6 +98,7 @@ func New(log *logrus.Entry) *cobra.Command {
 				serviceCache,
 				payloadParser,
 				int(maxFlows),
+				int(eventQueueSize),
 				log,
 			)
 			s.Start()
@@ -113,6 +114,8 @@ func New(log *logrus.Entry) *cobra.Command {
 
 	serverCmd.Flags().StringArrayVarP(&listenClientUrls, "listen-client-urls", "", []string{serverSocketPath}, "List of URLs to listen on for client traffic.")
 	serverCmd.Flags().Uint32Var(&maxFlows, "max-flows", 131071, "Max number of flows to store in memory (gets rounded up to closest (2^n)-1")
+	serverCmd.Flags().Uint32Var(&eventQueueSize, "event-queue-size", 128, "Size of the event queue for received monitor events")
+
 	serverCmd.Flags().StringVar(&serveDurationVar, "duration", "", "Shut the server down after this duration")
 	serverCmd.Flags().StringVar(&nodeName, "node-name", os.Getenv(envNodeName), "Node name where hubble is running (defaults to value set in env variable '"+envNodeName+"'")
 
@@ -129,7 +132,8 @@ func New(log *logrus.Entry) *cobra.Command {
 
 // observerCmd represents the monitor command
 var (
-	maxFlows uint32
+	maxFlows       uint32
+	eventQueueSize uint32
 
 	serveDurationVar string
 	serveDuration    time.Duration

--- a/pkg/server/local_observer.go
+++ b/pkg/server/local_observer.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cilium/cilium/pkg/math"
 	pb "github.com/cilium/hubble/api/v1/flow"
 	"github.com/cilium/hubble/api/v1/observer"
 	v1 "github.com/cilium/hubble/pkg/api/v1"
@@ -81,13 +80,13 @@ type LocalObserverServer struct {
 func NewLocalServer(
 	payloadParser *parser.Parser,
 	maxFlows int,
+	eventQueueSize int,
 	logger *logrus.Entry,
 ) *LocalObserverServer {
 	return &LocalObserverServer{
-		log:  logger,
-		ring: container.NewRing(maxFlows),
-		// have a channel with 1% of the max flows that we can receive
-		events:        make(chan *pb.Payload, uint64(math.IntMin(maxFlows/100, 100))),
+		log:           logger,
+		ring:          container.NewRing(maxFlows),
+		events:        make(chan *pb.Payload, eventQueueSize),
 		stopped:       make(chan struct{}),
 		eventschan:    make(chan *observer.GetFlowsResponse, 100),
 		payloadParser: payloadParser,

--- a/pkg/server/local_observer_test.go
+++ b/pkg/server/local_observer_test.go
@@ -38,7 +38,7 @@ func TestNewLocalServer(t *testing.T) {
 		&testutils.NoopIPGetter,
 		&testutils.NoopServiceGetter)
 	require.NoError(t, err)
-	s := NewLocalServer(pp, 10, logger.GetLogger())
+	s := NewLocalServer(pp, 10, 0, logger.GetLogger())
 	assert.NotNil(t, s.GetStopped())
 	assert.NotNil(t, s.GetPayloadParser())
 	assert.NotNil(t, s.GetRingBuffer())
@@ -54,7 +54,7 @@ func TestLocalObserverServer_ServerStatus(t *testing.T) {
 		&testutils.NoopIPGetter,
 		&testutils.NoopServiceGetter)
 	require.NoError(t, err)
-	s := NewLocalServer(pp, 1, logger.GetLogger())
+	s := NewLocalServer(pp, 1, 0, logger.GetLogger())
 	res, err := s.ServerStatus(context.Background(), &observer.ServerStatusRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, &observer.ServerStatusResponse{NumFlows: 0, MaxFlows: 2}, res)
@@ -62,6 +62,7 @@ func TestLocalObserverServer_ServerStatus(t *testing.T) {
 
 func TestLocalObserverServer_GetFlows(t *testing.T) {
 	numFlows := 100
+	queueSize := 0
 	req := &observer.GetFlowsRequest{Number: uint64(10)}
 	i := 0
 	fakeServer := &FakeGetFlowsServer{
@@ -82,7 +83,7 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 		&testutils.NoopIPGetter,
 		&testutils.NoopServiceGetter)
 	require.NoError(t, err)
-	s := NewLocalServer(pp, numFlows, logger.GetLogger())
+	s := NewLocalServer(pp, numFlows, queueSize, logger.GetLogger())
 	go s.Start()
 
 	m := s.GetEventsChannel()

--- a/pkg/server/observer.go
+++ b/pkg/server/observer.go
@@ -60,12 +60,13 @@ func NewServer(
 	serviceCache *servicecache.ServiceCache,
 	payloadParser *parser.Parser,
 	maxFlows int,
+	eventQueueSize int,
 	logger *logrus.Entry,
 ) *ObserverServer {
 	ciliumState := cilium.NewCiliumState(ciliumClient, endpoints, ipCache, fqdnCache, serviceCache, logger)
 	return &ObserverServer{
 		log:         logger,
-		grpcServer:  NewLocalServer(payloadParser, maxFlows, logger),
+		grpcServer:  NewLocalServer(payloadParser, maxFlows, eventQueueSize, logger),
 		ciliumState: ciliumState,
 	}
 }

--- a/pkg/server/observer_test.go
+++ b/pkg/server/observer_test.go
@@ -135,7 +135,7 @@ func TestObserverServer_GetLastNFlows(t *testing.T) {
 	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff, logger.GetLogger())
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff, 0, logger.GetLogger())
 	if s.GetGRPCServer().GetRingBuffer().Cap() != 0x100 {
 		t.Errorf("s.ring.Len() got = %#v, want %#v", s.GetGRPCServer().GetRingBuffer().Cap(), 0x100)
 	}
@@ -205,7 +205,7 @@ func TestObserverServer_GetLastNFlows_MustNotBlock(t *testing.T) {
 	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0x4, logger.GetLogger())
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0x4, 0, logger.GetLogger())
 	if s.GetGRPCServer().GetRingBuffer().Cap() != 0x8 {
 		t.Errorf("s.ring.Len() got = %#v, want %#v", s.GetGRPCServer().GetRingBuffer().Cap(), 0x8)
 	}
@@ -271,7 +271,7 @@ func TestObserverServer_GetLastNFlows_With_Follow(t *testing.T) {
 	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff, logger.GetLogger())
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff, 0, logger.GetLogger())
 	if s.GetGRPCServer().GetRingBuffer().Cap() != 0x100 {
 		t.Errorf("s.ring.Len() got = %#v, want %#v", s.GetGRPCServer().GetRingBuffer().Cap(), 0x100)
 	}
@@ -373,7 +373,7 @@ func TestObserverServer_GetFlowsBetween(t *testing.T) {
 	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff, logger.GetLogger())
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 0xff, 0, logger.GetLogger())
 	if s.GetGRPCServer().GetRingBuffer().Cap() != 0x100 {
 		t.Errorf("s.ring.Len() got = %#v, want %#v", s.GetGRPCServer().GetRingBuffer().Cap(), 0x100)
 	}
@@ -468,7 +468,7 @@ func TestObserverServer_GetFlows(t *testing.T) {
 	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30, logger.GetLogger())
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30, 0, logger.GetLogger())
 	go s.Start()
 	m := s.GetGRPCServer().GetEventsChannel()
 	eth := layers.Ethernet{
@@ -533,7 +533,7 @@ func TestObserverServer_GetFlowsWithFilters(t *testing.T) {
 	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, ipc, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30, logger.GetLogger())
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30, 0, logger.GetLogger())
 	go s.Start()
 	m := s.GetGRPCServer().GetEventsChannel()
 	eth := layers.Ethernet{
@@ -612,7 +612,7 @@ func TestObserverServer_GetFlowsOfANonLocalPod(t *testing.T) {
 	pp, err := parser.New(es, fakeDummyCiliumClient, fqdnc, fakeIPGetter, svcc)
 	assert.NoError(t, err)
 
-	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30, logger.GetLogger())
+	s := NewServer(fakeDummyCiliumClient, es, ipc, fqdnc, svcc, pp, 30, 0, logger.GetLogger())
 	go s.Start()
 	m := s.GetGRPCServer().GetEventsChannel()
 	eth := layers.Ethernet{


### PR DESCRIPTION
When Hubble runs in embedded mode inside Cilium, the event queue size
must be big enough so the Hubble flow decoder can keep up with short
bursts of flows. The current calculation of 1% of the ring buffer size
has proven to be too small for embedded mode. For comparision, Cilium
monitor uses a event queue size of 1024 * NumberOfCPUs.

However, when Hubble runs as its own process reading from the Cilium
monitor socket, the Cilium monitor queue already acts as this buffer.
Therefore the Hubble event size is less critical. In fact, it was
capped at 100. This PR simplifies the logic and sets the default for
stand-alone mode to 128.

The value for embedded mode will be configurable in cilium-agent.

Ref: #161