### PR TITLE
helm: Bump image to v0.5.2

### DIFF
--- a/install/kubernetes/hubble/values.yaml
+++ b/install/kubernetes/hubble/values.yaml
@@ -3,7 +3,7 @@ image:
   # repository of the docker image
   repository: quay.io/cilium/hubble
   # tag is the container image tag to use
-  tag: v0.5.1
+  tag: v0.5.2
   # pullPolicy is the container image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
*This PR targets the `v0.5` branch.*

This bumps the Helm charts to use the latest v0.5 version. 

In the documentation, we refer to the v0.5 branch for people who want to install standalone Hubble. Users reading the Cilium 1.7 documentation will use these Helm charts to install Hubble.