### PR TITLE
printer: ommit node name from output

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -49,6 +49,7 @@ var (
 	follow              bool
 	ignoreStderr        bool
 	enableIPTranslation bool
+	nodeName            bool
 
 	printer *hubprinter.Printer
 
@@ -242,6 +243,8 @@ programs attached to endpoints and devices. This includes:
 		"Translate IP addresses to logical names such as pod name, FQDN, ...",
 	)
 
+	observerCmd.Flags().BoolVarP(&nodeName, "print-node-name", "", false, "Print node name in output")
+
 	customObserverHelp(observerCmd)
 
 	return observerCmd
@@ -303,6 +306,9 @@ func handleArgs(ofilter *observeFilter) (err error) {
 	}
 	if debug {
 		opts = append(opts, hubprinter.WithDebug())
+	}
+	if nodeName {
+		opts = append(opts, hubprinter.WithNodeName())
 	}
 	printer = hubprinter.New(opts...)
 	return nil

--- a/pkg/printer/options.go
+++ b/pkg/printer/options.go
@@ -43,6 +43,7 @@ type Options struct {
 	werr                io.Writer
 	enableDebug         bool
 	enableIPTranslation bool
+	nodeName            bool
 }
 
 // Option ...
@@ -108,5 +109,12 @@ func WithDebug() Option {
 func WithIPTranslation() Option {
 	return func(opts *Options) {
 		opts.enableIPTranslation = true
+	}
+}
+
+// WithNodeName enables printing the node name.
+func WithNodeName() Option {
+	return func(opts *Options) {
+		opts.nodeName = true
 	}
 }

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -80,6 +80,19 @@ func TestPrinter_WriteProtoFlow(t *testing.T) {
 Jan  1 00:20:34.567   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROPPED   TCP Flags: SYN`,
 		},
 		{
+			name: "tabular-with-node",
+			options: []Option{
+				WithNodeName(),
+				Writer(&buf),
+			},
+			args: args{
+				f: &f,
+			},
+			wantErr: false,
+			expected: `TIMESTAMP             NODE   SOURCE          DESTINATION    TYPE            VERDICT   SUMMARY
+Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROPPED   TCP Flags: SYN`,
+		},
+		{
 			name: "compact",
 			options: []Option{
 				Compact(),
@@ -89,8 +102,23 @@ Jan  1 00:20:34.567   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROPPED   T
 				f: &f,
 			},
 			wantErr: false,
-			expected: "Jan  1 00:20:34.567 " +
-				"[k8s1]: 1.1.1.1:31793 -> 2.2.2.2:8080 " +
+			expected: "Jan  1 00:20:34.567: " +
+				"1.1.1.1:31793 -> 2.2.2.2:8080 " +
+				"Policy denied DROPPED (TCP Flags: SYN)\n",
+		},
+		{
+			name: "compact-with-node",
+			options: []Option{
+				Compact(),
+				WithNodeName(),
+				Writer(&buf),
+			},
+			args: args{
+				f: &f,
+			},
+			wantErr: false,
+			expected: "Jan  1 00:20:34.567 [k8s1]: " +
+				"1.1.1.1:31793 -> 2.2.2.2:8080 " +
 				"Policy denied DROPPED (TCP Flags: SYN)\n",
 		},
 		{
@@ -138,6 +166,25 @@ Jan  1 00:20:34.567   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROPPED   T
 			},
 			wantErr: false,
 			expected: `  TIMESTAMP: Jan  1 00:20:34.567
+     SOURCE: 1.1.1.1:31793
+DESTINATION: 2.2.2.2:8080
+       TYPE: Policy denied
+    VERDICT: DROPPED
+    SUMMARY: TCP Flags: SYN`,
+		},
+		{
+			name: "dict-with-node",
+			options: []Option{
+				Dict(),
+				WithNodeName(),
+				Writer(&buf),
+			},
+			args: args{
+				f: &f,
+			},
+			wantErr: false,
+			expected: `  TIMESTAMP: Jan  1 00:20:34.567
+       NODE: k8s1
      SOURCE: 1.1.1.1:31793
 DESTINATION: 2.2.2.2:8080
        TYPE: Policy denied


### PR DESCRIPTION
The node name gets ommited from the compact output by default since it takes up too much space. The node name can be displayed by adding the --node flag

Signed-off-by: Marco De Luca <marcodl404@gmail.com>