### PR TITLE
fqdn: Refactor FqdnCache interface

### DIFF
--- a/pkg/cilium/dns.go
+++ b/pkg/cilium/dns.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/hubble/pkg/parser/getters"
 )
 
 const (
@@ -29,9 +30,9 @@ const (
 
 // FqdnCache defines an interface for caching FQDN info from Cilium.
 type FqdnCache interface {
+	getters.DNSGetter
 	InitializeFrom(entries []*models.DNSLookup)
 	AddDNSLookup(epID uint64, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32)
-	GetNamesOf(epID uint64, ip net.IP) []string
 }
 
 // syncFQDNCache regularily syncs DNS lookups from Cilium into our local FQDN

--- a/pkg/cilium/dns_test.go
+++ b/pkg/cilium/dns_test.go
@@ -20,42 +20,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cilium/cilium/api/v1/models"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/cilium/hubble/pkg/logger"
+	"github.com/cilium/hubble/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 )
-
-type fakeFQDNCache struct {
-	fakeInitializeFrom func(entries []*models.DNSLookup)
-	fakeAddDNSLookup   func(epID uint64, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32)
-	fakeGetNamesOf     func(epID uint64, ip net.IP) []string
-}
-
-func (f *fakeFQDNCache) InitializeFrom(entries []*models.DNSLookup) {
-	if f.fakeInitializeFrom != nil {
-		f.fakeInitializeFrom(entries)
-		return
-	}
-	panic("InitializeFrom([]*models.DNSLookup) should not have been called since it was not defined")
-}
-
-func (f *fakeFQDNCache) AddDNSLookup(epID uint64, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32) {
-	if f.fakeAddDNSLookup != nil {
-		f.fakeAddDNSLookup(epID, lookupTime, domainName, ips, ttl)
-		return
-	}
-	panic("AddDNSLookup(uint64, time.Time, string, []net.IP, uint32) should not have been called since it was not defined")
-}
-
-func (f *fakeFQDNCache) GetNamesOf(epID uint64, ip net.IP) []string {
-	if f.fakeGetNamesOf != nil {
-		return f.fakeGetNamesOf(epID, ip)
-	}
-	panic("GetNamesOf(uint64, net.IP) should not have been called since it was not defined")
-}
 
 func TestObserverServer_consumeLogRecordNotifyChannel(t *testing.T) {
 	wg := sync.WaitGroup{}
@@ -89,8 +60,8 @@ func TestObserverServer_consumeLogRecordNotifyChannel(t *testing.T) {
 			},
 		},
 	}
-	fakeFQDNCache := &fakeFQDNCache{
-		fakeAddDNSLookup: func(epID uint64, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32) {
+	fakeFQDNCache := &testutils.FakeFQDNCache{
+		OnAddDNSLookup: func(epID uint64, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32) {
 			defer wg.Done()
 			assert.Equal(t, uint64(123), epID)
 			assert.Equal(t, []net.IP{net.ParseIP("1.2.3.4")}, ips)

--- a/pkg/parser/seven/parser_test.go
+++ b/pkg/parser/seven/parser_test.go
@@ -99,7 +99,7 @@ func TestDecodeL7HTTPRecord(t *testing.T) {
 
 	data := encodeL7Record(t, lr)
 
-	dnsGetter := &testutils.FakeDNSGetter{
+	dnsGetter := &testutils.FakeFQDNCache{
 		OnGetNamesOf: func(epID uint64, ip net.IP) (names []string) {
 			ipStr := ip.String()
 			switch {

--- a/pkg/parser/threefour/parser_test.go
+++ b/pkg/parser/threefour/parser_test.go
@@ -62,7 +62,7 @@ func TestL34Decode(t *testing.T) {
 			return nil, false
 		},
 	}
-	dnsGetter := &testutils.FakeDNSGetter{
+	dnsGetter := &testutils.FakeFQDNCache{
 		OnGetNamesOf: func(epID uint64, ip net.IP) (names []string) {
 			if epID == 1234 {
 				switch {
@@ -163,7 +163,7 @@ func TestL34Decode(t *testing.T) {
 			return nil, false
 		},
 	}
-	dnsGetter = &testutils.FakeDNSGetter{
+	dnsGetter = &testutils.FakeFQDNCache{
 		OnGetNamesOf: func(epID uint64, ip net.IP) (names []string) {
 			if epID == 1234 {
 				switch {


### PR DESCRIPTION
- Define GetNamesOf by composing getters.DNSGetter instead of redefining
  the same method.
- Move FakeFQDNCache to testutils package.
- Remove FakeDNSGetter since FakeFQDNCache can act as a fake DNSGetter.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>