### PR TITLE
update Go version to v1.14.2

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,7 +15,7 @@ jobs:
         path: go/src/github.com/cilium/hubble
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.14.1'
+        go-version: '1.14.2'
     - name: Run static checks
       env:
         GOPATH: /home/runner/work/hubble/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.14.1-alpine3.11 as builder
+FROM docker.io/library/golang:1.14.2-alpine3.11 as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache binutils git make \
  && go get -d github.com/google/gops \


### PR DESCRIPTION
Note: currently blocked by https://github.com/docker-library/golang/issues/322.