### PR TITLE
Build release artifacts inside a container

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,3 +28,11 @@ jobs:
         make check
     - name: Run unit tests
       run: make test
+    - name: Generate artifacts
+      run: make release
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      if: success()
+      with:
+        name: release
+        path: release

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ hubble:
 	$(GO) build $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET)
 
 release:
-	rm -rf release
+	docker run --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.14.4-alpine3.12 \
+		sh -c "apk add --no-cache make && make local-release"
+
+local-release: clean
 	for OS in darwin linux windows; do \
 		EXT=; \
 		if test $$OS = "windows"; then \


### PR DESCRIPTION
- Use make clean to delete the release directory.
- Run `make release` from inside a docker container to ensure that the
  artifacts get generated in a reproducible environment.
- Generate release artifacts as a part of the build.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>