### PR TITLE
build: ensure that binaries are always statically built

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/golang:1.15.3-alpine3.12 as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache git make
 COPY . .
-RUN make clean && CGO_ENABLED=0 make hubble
+RUN make clean && make hubble
 
 FROM docker.io/library/alpine:3.12
 RUN apk add --no-cache bash curl jq

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO := go
+GO := CGO_ENABLED=0 go
 INSTALL = $(QUIET)install
 BINDIR ?= /usr/local/bin
 IMAGE_REPOSITORY ?= quay.io/cilium/hubble


### PR DESCRIPTION
Current make release iterates over supported OS/Arch versions to
cross-compile release binaries. For all platforms that are NOT the same
as the one from which the build is run, CGO is automatically disabled.
This is expected as per [the reference documentation](https://golang.org/cmd/cgo/#hdr-Go_references_to_C):

> The cgo tool is enabled by default for native builds on systems where
> it is expected to work. It is disabled by default when
> cross-compiling.

However, when GOOS and GOARCH are the same as the host doing the build,
it seems that CGO is NOT automatically disabled. As we create release
binaries using an Alpine image, this means that the release binary for
Linux/AMD64 is dynamically linked against the musl libc. Example:

    $ file hubble
    hubble: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, Go BuildID=VA3fxK4tBsB4Zv8nGvhH/7h_TRfu0LvM0YKIBgvPu/uAObRaQQw0vOXYy0NVTF/6uhxSQlWDiL3MyvZeamO, stripped

This renders the binary unusable on most platforms. To address this,
ensure we always disable CGO.