### PR TITLE
cmd: fix environment variable names for options with dashes

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -24,7 +24,24 @@ func New(vp *viper.Viper) *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:   "config",
 		Short: "Modify or view hubble config",
-		Long:  "Modify or view hubble config",
+		Long: `Config allows to modify or view the hubble configuration. Global hubble options
+can be set via flags, environment variables or a configuration file. The
+following precedence order is used:
+
+1. Flag
+2. Environment variable
+3. Configuration file
+4. Default value
+
+The "config view" subcommand provides a merged view of the configuration. The
+"config set" and "config reset" subcommand modify values in the configuration
+file.
+
+Environment variable names start with HUBBLE_ followed by the flag name
+capitalized where eventual dashes ('-') are replaced by underscores ('_').
+For example, the environment variable that corresponds to the "--server" flag
+is HUBBLE_SERVER. The environment variable for "--tls-allow-insecure" is
+HUBBLE_TLS_ALLOW_INSECURE and so on.`,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			// override root persistent pre-run to avoid flag/config checks
 			// as we want to be able to modify/view the config even if it is

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cilium/hubble/cmd/common/conn"
 	"github.com/cilium/hubble/cmd/common/validate"
@@ -173,6 +174,9 @@ func newViper() *viper.Viper {
 
 	// read config from environment variables
 	vp.SetEnvPrefix("hubble") // env var must start with HUBBLE_
-	vp.AutomaticEnv()         // read in environment variables that match
+	// replace - by _ for environment variable names
+	// (eg: the env var for tls-server-name is TLS_SERVER_NAME)
+	vp.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	vp.AutomaticEnv() // read in environment variables that match
 	return vp
 }


### PR DESCRIPTION
See commits for a longer explanation. This PR also updates the long help for the config command.