### PR TITLE
cmd/status: Add flows per second to `hubble status`

### DIFF
--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
@@ -72,6 +73,13 @@ func runStatus() error {
 		ss.NumFlows,
 		(float64(ss.NumFlows)/float64(ss.MaxFlows))*100,
 	)
+
+	flowsPerSec := "N/A"
+	if uptime := time.Duration(ss.UptimeNs).Seconds(); uptime > 0 {
+		flowsPerSec = fmt.Sprintf("%.2f", float64(ss.SeenFlows)/uptime)
+	}
+	fmt.Printf("Flows/s: %s\n", flowsPerSec)
+
 	numConnected := ss.GetNumConnectedNodes()
 	numUnavailable := ss.GetNumUnavailableNodes()
 	if numConnected != nil {


### PR DESCRIPTION
This information is also provided by `cilium status` in Cilium 1.8 and newer.

```console
$ hubble status
Healthcheck (via unix:///var/run/cilium/hubble.sock): Ok
Max Flows: 4096
Current Flows: 4096 (100.00%) 
Flows/s: 9.20
```

Formatting is up for discussion. I opted to put it on a new line, but there are other variants, such as e.g. `Current Flows: 4096 (100%, 9.20 flows/s)`

Fixes #329

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>