### PR TITLE
Makefile: Add support for DOCKER_FLAGS environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,6 @@ vet:
 	go vet $$(go list ./...)
 
 image:
-	$(CONTAINER_ENGINE) build -t $(IMAGE_REPOSITORY)$(if $(IMAGE_TAG),:$(IMAGE_TAG)) .
+	$(CONTAINER_ENGINE) build $(DOCKER_FLAGS) -t $(IMAGE_REPOSITORY)$(if $(IMAGE_TAG),:$(IMAGE_TAG)) .
 
 .PHONY: all hubble release install clean test bench check check-fmt ineffassign lint vet image


### PR DESCRIPTION
Add support for `DOCKER_FLAGS` environment variable to the Makefile. This allows passing builder-specific flags to the docker build command, such as required when using Docker BuildX.