### PR TITLE
printer: use fmt.Fprintln instead of fmt.Fprintf

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -92,7 +92,7 @@ func (p *Printer) Close() error {
 
 // WriteErr returns the given msg into the err writer defined in the printer.
 func (p *Printer) WriteErr(msg string) error {
-	_, err := fmt.Fprintf(p.opts.werr, "%s\n", msg)
+	_, err := fmt.Fprintln(p.opts.werr, msg)
 	return err
 }
 


### PR DESCRIPTION
As suggested in https://github.com/cilium/hubble/pull/344#discussion_r469441231

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>