### PR TITLE
make: optimize binary size by omitting symbol table and debug info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TEST_TIMEOUT ?= 5s
 all: hubble
 
 hubble:
-	$(GO) build -ldflags "-X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)'" -o $(TARGET)
+	$(GO) build -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)'" -o $(TARGET)
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
Use the `-s -w` linker flags when compiling hubble in order to reduce the binary size.

The `-w` linker flag omits DWARF symbol table whereas the `-s` flag omits the symbol table and debug information.

This reduces the binary size from 18M to 13M.