### PR TITLE
cmd: Make pprof optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,14 @@ CONTAINER_ENGINE ?= docker
 TARGET=hubble
 GIT_BRANCH != which git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD
 GIT_HASH != which git >/dev/null 2>&1 && git rev-parse --short HEAD
+GO_TAGS ?=
 
 TEST_TIMEOUT ?= 5s
 
 all: hubble
 
 hubble:
-	$(GO) build -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)'" -o $(TARGET)
+	$(GO) build $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)'" -o $(TARGET)
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,12 +35,6 @@ var RootCmd = &cobra.Command{
 	SilenceErrors: true, // this is being handled in main, no need to duplicate error messages
 	SilenceUsage:  true,
 	Version:       pkg.Version,
-	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-		return pprofInit()
-	},
-	PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
-		return pprofTearDown()
-	},
 }
 
 func addSubcommands() {
@@ -65,15 +59,6 @@ func init() {
 	viper.BindPFlags(flags)
 	RootCmd.AddCommand(newCmdCompletion(os.Stdout))
 	RootCmd.SetErr(os.Stderr)
-
-	RootCmd.PersistentFlags().StringVar(&cpuprofile,
-		"cpuprofile", "", "Enable CPU profiling",
-	)
-	RootCmd.PersistentFlags().StringVar(&memprofile,
-		"memprofile", "", "Enable memory profiling",
-	)
-	RootCmd.PersistentFlags().Lookup("cpuprofile").Hidden = true
-	RootCmd.PersistentFlags().Lookup("memprofile").Hidden = true
 
 	RootCmd.SetVersionTemplate("{{with .Name}}{{printf \"%s \" .}}{{end}}{{printf \"v%s\" .Version}}\n")
 


### PR DESCRIPTION
Since the hubble binary is only used as a client, there is not much
value in providing pprof support by default. This commit hides the
pprof logic behind a go build tag.

This reduces the binary size by ~150KB.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>