### PR TITLE
cmd/serve: remove global default options

### DIFF
--- a/cmd/serve/option.go
+++ b/cmd/serve/option.go
@@ -29,17 +29,19 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
-// DefaultOptions is the reference point for default values.
-var DefaultOptions = Options{
-	Listeners: make(map[string]net.Listener),
-}
-
 // Options stores all the configuration values for the hubble server.
 type Options struct {
 	Listeners       map[string]net.Listener
 	HealthService   *health.Server
 	ObserverService *server.GRPCServer
 	PeerService     *peer.PeerServer
+}
+
+// newOptions creates new Options with default values.
+func newOptions() Options {
+	return Options{
+		Listeners: make(map[string]net.Listener),
+	}
 }
 
 // Option customizes then configuration of the hubble server.

--- a/cmd/serve/server.go
+++ b/cmd/serve/server.go
@@ -34,7 +34,7 @@ type Server struct {
 
 // NewServer creates a new hubble gRPC server.
 func NewServer(log *logrus.Entry, options ...Option) (*Server, error) {
-	opts := DefaultOptions
+	opts := newOptions()
 	for _, opt := range options {
 		if err := opt(&opts); err != nil {
 			return nil, fmt.Errorf("failed to apply option: %v", err)


### PR DESCRIPTION
This commits removes the global variable DefaultOptions in favor of a
private constructor.

The problem with DefaultOptions as a global variable is that it gets
modified the first time NewServer is called. Thus, subsequent calls to
NewServer instantiate a server with modified default options (with an
existing listener typically) leading to unpredictable behavior.