### PR TITLE
helm: Pin Hubble v0.5.1 in v0.5 branch

### DIFF
--- a/install/kubernetes/hubble/values.yaml
+++ b/install/kubernetes/hubble/values.yaml
@@ -3,9 +3,9 @@ image:
   # repository of the docker image
   repository: quay.io/cilium/hubble
   # tag is the container image tag to use
-  tag: latest
+  tag: v0.5.1
   # pullPolicy is the container image pull policy
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 # URL to listen to client requests. If this parameter is not specified, it
 # defaults to using unix domain socket.


### PR DESCRIPTION
*Reviewer note: This is PR targeting the `v0.5` branch.*

In the Cilium documentation, we ask users to obtain the Hubble v0.5
chart via the v0.5 branch. Therefore we should make sure that our chart
refers to v0.5 image tags.

Ref: https://github.com/cilium/cilium/pull/11121