### PR TITLE
cmd/serve: refactor, introduce Server struct and options

### DIFF
--- a/cmd/serve/option.go
+++ b/cmd/serve/option.go
@@ -1,0 +1,128 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serve
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/cilium/hubble/pkg/api"
+	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/hubble/pkg/server"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// DefaultOptions is the reference point for default values.
+var DefaultOptions = Options{
+	Listeners: make(map[string]net.Listener),
+}
+
+// Options stores all the configuration values for the hubble server.
+type Options struct {
+	Listeners       map[string]net.Listener
+	HealthService   *health.Server
+	ObserverService *server.GRPCServer
+}
+
+// Option customizes then configuration of the hubble server.
+type Option func(o *Options) error
+
+// WithListeners configures listeners. Addresses that are prefixed with
+// 'unix://' are assumed to be UNIX domain sockets, in which case appropriate
+// permissions are tentatively set and the group owner is set to socketGroup.
+// Otherwise, the address is assumed to be TCP.
+func WithListeners(addresses []string, socketGroup string) Option {
+	return func(o *Options) error {
+		var opt Option
+		for _, address := range addresses {
+			if strings.HasPrefix(address, "unix://") {
+				opt = WithUnixSocketListener(address, socketGroup)
+			} else {
+				opt = WithTCPListener(address)
+			}
+			if err := opt(o); err != nil {
+				for _, l := range o.Listeners {
+					l.Close()
+				}
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// WithTCPListener configures a TCP listener with the address.
+func WithTCPListener(address string) Option {
+	return func(o *Options) error {
+		socket, err := net.Listen("tcp", address)
+		if err != nil {
+			return err
+		}
+		if _, exist := o.Listeners[address]; exist {
+			socket.Close()
+			return fmt.Errorf("listener already configured: %s", address)
+		}
+		o.Listeners[address] = socket
+		return nil
+	}
+}
+
+// WithUnixSocketListener configures a unix domain socket listener with the
+// given file path. When the process runs in privileged mode, the file group
+// owner is set to socketGroup.
+func WithUnixSocketListener(path string, socketGroup string) Option {
+	return func(o *Options) error {
+		socketPath := strings.TrimPrefix(path, "unix://")
+		unix.Unlink(socketPath)
+		socket, err := net.Listen("unix", socketPath)
+		if err != nil {
+			return err
+		}
+		if os.Getuid() == 0 {
+			if err := api.SetDefaultPermissions(socketPath, socketGroup); err != nil {
+				return err
+			}
+		}
+		if _, exist := o.Listeners[path]; exist {
+			socket.Close()
+			unix.Unlink(socketPath)
+			return fmt.Errorf("listener already configured: %s", path)
+		}
+		o.Listeners[path] = socket
+		return nil
+	}
+}
+
+// WithHealthService configures the server to expose the gRPC health service.
+func WithHealthService() Option {
+	return func(o *Options) error {
+		healthSvc := health.NewServer()
+		healthSvc.SetServingStatus(v1.ObserverServiceName, healthpb.HealthCheckResponse_SERVING)
+		o.HealthService = healthSvc
+		return nil
+	}
+}
+
+// WithObserverService configures the server to expose the given observer server service.
+func WithObserverService(svc server.GRPCServer) Option {
+	return func(o *Options) error {
+		o.ObserverService = &svc
+		return nil
+	}
+}

--- a/cmd/serve/server.go
+++ b/cmd/serve/server.go
@@ -1,0 +1,74 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serve
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/cilium/hubble/api/v1/observer"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// Server is hubble's gRPC server.
+type Server struct {
+	log  *logrus.Entry
+	srv  *grpc.Server
+	opts Options
+}
+
+// NewServer creates a new hubble gRPC server.
+func NewServer(log *logrus.Entry, options ...Option) (*Server, error) {
+	opts := DefaultOptions
+	for _, opt := range options {
+		if err := opt(&opts); err != nil {
+			return nil, fmt.Errorf("failed to apply option: %v", err)
+		}
+	}
+	return &Server{log: log, opts: opts}, nil
+}
+
+func (s *Server) initGRPCServer() {
+	srv := grpc.NewServer()
+	if s.opts.HealthService != nil {
+		healthpb.RegisterHealthServer(srv, s.opts.HealthService)
+	}
+	if s.opts.ObserverService != nil {
+		observer.RegisterObserverServer(srv, *s.opts.ObserverService)
+	}
+	s.srv = srv
+}
+
+// Serve starts the hubble server. It accepts new connections on configured
+// listeners. Stop should be called to stop the server.
+func (s *Server) Serve() error {
+	s.initGRPCServer()
+	for name, listener := range s.opts.Listeners {
+		go func(name string, listener net.Listener) {
+			s.log.WithField("listener", name).Info("Starting gRPC server on listener")
+			if err := s.srv.Serve(listener); err != nil {
+				s.log.WithError(err).Error("failed to close grpc server")
+			}
+		}(name, listener)
+	}
+	return nil
+}
+
+// Stop stops the hubble server.
+func (s *Server) Stop() {
+	s.srv.Stop()
+}


### PR DESCRIPTION
When running in embedded mode, Hubble server will implement additional
gRPC services that do not exist in standalone mode (notably, the
in-development service for Hubble peers discovery that will be used by
the multi-node feature and will be a Hubble embedded only feature).

Parts of cmd/serve are already used by embedded Hubble. However, as the
code stood before this commit, customizing the Hubble server to add new
gRPC services for embedded mode without affecting standalone mode was
not possible.

This commit creates a new Server struct that can be configured using
options. For Hubble standalone, this commit brings no functional
changes. However, it will enable Hubble embedded to configure additional
gRPC services.

Ref: #89 