### PR TITLE
helm: ensure we can override the priority class name 

### DIFF
--- a/install/kubernetes/hubble/templates/daemonset.yaml
+++ b/install/kubernetes/hubble/templates/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         k8s-app: hubble
         kubernetes.io/cluster-service: "true"
     spec:
-      {{- if and .Values.priorityClassName (eq .Release.Namespace "kube-system") }}
+      {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
       affinity:

--- a/install/kubernetes/hubble/templates/deployment.yaml
+++ b/install/kubernetes/hubble/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         k8s-app: hubble-ui
     spec:
-      {{- if and .Values.priorityClassName (eq .Release.Namespace "kube-system") }}
+      {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.ui.priorityClassName }}
       {{- end }}
       serviceAccountName: hubble-ui

--- a/install/kubernetes/hubble/values.yaml
+++ b/install/kubernetes/hubble/values.yaml
@@ -67,9 +67,10 @@ ui:
   #         cpu: 100m
   #         memory: 64Mi
   resources: {}
+  
   # The priority class system-node-critical marks add-on pods as critical to the node itself.
   # This priority class is only valid under the kube-system namespace.
-  priorityClassName: ""
+  priorityClassName: system-node-critical
 
 ingress:
   enabled: false
@@ -94,6 +95,7 @@ ingress:
 #         cpu: 100m
 #         memory: 64Mi
 resources: {}
+
 # The priority class system-node-critical marks add-on pods as critical to the node itself.
 # This priority class is only valid under the kube-system namespace.
 priorityClassName: system-node-critical


### PR DESCRIPTION
When running in a namespace other than kube-system, we currently cannot override the `priorityClassName`