### PR TITLE
add version information

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Authors of Hubble
+// Copyright 2017-2020 Authors of Hubble
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@ import (
 	"github.com/cilium/hubble/cmd/observe"
 	"github.com/cilium/hubble/cmd/serve"
 	"github.com/cilium/hubble/cmd/status"
+	"github.com/cilium/hubble/pkg"
 	"github.com/cilium/hubble/pkg/logger"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -34,9 +36,10 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "hubble",
-	Short: "CLI",
-	Long:  `Hubble is a utility to observe and inspect recent Cilium routed traffic in a cluster.`,
+	Use:     "hubble",
+	Short:   "CLI",
+	Long:    `Hubble is a utility to observe and inspect recent Cilium routed traffic in a cluster.`,
+	Version: pkg.Version,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.
@@ -68,6 +71,8 @@ func init() {
 	)
 	rootCmd.PersistentFlags().Lookup("cpuprofile").Hidden = true
 	rootCmd.PersistentFlags().Lookup("memprofile").Hidden = true
+
+	rootCmd.SetVersionTemplate("{{with .Name}}{{printf \"%s \" .}}{{end}}{{printf \"v%s\" .Version}}\n")
 
 	l := logger.GetLogger()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/hubble/cmd/observe"
 	"github.com/cilium/hubble/cmd/serve"
 	"github.com/cilium/hubble/cmd/status"
+	"github.com/cilium/hubble/cmd/version"
 	"github.com/cilium/hubble/pkg"
 	"github.com/cilium/hubble/pkg/logger"
 
@@ -77,9 +78,10 @@ func init() {
 	l := logger.GetLogger()
 
 	// initialize all subcommands
-	rootCmd.AddCommand(status.New())
-	rootCmd.AddCommand(serve.New(l))
 	rootCmd.AddCommand(observe.New())
+	rootCmd.AddCommand(serve.New(l))
+	rootCmd.AddCommand(status.New())
+	rootCmd.AddCommand(version.New())
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/cilium/hubble/pkg"
+
+	"github.com/spf13/cobra"
+)
+
+// New version command.
+func New() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Display detailed version information",
+		Long:  `Displays information about the version of this software.`,
+		Run: func(cmd *cobra.Command, _ []string) {
+			//TODO add more information such as commit hash
+			fmt.Printf("%s v%s compiled with %v on %v/%v\n", cmd.Root().Name(), pkg.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		},
+	}
+}

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+// Version is the software version.
+const Version = "0.0.0"


### PR DESCRIPTION
This PR adds a `--version` flag to the root command:
```
$ hubble --version
hubble v0.0.0
```
As well as a `version` subcommand for more detailed version information:
```
$ hubble version
hubble v0.0.0 compiled with go1.14 on linux/amd64
```

This command is meant to provide more information in the future such as the commit hash, the server version/mode, etc.