### PR TITLE
server: Introduce hooks for extending server functionality

### DIFF
--- a/pkg/server/serveroption/option.go
+++ b/pkg/server/serveroption/option.go
@@ -14,6 +14,24 @@
 
 package serveroption
 
+import (
+	"context"
+
+	pb "github.com/cilium/hubble/api/v1/flow"
+	"github.com/sirupsen/logrus"
+)
+
+// CiliumDaemon is a reference to the Cilium's Daemon when running inside Cilium
+type CiliumDaemon interface {
+	DebugEnabled() bool
+}
+
+// Server gives access to the Hubble server
+type Server interface {
+	GetOptions() Options
+	GetLogger() *logrus.Entry
+}
+
 // Default serves only as reference point for default values. Very useful for
 // the CLI to pick these up instead of defining own defaults that need to be
 // kept in sync.
@@ -26,13 +44,62 @@ var Default = Options{
 type Options struct {
 	// Both sizes should really be uint32 but it's better saved for a single
 	// refactor commit.
-
 	MaxFlows      int // max number of flows that can be stored in the ring buffer
 	MonitorBuffer int // buffer size for monitor payload
+
+	CiliumDaemon CiliumDaemon // when running inside Cilium, contains a reference to the daemon
+
+	OnServerInit   []OnServerInit   // invoked when the hubble server is initialized
+	OnMonitorEvent []OnMonitorEvent // invoked before an event is decoded
+	OnDecodedFlow  []OnDecodedFlow  // invoked after a flow has been decoded
 }
+
+// returning `stop: true` from a callback stops the execution chain, regardless
+// of the error encountered (for example, explicitly filtering out certain
+// events, or similar).
+type stop = bool
 
 // Option customizes the configuration of the hubble server.
 type Option func(o *Options) error
+
+// OnServerInit is invoked after all server options have been applied
+type OnServerInit interface {
+	OnServerInit(Server) error
+}
+
+// OnServerInitFunc implements OnServerInit for a single function
+type OnServerInitFunc func(Server) error
+
+// OnServerInit is invoked after all server options have been applied
+func (f OnServerInitFunc) OnServerInit(srv Server) error {
+	return f(srv)
+}
+
+// OnMonitorEvent is invoked before each monitor event is decoded
+type OnMonitorEvent interface {
+	OnMonitorEvent(context.Context, *pb.Payload) (stop, error)
+}
+
+// OnMonitorEventFunc implements OnMonitorEvent for a single function
+type OnMonitorEventFunc func(context.Context, *pb.Payload) (stop, error)
+
+// OnMonitorEvent is invoked before each monitor event is decoded
+func (f OnMonitorEventFunc) OnMonitorEvent(ctx context.Context, payload *pb.Payload) (stop, error) {
+	return f(ctx, payload)
+}
+
+// OnDecodedFlow is invoked after a flow has been decoded
+type OnDecodedFlow interface {
+	OnDecodedFlow(context.Context, *pb.Flow) (stop, error)
+}
+
+// OnDecodedFlowFunc implements OnDecodedFlow for a single function
+type OnDecodedFlowFunc func(context.Context, *pb.Flow) (stop, error)
+
+// OnDecodedFlow is invoked after a flow has been decoded
+func (f OnDecodedFlowFunc) OnDecodedFlow(ctx context.Context, flow *pb.Flow) (stop, error) {
+	return f(ctx, flow)
+}
 
 // WithMonitorBuffer controls the size of the buffered channel between the
 // monitor socket and the hubble ring buffer.
@@ -49,4 +116,51 @@ func WithMaxFlows(size int) Option {
 		o.MaxFlows = size
 		return nil
 	}
+}
+
+// WithCiliumDaemon provides access to the Cilium daemon via downcast
+func WithCiliumDaemon(daemon CiliumDaemon) Option {
+	return func(o *Options) error {
+		o.CiliumDaemon = daemon
+		return nil
+	}
+}
+
+// WithOnServerInit adds a new callback to be invoked after server initialization
+func WithOnServerInit(f OnServerInit) Option {
+	return func(o *Options) error {
+		o.OnServerInit = append(o.OnServerInit, f)
+		return nil
+	}
+}
+
+// WithOnServerInitFunc adds a new callback to be invoked after server initialization
+func WithOnServerInitFunc(f func(Server) error) Option {
+	return WithOnServerInit(OnServerInitFunc(f))
+}
+
+// WithOnMonitorEvent adds a new callback to be invoked before decoding
+func WithOnMonitorEvent(f OnMonitorEvent) Option {
+	return func(o *Options) error {
+		o.OnMonitorEvent = append(o.OnMonitorEvent, f)
+		return nil
+	}
+}
+
+// WithOnMonitorEventFunc adds a new callback to be invoked before decoding
+func WithOnMonitorEventFunc(f func(context.Context, *pb.Payload) (stop, error)) Option {
+	return WithOnMonitorEvent(OnMonitorEventFunc(f))
+}
+
+// WithOnDecodedFlow adds a new callback to be invoked after decoding
+func WithOnDecodedFlow(f OnDecodedFlow) Option {
+	return func(o *Options) error {
+		o.OnDecodedFlow = append(o.OnDecodedFlow, f)
+		return nil
+	}
+}
+
+// WithOnDecodedFlowFunc adds a new callback to be invoked after decoding
+func WithOnDecodedFlowFunc(f func(context.Context, *pb.Flow) (stop, error)) Option {
+	return WithOnDecodedFlow(OnDecodedFlowFunc(f))
 }


### PR DESCRIPTION
This introduces hooks to allow libraries to extend the way Hubble
processes events and flows. An example of this could be the metrics
package, which is currently hard-coded into the decoding pipeline.
This commit introduces three initial hooks in the server:

  1. `OnServerInit`: Invoked after all server options have been parsed.
     This is mostly intended for hooks to obtain the finalized list of
     server properties, for example to obtain a reference to the
     Cilium daemon when running inside Cilium.
  2. `OnMonitorEvent`: Invoked after an Cilium monitor event has been
     observed, but not yet decoded.
  3. `OnDecodedFlow`: Invoked after the parser has decoded the event,
     provides write access to the fully populated `pb.Flow` before it
     is added to the ring buffer.

Co-Authored-By: Glib Smaga <code@gsmaga.com>
Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>

---

Actual users of this API (like a revamped `metrics` package) will be added in future PRs, once the feedback (e.g. proposals regarding naming) for this PR has been addressed.