### PR TITLE
cmd/config: add shell completion support for keys for get|set|reset

### DIFF
--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -29,6 +29,7 @@ func newGetCommand(vp *viper.Viper) *cobra.Command {
 		Short: "Get an individual value in the hubble config file",
 		Long: "Get an individual value in the hubble config file.\n" +
 			"If KEY is not provided, this command is equivalent to 'view'.",
+		ValidArgs: vp.AllKeys(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch len(args) {
 			case 1:

--- a/cmd/config/reset.go
+++ b/cmd/config/reset.go
@@ -29,6 +29,7 @@ func newResetCommand(vp *viper.Viper) *cobra.Command {
 		Long: "Reset all or an individual value in the hubble config file.\n" +
 			"When KEY is provided, this command is equivalent to 'set KEY'.\n" +
 			"If KEY is not provided, all values are reset to their default value.",
+		ValidArgs: vp.AllKeys(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch len(args) {
 			case 1:

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -32,6 +32,7 @@ func newSetCommand(vp *viper.Viper) *cobra.Command {
 		Short: "Set an individual value in the hubble config file",
 		Long: "Set an individual value in the hubble config file.\n" +
 			"If VALUE is not provided, the value is reset to its default value.",
+		ValidArgs: vp.AllKeys(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var val string
 			switch len(args) {


### PR DESCRIPTION
Add support for shell completion for keys for the `get`, `set` and
`reset` subcommands. This means that when using `<TAB>` after
`config get|set|reset`, the list of possible configuration keys is
offered for completion, improving the user experience.

Example with the `get` subcommand (using `zsh`):

```
$ hubble config get <TAB>
config                server                tls                   tls-ca-cert-files     tls-client-key-file
debug                 timeout               tls-allow-insecure    tls-client-cert-file  tls-server-name
```