### PR TITLE
observe: Show all the event types by default

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -53,17 +53,6 @@ var (
 
 	printer *hubprinter.Printer
 
-	allTypes = []string{
-		monitorAPI.MessageTypeNameL7,
-		monitorAPI.MessageTypeNameDrop,
-		monitorAPI.MessageTypeNameTrace,
-		// Currently we don't parse the following three as they are deemed too
-		// noisy:
-		// monitorAPI.MessageTypeDebug,
-		// monitorAPI.MessageTypeCapture,
-		// monitorAPI.MessageTypeAgent,
-	}
-
 	serverURL     string
 	serverTimeout time.Duration
 
@@ -114,7 +103,7 @@ programs attached to endpoints and devices. This includes:
 		"timeout", defaults.DefaultDialTimeout,
 		"How long to wait before giving up on server dialing")
 	observerCmd.Flags().VarP(filterVarP(
-		"type", "t", ofilter, allTypes,
+		"type", "t", ofilter, []string{},
 		fmt.Sprintf("Filter by event types TYPE[:SUBTYPE] (%v)", eventTypes())))
 
 	observerCmd.Flags().Uint64Var(&last, "last", 0, "Get last N flows stored in the hubble")


### PR DESCRIPTION
Filtering out certain event types by default on the client-side does
not make sense any more since the server already ignores events like
MessageType{Agent,Capture,Debug}. It can also be confusing when new
event types get added since they don't show up if you simply run
`hubble observe` without explicitly whitelisting the new event type.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>