### PR TITLE
defaults: avoid stutter in exported names

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,8 +95,8 @@ func New() *cobra.Command {
 	flags := rootCmd.PersistentFlags()
 	flags.String("config", defaultConfigFile, "Optional config file")
 	flags.BoolP("debug", "D", false, "Enable debug messages")
-	flags.String("server", defaults.GetDefaultSocketPath(), "Address of a Hubble server")
-	flags.Duration("timeout", defaults.DefaultDialTimeout, "Hubble server dialing timeout")
+	flags.String("server", defaults.GetSocketPath(), "Address of a Hubble server")
+	flags.Duration("timeout", defaults.DialTimeout, "Hubble server dialing timeout")
 	flags.Bool(
 		"tls",
 		false,

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -108,7 +108,7 @@ func runStatus(conn *grpc.ClientConn) error {
 }
 
 func getHC(conn *grpc.ClientConn) (healthy bool, status string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaults.DefaultRequestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.RequestTimeout)
 	defer cancel()
 
 	req := &healthpb.HealthCheckRequest{Service: v1.ObserverServiceName}
@@ -123,7 +123,7 @@ func getHC(conn *grpc.ClientConn) (healthy bool, status string, err error) {
 }
 
 func getStatus(conn *grpc.ClientConn) (*observer.ServerStatusResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaults.DefaultRequestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.RequestTimeout)
 	defer cancel()
 
 	req := &observer.ServerStatusRequest{}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -20,19 +20,11 @@ import (
 )
 
 const (
-	// DefaultSocketPathKey is the environment variable name to override the
-	// default socket path for observe and status commands.
-	DefaultSocketPathKey = "HUBBLE_DEFAULT_SOCKET_PATH"
+	// DialTimeout is the default timeout for dialing the server.
+	DialTimeout = 5 * time.Second
 
-	// DefaultDialTimeout is the timeout for dialing the server
-	DefaultDialTimeout = 5 * time.Second
-
-	// DefaultRequestTimeout is the timeout for client requests
-	DefaultRequestTimeout = 12 * time.Second
-
-	// defaultSocketPath on which to connect to the local hubble observer. Use
-	// GetDefaultSocketPath to access it.
-	defaultSocketPath = "unix:///var/run/cilium/hubble.sock"
+	// RequestTimeout is the default timeout for client requests.
+	RequestTimeout = 12 * time.Second
 
 	// FlowPrintCount is the default number of flows to print on the hubble
 	// observe CLI.
@@ -41,12 +33,20 @@ const (
 	// TargetTLSPrefix is a scheme that indicates that the target connection
 	// requires TLS.
 	TargetTLSPrefix = "tls://"
+
+	// socketPathKey is the environment variable name to override the default
+	// socket path for observe and status commands.
+	socketPathKey = "HUBBLE_DEFAULT_SOCKET_PATH"
+
+	// socketPath is the path of the socket on which to connect to the local
+	// hubble observer. Use GetDefaultSocketPath to access it.
+	socketPath = "unix:///var/run/cilium/hubble.sock"
 )
 
-// GetDefaultSocketPath returns the default server for status and observe command.
-func GetDefaultSocketPath() string {
-	if path, ok := os.LookupEnv(DefaultSocketPathKey); ok {
+// GetSocketPath returns the default server for status and observe command.
+func GetSocketPath() string {
+	if path, ok := os.LookupEnv(socketPathKey); ok {
 		return path
 	}
-	return defaultSocketPath
+	return socketPath
 }


### PR DESCRIPTION
Using symbol names such as defaults.DefaultDialTimeout or
defaults.DefaultRequestTimeout stutters (the word "default" is
repeated).  The package contents are always referred using the package
name as a prefix, so drop "Default" from these identifiers. Also see
https://blog.golang.org/package-names (section "Naming package
contents") and
https://github.com/golang/go/wiki/CodeReviewComments#package-names

Also unexport and rename DefaultSocketPathKey which is not used outside
pkg/defaults.