### PR TITLE
doc: Update DNS visibility policy

### DIFF
--- a/Documentation/dns_visibility.md
+++ b/Documentation/dns_visibility.md
@@ -28,7 +28,7 @@ policy accordingly if you are using other network policies.
             protocol: ANY
           rules:
             dns:
-            - matchPattern: '*'
+            - {}
       - toFQDNs:
         - matchPattern: '*'
       - toEntities:

--- a/policies/l7_80_53.yaml
+++ b/policies/l7_80_53.yaml
@@ -25,4 +25,4 @@ spec:
         protocol: UDP
       rules:
         dns:
-        - matchPattern: '*'
+        - {}

--- a/tutorials/deploy-hubble-and-grafana/example-apps/dns-visibility.yaml
+++ b/tutorials/deploy-hubble-and-grafana/example-apps/dns-visibility.yaml
@@ -15,7 +15,7 @@ spec:
         protocol: ANY
       rules:
         dns:
-        - matchPattern: '*'
+        - {}
   - toFQDNs:
     - matchPattern: '*'
   endpointSelector:


### PR DESCRIPTION
There is a subtle difference between `- {}` and `- matchPattern: '*'`.
More specifically, the former matches the record name `.`, whereas the
latter doesn't. You can use `dig NS .` to test this behavior.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>