### PR TITLE
docs: Point to stable documentation

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -8,20 +8,20 @@ branch](https://github.com/cilium/hubble/tree/v0.5/Documentation).
 
 ## Getting Started
 
- * [Quickstart](https://docs.cilium.io/en/latest/gettingstarted/hubble)
- * [What is Hubble?](https://docs.cilium.io/en/latest/intro/#what-is-hubble)
- * [Installation with Cilium](https://docs.cilium.io/en/latest/gettingstarted/#installation)
- * [Running Prometheus and Grafana](https://docs.cilium.io/en/latest/gettingstarted/grafana/)
+ * [Quickstart](https://docs.cilium.io/en/stable/gettingstarted/hubble)
+ * [What is Hubble?](https://docs.cilium.io/en/stable/intro/#what-is-hubble)
+ * [Installation with Cilium](https://docs.cilium.io/en/stable/gettingstarted/#installation)
+ * [Running Prometheus and Grafana](https://docs.cilium.io/en/stable/gettingstarted/grafana/)
 
 ## Troubleshooting
 
-  * [Observing Flows with Hubble](https://docs.cilium.io/en/latest/operations/troubleshooting/#observing-flows-with-hubble)
-  * [Observing Flows with Hubble Relay](https://docs.cilium.io/en/latest/operations/troubleshooting/#observing-flows-with-hubble-relay)
+  * [Observing Flows with Hubble](https://docs.cilium.io/en/stable/operations/troubleshooting/#observing-flows-with-hubble)
+  * [Observing Flows with Hubble Relay](https://docs.cilium.io/en/stable/operations/troubleshooting/#observing-flows-with-hubble-relay)
 
 ## Internals
 
- * [Contributing](https://docs.cilium.io/en/latest/contributing/development/)
- * [Components](https://docs.cilium.io/en/latest/concepts/overview/#hubble)
- * [Architecture](https://docs.cilium.io/en/latest/hubble/)
- * [Code Overview](https://docs.cilium.io/en/latest/contributing/development/codeoverview/#hubble)
- * [Metrics Reference](https://docs.cilium.io/en/latest/operations/metrics/#hubble)
+ * [Contributing](https://docs.cilium.io/en/stable/contributing/development/)
+ * [Components](https://docs.cilium.io/en/stable/concepts/overview/#hubble)
+ * [Architecture](https://docs.cilium.io/en/stable/hubble/)
+ * [Code Overview](https://docs.cilium.io/en/stable/contributing/development/codeoverview/#hubble)
+ * [Metrics Reference](https://docs.cilium.io/en/stable/operations/metrics/#hubble)

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ and have to be used with caution in critical production workloads.
 
 # Getting Started
 
-* [Introduction to Cilium & Hubble](https://docs.cilium.io/en/latest/intro/)
-* [Networking and Security Observability with Hubble](https://docs.cilium.io/en/latest/gettingstarted/hubble/)
+* [Introduction to Cilium & Hubble](https://docs.cilium.io/en/stable/intro/)
+* [Networking and Security Observability with Hubble](https://docs.cilium.io/en/stable/gettingstarted/hubble/)
 
 # Features
 

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -1,7 +1,7 @@
 # Deployment of Hubble alongside Cilium
 
 Starting with **Cilium >=1.8**, the Hubble Helm charts are now part of Cilium.
-Please refer to the Cilium [installation instructions](https://docs.cilium.io/en/latest/gettingstarted/#installation)
+Please refer to the Cilium [installation instructions](https://docs.cilium.io/en/stable/gettingstarted/#installation)
 for details.
 
 **Note:** If you are running Cilium 1.7, you will find the Helm charts and


### PR DESCRIPTION
Rather than pointing users to the latest development documentation,
point them towards the current stable release so they're less likely to
hit random issues due to ongoing development.