### PR TITLE
v0.6: backport 2020-10-20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,4 @@ RUN make clean && CGO_ENABLED=0 make hubble
 FROM docker.io/library/alpine:3.12
 RUN apk add --no-cache bash curl jq
 COPY --from=builder /go/src/github.com/cilium/hubble/hubble /usr/bin
-ENTRYPOINT ["/usr/bin/hubble"]
-CMD ["help"]
+CMD ["/usr/bin/hubble"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/golang:1.14.10-alpine3.12 as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache git make
 COPY . .
-RUN make clean && CGO_ENABLED=0 make hubble
+RUN make clean && make hubble
 
 FROM docker.io/library/alpine:3.12
 RUN apk add --no-cache bash curl jq

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO := go
+GO := CGO_ENABLED=0 go
 INSTALL = $(QUIET)install
 BINDIR ?= /usr/local/bin
 IMAGE_REPOSITORY ?= quay.io/cilium/hubble


### PR DESCRIPTION
- #355: Dockerfile: Remove ENTRYPOINT (@michi-covalent)
- #397: build: ensure that binaries are always statically built (@Rolinh)