### PR TITLE
Build release artifacts inside a container

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,3 +28,11 @@ jobs:
         make check
     - name: Run unit tests
       run: make test
+    - name: Generate artifacts
+      run: ./contrib/scripts/release.sh
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      if: success()
+      with:
+        name: release
+        path: release

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ all: hubble
 hubble:
 	$(GO) build $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET)
 
-release:
-	rm -rf release
+release: clean
 	for OS in darwin linux windows; do \
 		EXT=; \
 		if test $$OS = "windows"; then \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -111,9 +111,9 @@ https://github.com/cilium/hubble/releases/new
 
 ## Finally, upload release tarballs to the GitHub release
 
-Generate the release tarballs using the `release` make target:
+Generate the release tarballs using `contrib/scripts/release.sh` script:
 
-    make release
+    ./contrib/scripts/release.sh
 
 This will generate tarballs and associated checksum files in the `release`
 directory. Make sure to upload these tarball and checksum to the GitHub release

--- a/contrib/scripts/release.sh
+++ b/contrib/scripts/release.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+set -o pipefail
+
+docker run --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.14.4-alpine3.12 \
+  apk add --no-cache make && make release


### PR DESCRIPTION
- Use make clean to delete the release directory.
- Run `make release` from inside a docker container to ensure that the
  artifacts get generated in a reproducible environment.
- Generate release artifacts as a part of the build.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>