### PR TITLE
v0.5: Pin Hubble and Cilium branches

### DIFF
--- a/Documentation/installation.md
+++ b/Documentation/installation.md
@@ -7,9 +7,9 @@
 
 ## Install Cilium
 
-Install Cilium using the [Install instructions]. To deploy Cilium 1.7.0 using quick-install.yaml:
+Install Cilium using the [Install instructions]. To deploy Cilium 1.7 using quick-install.yaml:
 
-    kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.7.0/install/kubernetes/quick-install.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.7/install/kubernetes/quick-install.yaml
 
 If you need help to troubleshoot installation issues, ping us on the
 [Cilium Slack].
@@ -28,7 +28,7 @@ This is the default setting for new installs of Cilium 1.6 or later.
 
 Deploy Hubble using hubble-all-minikube.yaml:
 
-    kubectl apply -f https://raw.githubusercontent.com/cilium/hubble/master/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cilium/hubble/v0.5/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
 
 ### Optional: Configure Metrics
 

--- a/Documentation/installation.md
+++ b/Documentation/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
- * [Cilium] >= 1.7.0
+ * [Cilium] >= 1.7.0, < 1.8.0 (for Hubble v0.5)
  * [Kubernetes]
 
 ## Install Cilium
@@ -13,6 +13,9 @@ Install Cilium using the [Install instructions]. To deploy Cilium 1.7 using quic
 
 If you need help to troubleshoot installation issues, ping us on the
 [Cilium Slack].
+
+> Please note: If you are using Cilium 1.8 or newer, please check the Cilium
+> documentation on how to enable the embedded Hubble server in Cilium >= 1.8.0.
 
 ### Enable Datapath Aggregation
 

--- a/Documentation/installation.md
+++ b/Documentation/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
- * [Cilium] Recommended: >= 1.7.0, Minimal: >= 1.6.3
+ * [Cilium] >= 1.7.0
  * [Kubernetes]
 
 ## Install Cilium

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -36,7 +36,7 @@ instead of unix domain socket. For example, to listen to port 8080 on localhost:
    The following deploys Prometheus and Grafana into the `cilium-monitoring`
    namespace:
 
-       kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.6/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+       kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.7/examples/kubernetes/addons/prometheus/monitoring-example.yaml
 
    Import the dashboard (`install/kubernetes/grafana.json`) via *Create* ->
    *Import*

--- a/tutorials/deploy-hubble-servicemap/README.md
+++ b/tutorials/deploy-hubble-servicemap/README.md
@@ -23,9 +23,9 @@ minikube start --network-plugin=cni --memory=4096
 Install Cilium and Hubble as [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) into your new Kubernetes cluster:
 
 ```
-kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/install/kubernetes/quick-install.yaml
+kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.7/install/kubernetes/quick-install.yaml
 
-kubectl create -f https://raw.githubusercontent.com/cilium/hubble/master/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
+kubectl create -f https://raw.githubusercontent.com/cilium/hubble/v0.5/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
 ```
 
 


### PR DESCRIPTION
This PR ensures that we do not refer to the Hubble `master` branch in our Hubble v0.5 docs, as in Hubble 0.6 and latest, those files (i.e. Helm charts and documentation) have moved to the Cilium repository and will soon be removed from the Hubble master branch.

In addition, the PR also replaces a few occurrences of the `v1.7.0` Cilium git tag with the `v1.7` Cilium git branch, which will pick up the latest Cilium 1.7 patch release.