### PR TITLE
Bring back HUBBLE_DEFAULT_SOCKET_PATH env var

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -108,7 +108,7 @@ programs attached to endpoints and devices. This includes:
 		},
 	}
 	observerCmd.Flags().StringVarP(&serverURL,
-		"server", "", defaults.DefaultSocketPath,
+		"server", "", defaults.GetDefaultSocketPath(),
 		"URL to connect to server")
 	observerCmd.Flags().DurationVar(&serverTimeout,
 		"timeout", defaults.DefaultDialTimeout,

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -23,7 +23,6 @@ import (
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/hubble/pkg/defaults"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -46,7 +45,6 @@ func New() *cobra.Command {
 
 	statusCmd.Flags().StringVarP(&serverURL,
 		"server", "", defaults.DefaultSocketPath, "URL to connect to server")
-	viper.BindEnv("server", "HUBBLE_SOCK")
 	return statusCmd
 }
 

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -44,7 +44,7 @@ func New() *cobra.Command {
 	}
 
 	statusCmd.Flags().StringVarP(&serverURL,
-		"server", "", defaults.DefaultSocketPath, "URL to connect to server")
+		"server", "", defaults.GetDefaultSocketPath(), "URL to connect to server")
 	return statusCmd
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -14,15 +14,31 @@
 
 package defaults
 
-import "time"
+import (
+	"os"
+	"time"
+)
 
 const (
-	// DefaultSocketPath on which to connect to the local hubble observer
-	DefaultSocketPath = "unix:///var/run/cilium/hubble.sock"
+	// DefaultSocketPathKey is the environment variable name to override the
+	// default socket path for observe and status commands.
+	DefaultSocketPathKey = "HUBBLE_DEFAULT_SOCKET_PATH"
 
 	// DefaultDialTimeout is the timeout for dialing the server
 	DefaultDialTimeout = 5 * time.Second
 
 	// DefaultRequestTimeout is the timeout for client requests
 	DefaultRequestTimeout = 12 * time.Second
+
+	// defaultSocketPath on which to connect to the local hubble observer. Use
+	// GetDefaultSocketPath to access it.
+	defaultSocketPath = "unix:///var/run/cilium/hubble.sock"
 )
+
+// GetDefaultSocketPath returns the default server for status and observe command.
+func GetDefaultSocketPath() string {
+	if path, ok := os.LookupEnv(DefaultSocketPathKey); ok {
+		return path
+	}
+	return defaultSocketPath
+}


### PR DESCRIPTION
This PR brings back the `HUBBLE_DEFAULT_SOCKET_PATH` environment variable to overwrite the default Hubble socket path. This environment variable key is the same as the one present in Hubble v0.5.

It was removed 24bc03b by accident. Overwriting the default Hubble socket path has proven to be useful for forward-compatibility. The mechanism for example is used to point the Hubble 0.5 client to the new socket path in cilium-embedded Hubble in CI.
