### PR TITLE
v0.5: set hubble version to v0.5.2; fix Cilium ref link to v1.7

### DIFF
--- a/tutorials/deploy-hubble-and-grafana/README.md
+++ b/tutorials/deploy-hubble-and-grafana/README.md
@@ -30,7 +30,7 @@ Set up Prometheus and Grafana. If you already have a stack running, you can
 reuse that stack. Otherwise you can deploy a Prometheus and Grafana stack into
 the `cilium-monitoring` namespace using the following command:
 
-    kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.6/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.7/examples/kubernetes/addons/prometheus/monitoring-example.yaml
 
 ## Deploy the Example Application (Optional)
 

--- a/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
+++ b/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
@@ -169,7 +169,7 @@ spec:
             - kube-system
       containers:
       - name: hubble
-        image: "quay.io/cilium/hubble:latest"
+        image: "quay.io/cilium/hubble:v0.5.2"
         imagePullPolicy: Always
         command:
         - hubble


### PR DESCRIPTION
This PR updates the v0.5 branch in two places where we missed updating the Hubble version tag and a link that was still referring to Cilium v1.6.