### PR TITLE
Remove contrib/scripts/release.sh

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Run unit tests
       run: make test
     - name: Generate artifacts
-      run: ./contrib/scripts/release.sh
+      run: make release
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       if: success()

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,11 @@ all: hubble
 hubble:
 	$(GO) build $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET)
 
-release: clean
+release:
+	docker run --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.14.4-alpine3.12 \
+		sh -c "apk add --no-cache make && make local-release"
+
+local-release: clean
 	for OS in darwin linux windows; do \
 		EXT=; \
 		if test $$OS = "windows"; then \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -113,7 +113,7 @@ https://github.com/cilium/hubble/releases/new
 
 Generate the release tarballs using `contrib/scripts/release.sh` script:
 
-    ./contrib/scripts/release.sh
+    make release
 
 This will generate tarballs and associated checksum files in the `release`
 directory. Make sure to upload these tarball and checksum to the GitHub release

--- a/contrib/scripts/release.sh
+++ b/contrib/scripts/release.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex
-set -o pipefail
-
-docker run --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.14.4-alpine3.12 \
-  apk add --no-cache make && make release


### PR DESCRIPTION
Rename the current `release` make target to `local-release`, and update
the `release` target to generate release artifacts from inside Docker.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>