### PR TITLE
add git branch and hash information to version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@ BINDIR ?= /usr/local/bin
 IMAGE_REPOSITORY ?= quay.io/covalent/hubble
 CONTAINER_ENGINE ?= docker
 TARGET=hubble
+GIT_BRANCH != which git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD
+GIT_HASH != which git >/dev/null 2>&1 && git rev-parse --short HEAD
 
 all: hubble
 
 hubble:
-	$(GO) build -o $(TARGET)
+	$(GO) build -ldflags "-X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)'" -o $(TARGET)
 
 install:
 	groupadd -f hubble

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -30,8 +30,14 @@ func New() *cobra.Command {
 		Short: "Display detailed version information",
 		Long:  `Displays information about the version of this software.`,
 		Run: func(cmd *cobra.Command, _ []string) {
-			//TODO add more information such as commit hash
-			fmt.Printf("%s v%s compiled with %v on %v/%v\n", cmd.Root().Name(), pkg.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			var gitInfo string
+			switch {
+			case pkg.GitBranch != "" && pkg.GitHash != "":
+				gitInfo = fmt.Sprintf("@%s-%s", pkg.GitBranch, pkg.GitHash)
+			case pkg.GitHash != "":
+				gitInfo = fmt.Sprintf("@%s", pkg.GitHash)
+			}
+			fmt.Printf("%s v%s%s compiled with %v on %v/%v\n", cmd.Root().Name(), pkg.Version, gitInfo, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		},
 	}
 }

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -16,3 +16,11 @@ package pkg
 
 // Version is the software version.
 const Version = "0.0.0"
+
+// The following variables are set at compile time via LDFLAGS.
+var (
+	// GitBranch is the name of the git branch HEAD points to.
+	GitBranch string
+	// GitHash is the git checksum of the most recent commit in HEAD.
+	GitHash string
+)


### PR DESCRIPTION
Example output:

    $ hubble version
    hubble v0.0.0@master-9299103 compiled with go1.14 on linux/amd64

This information is omitted when `git` is not available:

    $ hubble version
    hubble v0.0.0 compiled with go1.14 on linux/amd64