### PR TITLE
Add config subcommand

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// New config command.
+func New(vp *viper.Viper) *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "config",
+		Short: "Modify or view hubble config",
+		Long:  "Modify or view hubble config",
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			// override root persistent pre-run to avoid flag/config checks
+			// as we want to be able to modify/view the config even if it is
+			// invalid
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	return configCmd
+}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -36,7 +36,17 @@ func New(vp *viper.Viper) *cobra.Command {
 		},
 	}
 	configCmd.AddCommand(
+		newSetCommand(vp),
 		newViewCommand(vp),
 	)
 	return configCmd
+}
+
+func isKey(vp *viper.Viper, key string) bool {
+	for _, k := range vp.AllKeys() {
+		if key == k {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -36,6 +36,7 @@ func New(vp *viper.Viper) *cobra.Command {
 		},
 	}
 	configCmd.AddCommand(
+		newResetCommand(vp),
 		newSetCommand(vp),
 		newViewCommand(vp),
 	)

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -36,6 +36,7 @@ func New(vp *viper.Viper) *cobra.Command {
 		},
 	}
 	configCmd.AddCommand(
+		newGetCommand(vp),
 		newResetCommand(vp),
 		newSetCommand(vp),
 		newViewCommand(vp),

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -1,0 +1,76 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+)
+
+func newGetCommand(vp *viper.Viper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get [KEY]",
+		Short: "Get an individual value in the hubble config file",
+		Long: "Get an individual value in the hubble config file.\n" +
+			"If KEY is not provided, this command is equivalent to 'view'.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch len(args) {
+			case 1:
+				return runGet(cmd, vp, args[0])
+			case 0:
+				return runView(cmd, vp)
+			default:
+				return fmt.Errorf("invalid arguments: get requires exactly 0 or 1 argument: got '%s'", strings.Join(args, " "))
+			}
+		},
+	}
+}
+
+func runGet(cmd *cobra.Command, vp *viper.Viper, key string) error {
+	if !isKey(vp, key) {
+		return fmt.Errorf("unknown key: %s", key)
+	}
+
+	// each viper key/val entry should be bound to a command flag
+	flag := cmd.Flag(key)
+	if flag == nil {
+		return fmt.Errorf("key=%s not bound to a flag", key)
+	}
+
+	var val interface{}
+	switch typ := flag.Value.Type(); typ {
+	case "bool":
+		val = vp.GetBool(key)
+	case "duration":
+		val = vp.GetDuration(key)
+	case "int":
+		val = vp.GetInt(key)
+	case "string":
+		val = vp.GetString(key)
+	case "stringSlice":
+		val = vp.GetStringSlice(key)
+	default:
+		val = vp.Get(key)
+	}
+	if bs, err := yaml.Marshal(val); err == nil {
+		val = string(bs)
+	}
+	_, err := fmt.Fprint(cmd.OutOrStdout(), val)
+	return err
+}

--- a/cmd/config/reset.go
+++ b/cmd/config/reset.go
@@ -1,0 +1,52 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func newResetCommand(vp *viper.Viper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "reset [KEY]",
+		Short: "Reset all or an individual value in the hubble config file",
+		Long: "Reset all or an individual value in the hubble config file.\n" +
+			"When KEY is provided, this command is equivalent to 'set KEY'.\n" +
+			"If KEY is not provided, all values are reset to their default value.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch len(args) {
+			case 1:
+				return runSet(cmd, vp, args[0], "")
+			case 0:
+				return runReset(cmd, vp)
+			default:
+				return fmt.Errorf("invalid arguments: resset requires exactly 0 or 1 argument: got '%s'", strings.Join(args, " "))
+			}
+		},
+	}
+}
+
+func runReset(cmd *cobra.Command, vp *viper.Viper) error {
+	for _, key := range vp.AllKeys() {
+		if err := runSet(cmd, vp, key, ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -1,0 +1,91 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cast"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func newSetCommand(vp *viper.Viper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set KEY [VALUE]",
+		Short: "Set an individual value in the hubble config file",
+		Long: "Set an individual value in the hubble config file.\n" +
+			"If VALUE is not provided, the value is reset to its default value.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var val string
+			switch len(args) {
+			case 2:
+				val = args[1]
+				fallthrough
+			case 1:
+				return runSet(cmd, vp, args[0], val)
+			default:
+				return fmt.Errorf("invalid arguments: set requires exactly 1 or 2 argument(s): got '%s'", strings.Join(args, " "))
+			}
+		},
+	}
+}
+
+func runSet(cmd *cobra.Command, vp *viper.Viper, key, value string) error {
+	if !isKey(vp, key) {
+		return fmt.Errorf("unknown key: %s", key)
+	}
+
+	// each viper key/val entry should be bound to a command flag
+	flag := cmd.Flag(key)
+	if flag == nil {
+		return fmt.Errorf("key=%s not bound to a flag", key)
+	}
+
+	val := value
+	if value == "" {
+		val = flag.DefValue
+	}
+
+	var err error
+	var newVal interface{}
+	typ := flag.Value.Type()
+	switch typ {
+	case "bool":
+		newVal, err = cast.ToBoolE(val)
+	case "duration":
+		newVal, err = cast.ToDurationE(val)
+	case "int":
+		newVal, err = cast.ToIntE(val)
+	case "string":
+		newVal = val
+	case "stringSlice":
+		val = strings.TrimSuffix(strings.TrimPrefix(val, "["), "]")
+		if val == "" {
+			newVal = []string{} // csv reader would return io.EOF
+		} else {
+			newVal, err = csv.NewReader(strings.NewReader(val)).Read()
+		}
+	default:
+		return fmt.Errorf("unhandeld type %s, please open an issue", typ)
+	}
+	if err != nil {
+		return fmt.Errorf("cannot assign value=%s for key=%s, expected type=%s: %w", value, key, typ, err)
+	}
+	vp.Set(key, newVal)
+	return vp.WriteConfig()
+}

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -15,28 +15,29 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
 
-// New config command.
-func New(vp *viper.Viper) *cobra.Command {
-	configCmd := &cobra.Command{
-		Use:   "config",
-		Short: "Modify or view hubble config",
-		Long:  "Modify or view hubble config",
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			// override root persistent pre-run to avoid flag/config checks
-			// as we want to be able to modify/view the config even if it is
-			// invalid
-			return nil
-		},
+func newViewCommand(vp *viper.Viper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "view",
+		Short: "Display merged configuration settings",
+		Long:  "Display merged configuration settings",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
+			return runView(cmd, vp)
 		},
 	}
-	configCmd.AddCommand(
-		newViewCommand(vp),
-	)
-	return configCmd
+}
+
+func runView(cmd *cobra.Command, vp *viper.Viper) error {
+	bs, err := yaml.Marshal(vp.AllSettings())
+	if err != nil {
+		return fmt.Errorf("failed to marshal config to YAML: %w", err)
+	}
+	_, err = fmt.Fprint(cmd.OutOrStdout(), string(bs))
+	return err
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/hubble/cmd/common/conn"
 	"github.com/cilium/hubble/cmd/common/validate"
 	"github.com/cilium/hubble/cmd/completion"
+	"github.com/cilium/hubble/cmd/config"
 	"github.com/cilium/hubble/cmd/observe"
 	"github.com/cilium/hubble/cmd/peer"
 	"github.com/cilium/hubble/cmd/reflect"
@@ -140,6 +141,7 @@ func New() *cobra.Command {
 
 	rootCmd.AddCommand(
 		completion.New(),
+		config.New(vp),
 		observe.New(vp),
 		peer.New(vp),
 		reflect.New(vp),

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.2
 	github.com/gordonklaus/ineffassign v0.0.0-20200809085317-e36bfde3bb78
+	github.com/spf13/cast v1.3.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
 	google.golang.org/grpc v1.33.0
+	gopkg.in/yaml.v2 v2.3.0
 	honnef.co/go/tools v0.0.1-2019.2.3
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -76,6 +76,7 @@ github.com/sirupsen/logrus/hooks/syslog
 github.com/spf13/afero
 github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.0
+## explicit
 github.com/spf13/cast
 # github.com/spf13/cobra v1.0.0
 ## explicit
@@ -225,6 +226,7 @@ google.golang.org/protobuf/types/known/wrapperspb
 # gopkg.in/ini.v1 v1.51.0
 gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.3.0
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 gopkg.in/yaml.v3


### PR DESCRIPTION
```
$ hubble config -h
Modify or view hubble config

Usage:
  hubble config [flags]
  hubble config [command]

Available Commands:
  get         Get an individual value in the hubble config file
  reset       Reset all or an individual value in the hubble config file
  set         Set an individual value in the hubble config file
  view        Display merged configuration settings
...
```