### PR TITLE
v0.6: make: set missing IMAGE_TAG variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 GO := CGO_ENABLED=0 go
 INSTALL = $(QUIET)install
 BINDIR ?= /usr/local/bin
-IMAGE_REPOSITORY ?= quay.io/cilium/hubble
-CONTAINER_ENGINE ?= docker
 TARGET=hubble
 VERSION=0.6.1
 GIT_BRANCH = $(shell which git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD)
 GIT_HASH = $(shell which git >/dev/null 2>&1 && git rev-parse --short HEAD)
 GO_TAGS ?=
+IMAGE_REPOSITORY ?= quay.io/cilium/hubble
+IMAGE_TAG ?= $(if $(findstring -dev,$(VERSION)),latest,v$(VERSION))
+CONTAINER_ENGINE ?= docker
 RELEASE_UID ?= $(shell id -u)
 RELEASE_GID ?= $(shell id -g)
 


### PR DESCRIPTION
This is a backport of #432 to the v0.6 branch.