### PR TITLE
v0.6: cmd/status: do not report flows ratio when max flows is zero

### DIFF
--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -65,11 +65,11 @@ func runStatus() error {
 		return fmt.Errorf("failed to get hubble server status: %v", err)
 	}
 	fmt.Println("Max Flows:", ss.MaxFlows)
-	fmt.Printf(
-		"Current Flows: %v (%.2f%%) \n",
-		ss.NumFlows,
-		(float64(ss.NumFlows)/float64(ss.MaxFlows))*100,
-	)
+	flowsRatio := ""
+	if ss.MaxFlows > 0 {
+		flowsRatio = fmt.Sprintf(" (%.2f%%)", (float64(ss.NumFlows)/float64(ss.MaxFlows))*100)
+	}
+	fmt.Printf("Current Flows: %v%s\n", ss.NumFlows, flowsRatio)
 	return nil
 }
 


### PR DESCRIPTION
Backport #345 to v0.6 branch:

When max flows is zero, a division by zero occurs which causes `hubble status` to report NaN. Don't report any flows ratio when max flows is zero instead.

Fixes: #303