### PR TITLE
container/ring: Fix various data races and race conditions

### DIFF
--- a/pkg/container/ring_reader_test.go
+++ b/pkg/container/ring_reader_test.go
@@ -213,6 +213,7 @@ func TestRingReader_NextFollow(t *testing.T) {
 				case <-ctx.Done():
 					timedOut = true
 				default:
+					assert.NotNil(t, got[i])
 				}
 				cancel()
 			}

--- a/pkg/container/ring_reader_test.go
+++ b/pkg/container/ring_reader_test.go
@@ -207,7 +207,7 @@ func TestRingReader_NextFollow(t *testing.T) {
 			var timedOut bool
 			var got []*v1.Event
 			for i := 0; i < tt.count; i++ {
-				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 				got = append(got, reader.NextFollow(ctx))
 				select {
 				case <-ctx.Done():
@@ -237,7 +237,7 @@ func TestRingReader_NextFollow_WithEmptyRing(t *testing.T) {
 	select {
 	case <-c:
 		t.Fail()
-	case <-time.After(1 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		// the call blocked, we're good
 	}
 	cancel()

--- a/pkg/container/ring_test.go
+++ b/pkg/container/ring_test.go
@@ -19,7 +19,6 @@ import (
 	"container/ring"
 	"context"
 	"reflect"
-	"sync"
 	"testing"
 
 	v1 "github.com/cilium/hubble/pkg/api/v1"
@@ -374,7 +373,6 @@ func TestRing_Write(t *testing.T) {
 				mask:  tt.fields.len,
 				data:  tt.fields.data,
 				write: tt.fields.write,
-				cond:  sync.NewCond(&sync.RWMutex{}),
 			}
 			r.Write(tt.args.event)
 			want := &Ring{


### PR DESCRIPTION
This is a first step towards fixing #82. This uses
`atomic.{Load,Store}Pointer` to access the individual slots in the ring
buffer, ensuring that each write is properly propagated to all other
threads. While it seems to satisfy the Go race detector, it seems that
running the unit test now with `-race` will now sometimes fail with a
semantic error, i.e. the ring buffer content is not what is expected.
This indicates that there remains a real race condition somewhere, this
commit only addresses the data race discovered by the Go race detector.

This means that #142 remains blocked, as we also have to find the root
cause for the race condition. Tests pass consistently when running
this commit without `-race` however, therefore it does not seem to
introduce any regressions.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>