### PR TITLE
release: fix `release` binary usage instruction

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -68,7 +68,7 @@ to reflect the next planned release, i.e.
 Using https://github.com/cilium/release, prepare the release notes between the
 last minor version (latest patch) and current.
 
-    ./release --base $LAST_RELEASE --head v$MAJOR.$MINOR
+    ./release --repo cilium/hubble --base v$LAST_RELEASE --head v$MAJOR.$MINOR
     **Bugfixes:**
     * api: fix potential panic in endpoint's EqualsByID (#199, @Rolinh)
 


### PR DESCRIPTION
This tool defaults to `cilium/cilium` as the base repository so one needs to pass `--repo cilium/hubble`.
Also, add a `v` in `--base v$LAST_RELEASE` as Github can't find the version to compare to otherwise.
