### PR TITLE
make: fix git hash variable assignments for old make versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ IMAGE_REPOSITORY ?= quay.io/cilium/hubble
 CONTAINER_ENGINE ?= docker
 TARGET=hubble
 VERSION=0.7.0-dev
-GIT_BRANCH != which git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD
-GIT_HASH != which git >/dev/null 2>&1 && git rev-parse --short HEAD
+GIT_BRANCH = $(shell which git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD)
+GIT_HASH = $(shell which git >/dev/null 2>&1 && git rev-parse --short HEAD)
 GO_TAGS ?=
 
 TEST_TIMEOUT ?= 5s


### PR DESCRIPTION
Antediluvian versions of GNU make, such as the one shipped by default on
MacOS (GNU Make 3.81, the last GPLv2 version released back in 2006) do
not understand the `!=` operator which executes and assigns the results
to a variable. This results in the GIT_BRANCH and GIT_HASH variables not
being assigned on MacOS. This commit addresses this issue by using the
`$(shell ...)` construct instead.