### PR TITLE
cmd: honor user configuration directory for the configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /hubble
 /release
-install/kubernetes/hubble.yaml
+config.yaml

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,7 @@ func New() *cobra.Command {
 			vp.SetConfigFile(cfg)
 		}
 		// if a config file is found, read it in.
-		if err := vp.ReadInConfig(); err == nil {
+		if err := vp.ReadInConfig(); err == nil && vp.GetBool("debug") {
 			fmt.Fprintln(rootCmd.ErrOrStderr(), "Using config file:", vp.ConfigFileUsed())
 		}
 	})


### PR DESCRIPTION
Honor platform specific user configuration directory to look for a
configuration file for hubble. In addition, look up in the current
directory first and fallback to `$HOME/.hubble`.

On Unix systems, the user specific configuration directory is
`$XDG_CONFIG_HOME` if non-empty, else `$HOME/.config`. On MacOS, it's
`$HOME/Library/Application Support` and on Windows it's `%AppData%`.

For example, on Linux the configuration file is now looked for in this
order:

1. `$PWD/config.yaml`
2. `$XDG_CONFIG_HOME/hubble/config.yaml`
3. `$HOME/.config/hubble/config.yaml`
4. `$HOME/.hubble/config.yaml`

Note that this is a breaking change as previously the configuration file
was expected to be found in `$HOME/.hubble.yaml`. As the latter is not
standard and not recommended, let's opt for the freedesktop
recommendation and avoid polluting the user's home directory root with a
hidden config file.
