### PR TITLE
printer: Fall back on ethernet MAC addresses

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -114,9 +114,17 @@ func (p *Printer) GetPorts(f v1.Flow) (string, string) {
 // GetHostNames returns source and destination hostnames of a flow.
 func (p *Printer) GetHostNames(f v1.Flow) (string, string) {
 	var srcNamespace, dstNamespace, srcPodName, dstPodName, srcSvcName, dstSvcName string
-	if f == nil || f.GetIP() == nil {
+	if f == nil {
 		return "", ""
 	}
+
+	if f.GetIP() == nil {
+		if eth := f.GetEthernet(); eth != nil {
+			return eth.GetSource(), eth.GetDestination()
+		}
+		return "", ""
+	}
+
 	if src := f.GetSource(); src != nil {
 		srcNamespace = src.Namespace
 		srcPodName = src.PodName

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -330,6 +330,21 @@ func Test_getHostNames(t *testing.T) {
 				dst: "b:65432",
 			},
 		},
+		{
+			name: "ethernet",
+			args: args{
+				f: &pb.Flow{
+					Ethernet: &pb.Ethernet{
+						Source:      "00:01:02:03:04:05",
+						Destination: "06:07:08:09:0a:0b",
+					},
+				},
+			},
+			want: want{
+				src: "00:01:02:03:04:05",
+				dst: "06:07:08:09:0a:0b",
+			},
+		},
 	}
 	p := New(WithPortTranslation(), WithIPTranslation())
 	for _, tt := range tests {


### PR DESCRIPTION
This is a backport of #261 for the v0.5 branch.