### PR TITLE
cmd: remove syscall references

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -21,12 +21,12 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"syscall"
 	"time"
 
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -391,7 +391,7 @@ func getFlows(client observer.ObserverClient, req *observer.GetFlowsRequest) err
 
 	go func() {
 		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		signal.Notify(sigs, unix.SIGINT, unix.SIGTERM)
 		select {
 		case <-sigs:
 		case <-ctx.Done():

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"syscall"
 
 	"github.com/cilium/hubble/api/v1/observer"
 	"github.com/cilium/hubble/pkg/api"
@@ -40,6 +39,7 @@ import (
 	"github.com/google/gops/agent"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -191,7 +191,7 @@ func setupListeners(listenClientUrls []string) (listeners map[string]net.Listene
 			listeners[listenClientURL] = socket
 		} else {
 			socketPath := strings.TrimPrefix(listenClientURL, "unix://")
-			syscall.Unlink(socketPath)
+			_ = unix.Unlink(socketPath)
 			var socket net.Listener
 			socket, err = net.Listen("unix", socketPath)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/goleak v1.0.0
+	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	google.golang.org/grpc v1.25.1
 	k8s.io/apimachinery v0.17.3
 )

--- a/pkg/printer/options.go
+++ b/pkg/printer/options.go
@@ -16,8 +16,7 @@ package printer
 
 import (
 	"io"
-	"os"
-	"syscall"
+	"io/ioutil"
 )
 
 // Output enum of the printer.
@@ -85,7 +84,7 @@ func Writer(w io.Writer) Option {
 // IgnoreStderr configures the output to not print any
 func IgnoreStderr() Option {
 	return func(opts *Options) {
-		opts.werr = os.NewFile(uintptr(syscall.Stderr), os.DevNull)
+		opts.werr = ioutil.Discard
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -254,6 +254,7 @@ golang.org/x/net/trace
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
+## explicit
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 # golang.org/x/text v0.3.2


### PR DESCRIPTION
The `syscall` package is deprecated since Go 1.4:

> Deprecated: this package is locked down. Callers should use the
> corresponding package in the golang.org/x/sys repository instead. That
> is also where updates required by new systems or versions should be
> applied. See https://golang.org/s/go1.4-syscall for more information.

In effect the `syscall` package is not updated, "not even to keep pace with changes in operating systems it references".

This commit replaces references to the `syscall` package by `golang.org/x/sys/unix`, as hinted by the Go documentation of the `syscall` package. This has already been done on Cilium (see https://github.com/cilium/cilium/issues/10116).