### PR TITLE
printer: Add jsonpb output

### DIFF
--- a/pkg/printer/options.go
+++ b/pkg/printer/options.go
@@ -32,6 +32,8 @@ const (
 	// DictOutput presents the same information as TabOutput, but each flow is
 	// presented as a key:value dictionary, similar to \G output of mysql.
 	DictOutput
+	// JSONPBOutput prints GetFlowsResponse as JSON according to proto3's JSON mapping.
+	JSONPBOutput
 )
 
 // Options for the printer.
@@ -50,6 +52,13 @@ type Option func(*Options)
 func JSON() Option {
 	return func(opts *Options) {
 		opts.output = JSONOutput
+	}
+}
+
+// JSONPB encodes GetFlowsResponse as JSON according to proto3's JSON mapping.
+func JSONPB() Option {
+	return func(opts *Options) {
+		opts.output = JSONPBOutput
 	}
 }
 


### PR DESCRIPTION
This output option serializes the entire GetFlowResponse using proto3's
JSON mapping so that the JSON format is consistent across all the event
types. The output looks like this:

```
% hubble observe --debug -o jsonpb 2>&1 | jq
{
  "node_status": {
    ...
  },
  "node_name": "hubble-relay-565f76c75f-974d9",
  "time": "2020-06-15T20:56:44.689246261Z"
}
{
  "flow": {
    ...
  },
  "node_name": "hubble-relay-565f76c75f-974d9",
  "time": "2020-06-15T20:56:44.689246262Z"
}
```

Here is the updated description of `--output` option:
```
-o, --output string      Specify the output format, one of:
                          compact:  Compact output
                          dict:     Each flow is shown as KEY:VALUE pair
                          json:     JSON encoding
                          jsonpb:   Output each GetFlowResponse according to proto3's JSON mapping
                          table:    Tab-aligned columns
```

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>