### PR TITLE
ghactions: Do not upload artifacts for each commit

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -30,9 +30,3 @@ jobs:
       run: make test
     - name: Generate artifacts
       run: make release
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      if: success()
-      with:
-        name: release
-        path: release


### PR DESCRIPTION
Uploading the release artifacts for each commit seems to eat away at the
GitHub shared storage and bandwith quota of the Cilium GitHub organization.
Since we are not actively using these artifacts, this commit disables the
upload to avoid wasting storage space.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>