### PR TITLE
make: fix release build directory ownership

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ VERSION=0.7.0-dev
 GIT_BRANCH = $(shell which git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD)
 GIT_HASH = $(shell which git >/dev/null 2>&1 && git rev-parse --short HEAD)
 GO_TAGS ?=
+RELEASE_UID ?= $(shell id -u)
+RELEASE_GID ?= $(shell id -g)
 
 TEST_TIMEOUT ?= 5s
 
@@ -17,7 +19,7 @@ hubble:
 	$(GO) build $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET)
 
 release:
-	docker run --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.14.6-alpine3.12 \
+	docker run --env "RELEASE_UID=$(RELEASE_UID)" --env "RELEASE_GID=$(RELEASE_GID)" --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.14.6-alpine3.12 \
 		sh -c "apk add --no-cache make && make local-release"
 
 local-release: clean
@@ -30,10 +32,13 @@ local-release: clean
 			test -d release/$$OS/$$ARCH|| mkdir -p release/$$OS/$$ARCH; \
 			env GOOS=$$OS GOARCH=$$ARCH $(GO) build $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.Version=${VERSION}'" -o release/$$OS/$$ARCH/$(TARGET)$$EXT; \
 			tar -czf release/$(TARGET)-$$OS-$$ARCH.tar.gz -C release/$$OS/$$ARCH $(TARGET)$$EXT; \
-			cd release && sha256sum $(TARGET)-$$OS-$$ARCH.tar.gz > $(TARGET)-$$OS-$$ARCH.tar.gz.sha256sum && cd $(CURDIR); \
+			(cd release && sha256sum $(TARGET)-$$OS-$$ARCH.tar.gz > $(TARGET)-$$OS-$$ARCH.tar.gz.sha256sum); \
 		done; \
 		rm -r release/$$OS; \
-	done
+	done; \
+	if [ $$(id -u) -eq 0 -a -n "$$RELEASE_UID" -a -n "$$RELEASE_GID" ]; then \
+		chown -R "$$RELEASE_UID:$$RELEASE_GID" release; \
+	fi
 
 install: hubble
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
Before this patch, `make release` would generate the release/ directory (and files underneath) owned by root:root. This is caused by the fact that the build happen as root inside the Docker container. As a result, a following `make clean` from outside the container as an unprivileged user would fail.

This patch fix the issue by chowning the release directory and files to the user uid and gid whom invoked make originally (i.e. from outside the container).