### PR TITLE
api/endpoint: stop marking endpoints as deleted, just remove them

### DIFF
--- a/pkg/api/v1/endpoint.go
+++ b/pkg/api/v1/endpoint.go
@@ -16,17 +16,15 @@ package v1
 
 import (
 	"net"
-	"time"
 )
 
 // EndpointsHandler defines an interface for interacting with Cilium endpoints.
 type EndpointsHandler interface {
 	SyncEndpoints([]*Endpoint)
 	UpdateEndpoint(*Endpoint)
-	MarkDeleted(*Endpoint)
 	FindEPs(epID uint64, ns, pod string) []Endpoint
 	GetEndpoint(ip net.IP) (endpoint *Endpoint, ok bool)
-	GarbageCollect()
+	DeleteEndpoint(*Endpoint)
 	GetEndpointByContainerID(id string) (*Endpoint, bool)
 	GetEndpointByPodName(namespace string, name string) (*Endpoint, bool)
 }
@@ -40,8 +38,8 @@ func (e *Endpoint) EqualsByID(o *Endpoint) bool {
 			e.PodNamespace == o.PodNamespace
 }
 
-// SetFrom sets all fields that are not time based, i.e. Created and Deleted,
-// from the given endpoint 'o' in receiver's endpoint.
+// SetFrom sets all fields that are not time based (all but Created) from the
+// given endpoint 'o' in receiver's endpoint.
 func (e *Endpoint) SetFrom(o *Endpoint) {
 	if o.ContainerIDs != nil {
 		e.ContainerIDs = o.ContainerIDs
@@ -69,10 +67,6 @@ func (e *Endpoint) SetFrom(o *Endpoint) {
 // DeepCopy returns a deep copy of this endpoint.
 func (e *Endpoint) DeepCopy() *Endpoint {
 	result := *e
-	if e.Deleted != nil {
-		result.Deleted = &time.Time{}
-		*result.Deleted = *e.Deleted
-	}
 	if e.ContainerIDs != nil {
 		result.ContainerIDs = make([]string, len(e.ContainerIDs))
 		copy(result.ContainerIDs, e.ContainerIDs)
@@ -92,43 +86,32 @@ func (e *Endpoint) DeepCopy() *Endpoint {
 	return &result
 }
 
-// SyncEndpoints adds the given list of endpoints in the internal endpoint
-// slice. All endpoints in the internal endpoint slice that are not in the given
-// 'newEps' slice will be marked as "deleted".
+// SyncEndpoints adds the given list of endpoints to the internal endpoint
+// slice.
 func (es *Endpoints) SyncEndpoints(newEps []*Endpoint) {
 	if len(newEps) == 0 {
 		return
 	}
 	es.mutex.Lock()
 	defer es.mutex.Unlock()
-	// Mark all endpoints not found as deleted
-	for _, ep := range es.eps {
-		if ep.Deleted != nil {
-			continue
-		}
-		found := false
-		for _, updatedEp := range newEps {
-			if ep.EqualsByID(updatedEp) {
-
-				found = true
-				break
-			}
-		}
-		// If we haven't found it, it means we have lost, or haven't receive
-		// yet, an event signalizing that this endpoint was deleted.
-		if !found {
-			t := time.Now()
-			// TODO: remove leftover endpoints if the timestamp of the last
-			//  flow written is after the endpoint was deleted.
-			//  This requires a method in the ring buffer that returns
-			//  the older flow written.
-			ep.Deleted = &t
-		}
-	}
-
 	// Add the endpoint to the list of endpoints.
 	for _, updatedEp := range newEps {
 		es.updateEndpoint(updatedEp)
+	}
+	// some endpoints were deleted, remove them
+	if len(es.eps) != len(newEps) {
+		for _, ep := range es.eps {
+			found := false
+			for _, newEp := range newEps {
+				if newEp.EqualsByID(ep) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				es.deleteEndpoint(ep)
+			}
+		}
 	}
 }
 
@@ -139,10 +122,6 @@ func (es *Endpoints) FindEPs(epID uint64, namespace string, podName string) []En
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 	for _, ep := range es.eps {
-		if ep.Deleted != nil {
-			continue
-		}
-
 		// If is the endpoint ID we are looking for
 		if (epID != 0 && ep.ID == epID) ||
 			// The pod name is the one we are looking for
@@ -157,21 +136,13 @@ func (es *Endpoints) FindEPs(epID uint64, namespace string, podName string) []En
 	return eps
 }
 
-// updateEndpoint updates the given endpoint if already exists in the slice
-// of endpoints. If the endpoint does not exists, it is appended to the slice of
-// endpoints.
 func (es *Endpoints) updateEndpoint(updateEp *Endpoint) {
 	for _, ep := range es.eps {
-		if ep.Deleted != nil {
-			continue
-		}
 		// Update endpoint if the ID is the same *and* the podName and
 		// podNamespace do not exist, otherwise check if the given updateEp
 		// equals to ep.
 		if ep.EqualsByID(updateEp) {
-
 			ep.SetFrom(updateEp)
-
 			return
 		}
 	}
@@ -180,8 +151,8 @@ func (es *Endpoints) updateEndpoint(updateEp *Endpoint) {
 	es.eps = append(es.eps, updateEp)
 }
 
-// UpdateEndpoint updates the given endpoint if already exists in the slice
-// of endpoints. If the endpoint does not exists, it is appended to the slice of
+// UpdateEndpoint updates the given endpoint if already exists in the slice of
+// endpoints. If the endpoint does not exists, it is appended to the slice of
 // endpoints.
 func (es *Endpoints) UpdateEndpoint(updateEp *Endpoint) {
 	es.mutex.Lock()
@@ -189,50 +160,35 @@ func (es *Endpoints) UpdateEndpoint(updateEp *Endpoint) {
 	es.updateEndpoint(updateEp)
 }
 
-// MarkDeleted marks the given endpoint as deleted by setting the "Deleted"
-// endpoint field with the value of the given 'del' endpoint. If the endpoint is
-// not found in the internal slice of endpoints, it's added to the slice of
-// endpoints.
-func (es *Endpoints) MarkDeleted(del *Endpoint) {
-	es.mutex.Lock()
-	defer es.mutex.Unlock()
-	for _, ep := range es.eps {
-		if ep.Deleted != nil {
-			continue
-		}
-
-		if ep.EqualsByID(del) {
-			ep.Deleted = del.Deleted
-			return
-		}
-	}
-	es.eps = append(es.eps, del)
-}
-
-// GarbageCollect removes all endpoints marked as deleted from the collection
-func (es *Endpoints) GarbageCollect() {
-	es.mutex.Lock()
-	defer es.mutex.Unlock()
-	n := 0
-	for _, ep := range es.eps {
-		if ep.Deleted == nil {
-			es.eps[n] = ep
-			n++
-		}
-	}
-	es.eps = es.eps[:n]
-}
-
 // GetEndpoint returns the endpoint that has the given ip.
 func (es *Endpoints) GetEndpoint(ip net.IP) (endpoint *Endpoint, ok bool) {
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 	for _, ep := range es.eps {
-		if ep.Deleted == nil && (ep.IPv4.Equal(ip) || ep.IPv6.Equal(ip)) {
+		if ep.IPv4.Equal(ip) || ep.IPv6.Equal(ip) {
 			return ep.DeepCopy(), true
 		}
 	}
 	return
+}
+
+// DeleteEndpoint deletes the given endpoint if present in the endpoints slice.
+func (es *Endpoints) DeleteEndpoint(del *Endpoint) {
+	es.mutex.Lock()
+	defer es.mutex.Unlock()
+	es.deleteEndpoint(del)
+}
+
+func (es *Endpoints) deleteEndpoint(del *Endpoint) {
+	for i, ep := range es.eps {
+		if ep.EqualsByID(del) {
+			// deleting without preserving order avoids doing a new allocation
+			es.eps[i] = es.eps[len(es.eps)-1]
+			es.eps[len(es.eps)-1] = nil // avoid memory leak
+			es.eps = es.eps[:len(es.eps)-1]
+			break
+		}
+	}
 }
 
 // GetEndpointInfo returns the endpoint info that has the given ip.
@@ -245,9 +201,6 @@ func (es *Endpoints) GetEndpointByContainerID(id string) (*Endpoint, bool) {
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 	for _, ep := range es.eps {
-		if ep.Deleted != nil {
-			continue
-		}
 		for _, containerID := range ep.ContainerIDs {
 			if id == containerID {
 				return ep.DeepCopy(), true
@@ -262,9 +215,6 @@ func (es *Endpoints) GetEndpointByPodName(namespace string, name string) (*Endpo
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 	for _, ep := range es.eps {
-		if ep.Deleted != nil {
-			continue
-		}
 		if ep.PodNamespace == namespace && ep.PodName == name {
 			return ep.DeepCopy(), true
 		}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -27,7 +27,6 @@ import (
 // Endpoint is the representation of an endpoint running in the Cilium agent
 type Endpoint struct {
 	Created      time.Time                `json:"created"`
-	Deleted      *time.Time               `json:"deleted"`
 	ContainerIDs []string                 `json:"container-ids"`
 	ID           uint64                   `json:"id"`
 	Identity     identity.NumericIdentity `json:"identity"`

--- a/pkg/cilium/endpoint.go
+++ b/pkg/cilium/endpoint.go
@@ -65,7 +65,6 @@ func (s *State) syncEndpoints() {
 		}
 
 		s.endpoints.SyncEndpoints(parsedEPs)
-		s.endpoints.GarbageCollect()
 	}
 }
 
@@ -103,7 +102,7 @@ func (s *State) consumeEndpointEvents() {
 			}
 
 			ep := endpoint.ParseEndpointFromEndpointDeleteNotification(edn)
-			s.endpoints.MarkDeleted(ep)
+			s.endpoints.DeleteEndpoint(ep)
 		default:
 			s.log.WithFields(logrus.Fields{
 				"type":         int(an.Type),

--- a/pkg/parser/endpoint/endpoint.go
+++ b/pkg/parser/endpoint/endpoint.go
@@ -73,12 +73,10 @@ func ParseEndpointFromModel(modelEP *models.Endpoint) *v1.Endpoint {
 // ParseEndpointFromEndpointDeleteNotification returns an endpoint parsed from
 // the EndpointDeleteNotification.
 func ParseEndpointFromEndpointDeleteNotification(edn monitorAPI.EndpointDeleteNotification) *v1.Endpoint {
-	now := time.Now()
 	return &v1.Endpoint{
 		ID:           edn.ID,
 		PodName:      edn.PodName,
 		PodNamespace: edn.Namespace,
 		Created:      time.Unix(0, 0),
-		Deleted:      &now,
 	}
 }

--- a/pkg/parser/endpoint/endpoint_test.go
+++ b/pkg/parser/endpoint/endpoint_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/monitor/api"
-	"github.com/stretchr/testify/assert"
 
 	v1 "github.com/cilium/hubble/pkg/api/v1"
 )
@@ -123,8 +122,6 @@ func TestParseEndpointFromModel(t *testing.T) {
 			zeroTime := time.Unix(0, 0)
 			got.Created = zeroTime
 			tt.want.Created = zeroTime
-			got.Deleted = &zeroTime
-			tt.want.Deleted = &zeroTime
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ParseEndpointFromModel()\n =   %+v, \nwant %+v", got, tt.want)
 			}
@@ -163,8 +160,6 @@ func TestParseEndpointFromEndpointDeleteNotification(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseEndpointFromEndpointDeleteNotification(tt.args.edn)
-			assert.NotNil(t, got.Deleted)
-			got.Deleted = nil
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ParseEndpointFromEndpointDeleteNotification() = %v, want %v", got, tt.want)
 			}

--- a/pkg/testutils/fake.go
+++ b/pkg/testutils/fake.go
@@ -117,10 +117,9 @@ var NoopIdentityGetter = FakeIdentityGetter{
 type FakeEndpointsHandler struct {
 	FakeSyncEndpoints            func([]*v1.Endpoint)
 	FakeUpdateEndpoint           func(*v1.Endpoint)
-	FakeMarkDeleted              func(*v1.Endpoint)
+	FakeDeleteEndpoint           func(*v1.Endpoint)
 	FakeFindEPs                  func(epID uint64, ns, pod string) []v1.Endpoint
 	FakeGetEndpoint              func(ip net.IP) (endpoint *v1.Endpoint, ok bool)
-	FakeGarbageCollect           func()
 	FakeGetEndpointByContainerID func(id string) (endpoint *v1.Endpoint, ok bool)
 	FakeGetEndpointByPodName     func(namespace string, name string) (*v1.Endpoint, bool)
 }
@@ -143,13 +142,13 @@ func (f *FakeEndpointsHandler) UpdateEndpoint(ep *v1.Endpoint) {
 	panic("UpdateEndpoint(*v1.Endpoint) should not have been called since it was not defined")
 }
 
-// MarkDeleted calls FakeMarkDeleted.
-func (f *FakeEndpointsHandler) MarkDeleted(ep *v1.Endpoint) {
-	if f.FakeMarkDeleted != nil {
-		f.FakeMarkDeleted(ep)
+// DeleteEndpoint calls FakeDeleteEndpoint.
+func (f *FakeEndpointsHandler) DeleteEndpoint(ep *v1.Endpoint) {
+	if f.FakeDeleteEndpoint != nil {
+		f.FakeDeleteEndpoint(ep)
 		return
 	}
-	panic("MarkDeleted(ep *v1.Endpoint) should not have been called since it was not defined")
+	panic("DeleteEndpoint(*v1.Endpoint) should not have been called since it was not defined")
 }
 
 // FindEPs calls FakeFindEPs.
@@ -182,15 +181,6 @@ func (f *FakeEndpointsHandler) GetEndpointByPodName(namespace string, name strin
 		return f.FakeGetEndpointByPodName(namespace, name)
 	}
 	panic("GetEndpointByPodName(namespace string, name string) (ep *v1.Endpoint, ok bool) should not have been called since it was not defined")
-}
-
-// GarbageCollect calls FakeGarbageCollect.
-func (f *FakeEndpointsHandler) GarbageCollect() {
-	if f.FakeGarbageCollect != nil {
-		f.FakeGarbageCollect()
-		return
-	}
-	panic("GarbageCollect() should not have been called since it was not defined")
 }
 
 // FakeCiliumClient implements CliliumClient interface for unit testing.


### PR DESCRIPTION
The endpoint cache contained a few artifacts from early versions of
Hubble where flows were decoded late, i.e. when a gRPC flow requested
them. This meant that the endpoint cache had to keep "historic" data
about endpoints around. This was done by tracking endpoints deletion
time using Endpoint's Deleted field.

As now now, however, endpoint information is annotated as soon as a flow
is observed, making it pointless to keep deleted endpoints around.

This commit removes the Deleted field from the Endpoint struct and
adjust the code so that when an endpoint has to be deleted, it is
actually deleted rather than soft-deleted then garbage collected.
This also removes the need to garbage collect soft-deleted endpoints
from the endpoint cache.

Ref: #76