### PR TITLE
peers: add Peers interface

### DIFF
--- a/pkg/peers/peers.go
+++ b/pkg/peers/peers.go
@@ -1,0 +1,27 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peers
+
+import (
+	"context"
+)
+
+// Peers is an interface that wraps methods to retrieve information about
+// hubble peers.
+type Peers interface {
+	// ListEndpoints returns a list of hubble endpoints in the form "host:port"
+	// or "[host]:port".
+	ListEndpoints(ctx context.Context) ([]string, error)
+}


### PR DESCRIPTION
Add Peers interface to retrieve information about hubble peers. This
interface will be implemented using the kube apisever when hubble runs
in client mode and via cilium node manager+ip cache when hubble runs
embedded into cilium. It thus needs to be implemented inside cilium for
hubble embedded mode.

One goal is for embedded hubble server to publish the list of hubble
peers via gRPC. However, a hubble client will also need to get the
address of at least one hubble server endpoint initially. This
information can be obtained via the kube apiserver once when starting.

It is likely that this interface will get extended as needs arise. For
example, a method to obtain a more succinct list of hubble endpoints
when using flows filters that would not require querying all hubble
peers for flows will probably be required at some points.

Ref #89 