### PR TITLE
cmd: Introduce hubble_{serve,pprof} build tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,14 @@ CONTAINER_ENGINE ?= docker
 TARGET=hubble
 GIT_BRANCH != which git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD
 GIT_HASH != which git >/dev/null 2>&1 && git rev-parse --short HEAD
+GOTAGS ?= hubble_serve
 
 TEST_TIMEOUT ?= 5s
 
 all: hubble
 
 hubble:
-	$(GO) build -ldflags "-X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)'" -o $(TARGET)
+	$(GO) build $(if $(GOTAGS),-tags $(GOTAGS)) -ldflags "-X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)'" -o $(TARGET)
 
 install:
 	groupadd -f hubble

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,24 +18,17 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
-	"runtime/pprof"
 
 	"github.com/cilium/hubble/cmd/observe"
-	"github.com/cilium/hubble/cmd/serve"
 	"github.com/cilium/hubble/cmd/status"
 	"github.com/cilium/hubble/cmd/version"
 	"github.com/cilium/hubble/pkg"
-	"github.com/cilium/hubble/pkg/logger"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 var (
-	cfgFile                        string
-	cpuprofile, memprofile         string
-	cpuprofileFile, memprofileFile *os.File
+	cfgFile string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -46,45 +39,6 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true, // this is being handled in main, no need to duplicate error messages
 	SilenceUsage:  true,
 	Version:       pkg.Version,
-	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-		return pprofInit()
-	},
-	PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
-		return pprofTearDown()
-	},
-}
-
-func pprofInit() error {
-	var err error
-	if cpuprofile != "" {
-		cpuprofileFile, err = os.Create(cpuprofile)
-		if err != nil {
-			return fmt.Errorf("failed to create cpu profile: %v", err)
-		}
-		pprof.StartCPUProfile(cpuprofileFile)
-	}
-	if memprofile != "" {
-		memprofileFile, err = os.Create(memprofile)
-		if err != nil {
-			return fmt.Errorf("failed to create memory profile: %v", err)
-		}
-	}
-	return nil
-}
-
-func pprofTearDown() error {
-	if cpuprofileFile != nil {
-		pprof.StopCPUProfile()
-		cpuprofileFile.Close()
-	}
-	if memprofileFile != nil {
-		runtime.GC() // get up-to-date statistics
-		if err := pprof.WriteHeapProfile(memprofileFile); err != nil {
-			return fmt.Errorf("failed to write memory profile: %v", err)
-		}
-		memprofileFile.Close()
-	}
-	return nil
 }
 
 // Execute adds all child commands to the root command sets flags
@@ -103,22 +57,10 @@ func init() {
 	rootCmd.AddCommand(newCmdCompletion(os.Stdout))
 	rootCmd.SetErr(os.Stderr)
 
-	rootCmd.PersistentFlags().StringVar(&cpuprofile,
-		"cpuprofile", "", "Enable CPU profiling",
-	)
-	rootCmd.PersistentFlags().StringVar(&memprofile,
-		"memprofile", "", "Enable memory profiling",
-	)
-	rootCmd.PersistentFlags().Lookup("cpuprofile").Hidden = true
-	rootCmd.PersistentFlags().Lookup("memprofile").Hidden = true
-
 	rootCmd.SetVersionTemplate("{{with .Name}}{{printf \"%s \" .}}{{end}}{{printf \"v%s\" .Version}}\n")
-
-	l := logger.GetLogger()
 
 	// initialize all subcommands
 	rootCmd.AddCommand(observe.New())
-	rootCmd.AddCommand(serve.New(l))
 	rootCmd.AddCommand(status.New())
 	rootCmd.AddCommand(version.New())
 }

--- a/cmd/root_pprof.go
+++ b/cmd/root_pprof.go
@@ -1,0 +1,94 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build hubble_serve hubble_pprof
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/pprof"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cpuprofile, memprofile         string
+	cpuprofileFile, memprofileFile *os.File
+)
+
+func pprofInit() error {
+	var err error
+	if cpuprofile != "" {
+		cpuprofileFile, err = os.Create(cpuprofile)
+		if err != nil {
+			return fmt.Errorf("failed to create cpu profile: %v", err)
+		}
+		pprof.StartCPUProfile(cpuprofileFile)
+	}
+	if memprofile != "" {
+		memprofileFile, err = os.Create(memprofile)
+		if err != nil {
+			return fmt.Errorf("failed to create memory profile: %v", err)
+		}
+	}
+	return nil
+}
+
+func pprofTearDown() error {
+	if cpuprofileFile != nil {
+		pprof.StopCPUProfile()
+		cpuprofileFile.Close()
+	}
+	if memprofileFile != nil {
+		runtime.GC() // get up-to-date statistics
+		if err := pprof.WriteHeapProfile(memprofileFile); err != nil {
+			return fmt.Errorf("failed to write memory profile: %v", err)
+		}
+		memprofileFile.Close()
+	}
+	return nil
+}
+
+func init() {
+	persistentPreRunE := rootCmd.PersistentPreRunE
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if persistentPreRunE != nil {
+			if err := persistentPreRunE(cmd, args); err != nil {
+				return err
+			}
+		}
+		return pprofInit()
+	}
+	prersistentPostRunE := rootCmd.PersistentPostRunE
+	rootCmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
+		if prersistentPostRunE != nil {
+			if err := prersistentPostRunE(cmd, args); err != nil {
+				return err
+			}
+		}
+		return pprofTearDown()
+	}
+
+	rootCmd.PersistentFlags().StringVar(&cpuprofile,
+		"cpuprofile", "", "Enable CPU profiling",
+	)
+	rootCmd.PersistentFlags().StringVar(&memprofile,
+		"memprofile", "", "Enable memory profiling",
+	)
+	rootCmd.PersistentFlags().Lookup("cpuprofile").Hidden = true
+	rootCmd.PersistentFlags().Lookup("memprofile").Hidden = true
+}

--- a/cmd/root_serve.go
+++ b/cmd/root_serve.go
@@ -1,0 +1,27 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build hubble_serve
+
+package cmd
+
+import (
+	"github.com/cilium/hubble/cmd/serve"
+	"github.com/cilium/hubble/pkg/logger"
+)
+
+func init() {
+	l := logger.GetLogger()
+	rootCmd.AddCommand(serve.New(l))
+}


### PR DESCRIPTION
This introduces a new build tag for both the standalone hubble serve
command, as well as the profiling intrastructure. Both features are
enabled in our Makefile by default, so this should not introduce any
functional changes to current end-users.

The motivation for this change is to enable a hubble/cilium hybrid
client binary that depending on its `argv[0]` name will either dispatch
to the Hubble or Cilium client command-line interface. Since we do not
want to ship the Hubble standalone server code in a binary intended for
client use only, the serve subcommand (and pprof) is only included when
the corresponding `hubble_serve` build tag is set.

Profiling is automatically enabled if `hubble_serve` is set, but can
also be enabled separately for client use with `hubble_pprof`.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>