### PR TITLE
v0.5: fix Hubble UI tag to v0.5.0

### DIFF
--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -38,11 +38,12 @@ instead of unix domain socket. For example, to listen to port 8080 on localhost:
 
        kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.7/examples/kubernetes/addons/prometheus/monitoring-example.yaml
 
-   Import the dashboard (`install/kubernetes/grafana.json`) via *Create* ->
-   *Import*
+   Import the dashboard ([grafana.json]) via `*Create* ->  *Import*`.
 
 ## Usage
 
 To query Hubble with the CLI on the first node:
 
     kubectl exec -n kube-system -t -c hubble ds/hubble -- hubble observe --since 1s
+
+[grafana.json]: ../../tutorials/deploy-hubble-and-grafana/grafana.json

--- a/install/kubernetes/hubble/values.yaml
+++ b/install/kubernetes/hubble/values.yaml
@@ -56,7 +56,7 @@ ui:
     # repository of the docker image
     repository: quay.io/cilium/hubble-ui
     # tag is the container image tag to use
-    tag: latest
+    tag: v0.5.0
     # pullPolicy is the container image pull policy
     pullPolicy: Always
   clusterDomain: cluster.local

--- a/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
+++ b/tutorials/deploy-hubble-servicemap/hubble-all-minikube.yaml
@@ -244,7 +244,7 @@ spec:
       serviceAccountName: hubble-ui
       containers:
         - name: hubble-ui
-          image: "quay.io/cilium/hubble-ui:latest"
+          image: "quay.io/cilium/hubble-ui:v0.5.0"
           imagePullPolicy: Always
           env:
             - name: NODE_ENV


### PR DESCRIPTION
The YAML files were still pointing to `latest`. For Hubble v0.5, Hubble UI v0.5 is required.
While there, also fix a bad reference to `grafana.json` file.