### PR TITLE
Set version to 0.6.0-dev

### DIFF
--- a/pkg/version.go
+++ b/pkg/version.go
@@ -15,7 +15,7 @@
 package pkg
 
 // Version is the software version.
-const Version = "0.0.0"
+const Version = "0.6.0-dev"
 
 // The following variables are set at compile time via LDFLAGS.
 var (


### PR DESCRIPTION
Not much can be done for 0.5.0 without force pushing the tag. I'll put together a releasing.md to make sure some things like correcting the version before tagging are checked off.

https://github.com/cilium/hubble/issues/201

Signed-off-by: Glib Smaga <code@gsmaga.com>