### PR TITLE
backport/v0.5: update Go version, pull in a fix

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,7 +17,7 @@ jobs:
         path: go/src/github.com/cilium/hubble
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.14.1'
+        go-version: '1.14.2'
     - name: Run static checks
       env:
         GOPATH: /home/runner/work/hubble/go

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,7 +17,7 @@ jobs:
         path: go/src/github.com/cilium/hubble
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.14.2'
+        go-version: '1.14.3'
     - name: Run static checks
       env:
         GOPATH: /home/runner/work/hubble/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.14.1-alpine3.11 as builder
+FROM docker.io/library/golang:1.14.2-alpine3.11 as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache binutils git make \
  && go get -d github.com/google/gops \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.14.2-alpine3.11 as builder
+FROM docker.io/library/golang:1.14.3-alpine3.11 as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache binutils git make \
  && go get -d github.com/google/gops \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO := go
 INSTALL = $(QUIET)install
 BINDIR ?= /usr/local/bin
-IMAGE_REPOSITORY ?= quay.io/covalent/hubble
+IMAGE_REPOSITORY ?= quay.io/cilium/hubble
 CONTAINER_ENGINE ?= docker
 TARGET=hubble
 GIT_BRANCH != which git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD


### PR DESCRIPTION
This PR backports a minor bugfix and Go version bump to v0.5.