### PR TITLE
Dockerfile: Remove ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,4 @@ RUN make clean && CGO_ENABLED=0 make hubble
 FROM docker.io/library/alpine:3.12
 RUN apk add --no-cache bash curl jq
 COPY --from=builder /go/src/github.com/cilium/hubble/hubble /usr/bin
-ENTRYPOINT ["/usr/bin/hubble"]
-CMD ["help"]
+CMD ["/usr/bin/hubble"]


### PR DESCRIPTION
Specifying ENTRYPOINT doesn't make sense for this image anymore since
it no longer runs Hubble server, and it's primarily used to access the
CLI. Remove ENTRYPOINT so that you can bash into the container without
providing additional arguments to override it.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>