### PR TITLE
helm: set hubble-ui securityContext

### DIFF
--- a/install/kubernetes/hubble/templates/deployment.yaml
+++ b/install/kubernetes/hubble/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       {{- if and .Values.priorityClassName (eq .Release.Namespace "kube-system") }}
       priorityClassName: {{ .Values.ui.priorityClassName }}
       {{- end }}
+      securityContext:
+        runAsUser: 1001
       serviceAccountName: hubble-ui
       containers:
         - name: hubble-ui


### PR DESCRIPTION
The image hubble-ui no longer needs run as root user

**Special notes for your reviewer**:
Do not merge it until new hubble-ui image is released, see corresponding pull request: [cilium/hubble-ui#31](https://github.com/cilium/hubble-ui/pull/31). Tested on k8s (`v1.18`) with enforced  [restricted PSP](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#example-policies).

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>