### PR TITLE
observe: Document default flow count output

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -107,7 +107,7 @@ programs attached to endpoints and devices. This includes:
 		"type", "t", ofilter, []string{},
 		fmt.Sprintf("Filter by event types TYPE[:SUBTYPE] (%v)", eventTypes())))
 
-	observerCmd.Flags().Uint64Var(&last, "last", 0, "Get last N flows stored in the hubble")
+	observerCmd.Flags().Uint64Var(&last, "last", 0, fmt.Sprintf("Get last N flows stored in the hubble (default %d)", defaults.FlowPrintCount))
 	observerCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow flows output")
 	observerCmd.Flags().StringVar(&sinceVar, "since", "", "Filter flows since a specific date (relative or RFC3339)")
 	observerCmd.Flags().StringVar(&untilVar, "until", "", "Filter flows until a specific date (relative or RFC3339)")
@@ -347,8 +347,7 @@ func runObserve(serverURL string, ofilter *observeFilter) error {
 
 	// no specific parameters were provided, just a vanilla `hubble observe`
 	if last == 0 && since == nil && until == nil {
-		// assume --last 20
-		last = 20
+		last = defaults.FlowPrintCount
 	}
 
 	var (

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -33,6 +33,10 @@ const (
 	// defaultSocketPath on which to connect to the local hubble observer. Use
 	// GetDefaultSocketPath to access it.
 	defaultSocketPath = "unix:///var/run/cilium/hubble.sock"
+
+	// FlowPrintCount is the default number of flows to print on the hubble
+	// observe CLI.
+	FlowPrintCount = 20
 )
 
 // GetDefaultSocketPath returns the default server for status and observe command.


### PR DESCRIPTION
I couldn't tell from the help text what the intended default was here,
but there seems to be some special logic to try to ensure that the
number of flows is only restricted when no other selector parameters are
specified. Manually add the default string at the end so that we don't
have to restrict the number of flows to 20 by default when specifying
other selector criteria, but it's still apparent what the default
behaviour is.