### PR TITLE
Allow enabling the hubble-grpc service without Hubble UI enabled

### DIFF
--- a/install/kubernetes/hubble/Chart.yaml
+++ b/install/kubernetes/hubble/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: hubble
-version: 0.0.3
-appVersion: 0.0.1
+version: 0.5.2
+appVersion: 0.5.2
 tillerVersion: ">=2.7.2"
 description: Helm chart for the Hubble server
 keywords:

--- a/install/kubernetes/hubble/templates/clusterrole.yaml
+++ b/install/kubernetes/hubble/templates/clusterrole.yaml
@@ -15,7 +15,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: hubble-ui 
+  name: hubble-ui
 rules:
   - apiGroups:
       - networking.k8s.io

--- a/install/kubernetes/hubble/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/hubble/templates/clusterrolebinding.yaml
@@ -19,9 +19,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: hubble-ui 
+  name: hubble-ui
 subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}
-    name: hubble-ui 
+    name: hubble-ui
 {{- end }}

--- a/install/kubernetes/hubble/templates/daemonset.yaml
+++ b/install/kubernetes/hubble/templates/daemonset.yaml
@@ -50,7 +50,7 @@ spec:
 {{- range .Values.listenClientUrls }}
         - --listen-client-urls={{ . }}
 {{- end }}
-{{- if and .Values.ui.enabled (not (has "0.0.0.0:50051" .Values.listenClientUrls)) }}
+{{- if and (or .Values.grpc.enabled .Values.ui.enabled) (not (has "0.0.0.0:50051" .Values.listenClientUrls)) }}
         - --listen-client-urls=0.0.0.0:50051
 {{- if not .Values.listenClientUrls }}
         - --listen-client-urls=unix:///var/run/hubble.sock

--- a/install/kubernetes/hubble/templates/serviceaccount.yaml
+++ b/install/kubernetes/hubble/templates/serviceaccount.yaml
@@ -10,5 +10,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: hubble-ui 
+  name: hubble-ui
 {{- end }}

--- a/install/kubernetes/hubble/templates/svc.yaml
+++ b/install/kubernetes/hubble/templates/svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ui.enabled }}
+{{- if or .Values.grpc.enabled .Values.ui.enabled }}
 ---
 kind: Service
 apiVersion: v1
@@ -16,6 +16,8 @@ spec:
   - targetPort: 50051
     protocol: TCP
     port: 50051
+{{- end }}
+{{- if .Values.ui.enabled }}
 ---
 kind: Service
 apiVersion: v1

--- a/install/kubernetes/hubble/values.yaml
+++ b/install/kubernetes/hubble/values.yaml
@@ -45,6 +45,10 @@ metrics:
   serviceMonitor:
     enabled: false
 
+# Configuration for the hubble-grpc Service
+grpc:
+  enabled: false
+
 # Configuration for hubble ui
 ui:
   enabled: false


### PR DESCRIPTION
_**NOTE**: This PR targets the v0.5 branch._

Allow users to enable the hubble-grpc Service (through `.Values.grpc.enabled`) without requiring Hubble UI to be enabled. Note that when Hubble UI is enabled, the hubble-grpc Service is enabled unconditionally since UI depends on it.
