### PR TITLE
server: Log server configuration parameters

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -181,10 +181,7 @@ func validateArgs(log *logrus.Entry) error {
 		serveDuration = d
 	}
 
-	log.WithFields(logrus.Fields{
-		"max-flows": maxFlows,
-		"duration":  serveDuration,
-	}).Info("Started server with args")
+	log.WithField("duration", serveDuration).Info("Started server with duration")
 
 	if metricsServer != "" {
 		EnableMetrics(log, metricsServer, enabledMetrics)

--- a/pkg/server/local_observer.go
+++ b/pkg/server/local_observer.go
@@ -83,6 +83,10 @@ func NewLocalServer(
 	eventQueueSize int,
 	logger *logrus.Entry,
 ) *LocalObserverServer {
+	logger.WithFields(logrus.Fields{
+		"maxFlows":       maxFlows,
+		"eventQueueSize": eventQueueSize,
+	}).Info("Configuring Hubble server")
 	return &LocalObserverServer{
 		log:           logger,
 		ring:          container.NewRing(maxFlows),


### PR DESCRIPTION
Move around log messages a bit so that the configuration parameters for
Hubble gets printed in both standalone and embedded mode. Info logs look
like this in standalone mode after the change:

    level=info msg="Started server with duration" duration=0s
    level=info msg="Configured metrics plugin" name=flow status=
    level=info msg="Configured metrics plugin" name=dns status="query,"
    level=info msg="Configured metrics plugin" name=drop status=
    level=info msg="Configuring Hubble server" eventQueueSize=128 maxFlows=131071
    level=info msg="Starting gRPC server on client-listener" client-listener="0.0.0.0:50051"
    level=info msg="Starting gRPC server on client-listener" client-listener="unix:///var/run/hubble.sock"

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>