### PR TITLE
completion: remove the copyright header

### DIFF
--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -21,22 +21,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const copyRightHeader = `
-# Copyright 2019 Authors of Hubble
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-`
-
 var (
 	completionExample = `
 # Installing bash completion on macOS using homebrew
@@ -94,9 +78,6 @@ func New() *cobra.Command {
 func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
 		return fmt.Errorf("too many arguments; expected only the shell type")
-	}
-	if _, err := out.Write([]byte(copyRightHeader)); err != nil {
-		return err
 	}
 
 	if len(args) == 0 {


### PR DESCRIPTION
Before this patch, the zsh completion was broken.

For zsh specifically, the first line of the completion file [must be a zsh autoload tag](http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Autoloaded-files):

>  Files whose first line does not start with one of these tags are not considered to be part of the completion system and will not be treated specially.