### PR TITLE
cmd/observe: add support for dns-query filters

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -195,6 +195,10 @@ more.`,
 	})
 
 	observerCmd.Flags().Var(filterVar(
+		"dns-query", ofilter,
+		`Show all flows related to the given DNS query (e.g. "*.cilium.io").`))
+
+	observerCmd.Flags().Var(filterVar(
 		"http-status", ofilter,
 		`Show only flows which match this HTTP status code prefix (e.g. "404", "5+")`))
 	observerCmd.RegisterFlagCompletionFunc("http-status", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/observe/observe_filter.go
+++ b/cmd/observe/observe_filter.go
@@ -118,6 +118,7 @@ func newObserveFilter() *observeFilter {
 			{"service", "to-service"},
 			{"verdict"},
 			{"type"},
+			{"dns-query"},
 			{"http-status"},
 			{"http-method"},
 			{"http-path"},
@@ -203,6 +204,12 @@ func (of *observeFilter) set(f *filterTracker, name, val string, track bool) err
 	}
 
 	switch name {
+	// dns filters
+	case "dns-query":
+		f.apply(func(f *pb.FlowFilter) {
+			f.DnsQuery = append(f.DnsQuery, val)
+		})
+
 	// fqdn filters
 	case "fqdn":
 		f.applyLeft(func(f *pb.FlowFilter) {

--- a/cmd/observe/observe_usage.go
+++ b/cmd/observe/observe_usage.go
@@ -59,9 +59,10 @@ func modifyTemplate(orig string, cmd *cobra.Command) string {
 				"label", "to-label", "from-label",
 				"namespace", "to-namespace", "from-namespace",
 				"service", "to-service", "from-service",
-				"port", "to-port", "from-port",
-				"type", "verdict", "http-status", "http-method", "http-path", "protocol",
 				"identity", "to-identity", "from-identity",
+				"port", "to-port", "from-port",
+				"http-status", "http-method", "http-path",
+				"dns-query", "type", "verdict", "protocol",
 			},
 		},
 	}


### PR DESCRIPTION
Example usage (requires L7 visibility):
```
$ hubble observe --dns-query cilium.io
TIMESTAMP             SOURCE                                   DESTINATION                              TYPE           VERDICT     SUMMARY
Nov 18 15:55:04.400   default/alpine:33602                     kube-system/coredns-f9fd979d6-cwfsw:53   dns-request    FORWARDED   DNS Query cilium.io. A
Nov 18 15:55:04.402   kube-system/coredns-f9fd979d6-cwfsw:53   default/alpine:33602                     dns-response   FORWARDED   DNS Answer "104.198.14.52" TTL: 1 (Proxy cilium.io. A)
```