### PR TITLE
.gitattributes: hide go.sum and vendor/modules.txt in pull requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+go.sum linguist-generated
+vendor/modules.txt linguist-generated


### PR DESCRIPTION
This marks the go.sum and vendor/modules.txt file sas generated so that they are collapsed by default in Github pull requests.