### PR TITLE
update Go version to v1.14.4 and alpine base image to v3.12

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,7 +17,7 @@ jobs:
         path: go/src/github.com/cilium/hubble
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.14.3'
+        go-version: '1.14.4'
     - name: Run static checks
       env:
         GOPATH: /home/runner/work/hubble/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/library/golang:1.14.3-alpine3.11 as builder
+FROM docker.io/library/golang:1.14.4-alpine3.12 as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache git make
 COPY . .
 RUN make clean && CGO_ENABLED=0 make hubble
 
-FROM docker.io/library/alpine:3.11
+FROM docker.io/library/alpine:3.12
 RUN apk add --no-cache bash curl jq
 COPY --from=builder /go/src/github.com/cilium/hubble/hubble /usr/bin
 ENTRYPOINT ["/usr/bin/hubble"]


### PR DESCRIPTION
This is a backport for the v0.6 branch.