### PR TITLE
observe: Disable port-translation by default

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -245,7 +245,7 @@ programs attached to endpoints and devices. This includes:
 	observerCmd.Flags().BoolVar(
 		&enablePortTranslation,
 		"port-translation",
-		true,
+		false,
 		"Translate port numbers to names",
 	)
 


### PR DESCRIPTION
Seems like most people don't care for it.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>