### PR TITLE
helm: Add priorityClassName for kube-system only

### DIFF
--- a/install/kubernetes/hubble/templates/daemonset.yaml
+++ b/install/kubernetes/hubble/templates/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         k8s-app: hubble
         kubernetes.io/cluster-service: "true"
     spec:
-      {{- if .Values.priorityClassName }}
+      {{- if and .Values.priorityClassName (eq .Release.Namespace "kube-system") }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
       affinity:

--- a/install/kubernetes/hubble/templates/deployment.yaml
+++ b/install/kubernetes/hubble/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         k8s-app: hubble-ui
     spec:
-      {{- if .Values.ui.priorityClassName }}
+      {{- if and .Values.priorityClassName (eq .Release.Namespace "kube-system") }}
       priorityClassName: {{ .Values.ui.priorityClassName }}
       {{- end }}
       serviceAccountName: hubble-ui


### PR DESCRIPTION
Don't mark Hubble pod as system-node-critical if it's not in kube-system
namespace. Later versions of Kubernetes don't have this restriction, but
for now I'm simply setting this field based on which namespace Hubble is
in.

Ref: https://github.com/kubernetes/kubernetes/pull/76310
Ref: https://github.com/cilium/cilium/issues/10504

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>