### PR TITLE
Add staticcheck to `make check`

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -25,6 +25,7 @@ jobs:
         export PATH=${PATH}:${GOPATH}/bin
         GO111MODULE=off go get -u github.com/gordonklaus/ineffassign
         GO111MODULE=off go get -u golang.org/x/lint/golint
+        GO111MODULE=off go get -u honnef.co/go/tools/cmd/staticcheck
         make check
     - name: Run unit tests
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test:
 bench:
 	go test -timeout=30s -bench=. $$(go list ./...)
 
-check: check-fmt ineffassign lint vet
+check: check-fmt ineffassign lint staticcheck vet
 
 check-fmt:
 	./contrib/scripts/check-fmt.sh
@@ -70,6 +70,15 @@ ifeq (, $(shell which golint))
 	$(error "golint not installed; you can install it with `go get -u golang.org/x/lint/golint`")
 endif
 	golint -set_exit_status $$(go list ./...)
+
+# Ignored staticcheck warnings:
+# - SA1019 deprecation warnings: https://staticcheck.io/docs/checks#SA1019
+# - ST1000 missing package comment: https://staticcheck.io/docs/checks#ST1000
+staticcheck:
+ifeq (, $(shell which staticcheck))
+	$(error "staticcheck not installed; you can install it with `go get -u honnef.co/go/tools/cmd/staticcheck`")
+endif
+	staticcheck -checks="all,-SA1019,-ST1000" ./...
 
 vet:
 	go vet $$(go list ./...)

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -43,7 +43,6 @@ var (
 	sinceVar, untilVar string
 
 	jsonOutput          bool
-	jsonPBOutput        bool
 	compactOutput       bool
 	dictOutput          bool
 	output              string

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -92,7 +92,7 @@ func (p *Printer) Close() error {
 
 // WriteErr returns the given msg into the err writer defined in the printer.
 func (p *Printer) WriteErr(msg string) error {
-	_, err := fmt.Fprint(p.opts.werr, fmt.Sprintf("%s\n", msg))
+	_, err := fmt.Fprintf(p.opts.werr, "%s\n", msg)
 	return err
 }
 


### PR DESCRIPTION
Add `staticcheck` to the `make check` target which will also run it as part of GitHub actions.

The first two commits fix remaining issues reported by `staticcheck`, the third commit enables the check. Currently, the following checks are disabled:

* SA1019 deprecation warnings: https://staticcheck.io/docs/checks#SA1019
* ST1000 missing package comment: https://staticcheck.io/docs/checks#ST1000

I guess the second one should eventually be fixed by adding package level godoc comments to all sub-packages.