### PR TITLE
cmd/observe: support for filtering events based on tcp-flags

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -138,6 +138,9 @@ more.`,
 	filterFlags.Var(filterVar(
 		"protocol", ofilter,
 		`Show only flows which match the given L4/L7 flow protocol (e.g. "udp", "http")`))
+	filterFlags.Var(filterVar(
+		"tcp-flags", ofilter,
+		`Show only flows which match the given TCP flags (e.g. "syn", "ack", "fin")`))
 	filterFlags.VarP(filterVarP(
 		"type", "t", ofilter, []string{},
 		fmt.Sprintf("Filter by event types TYPE[:SUBTYPE] (%v)", eventTypes())))

--- a/cmd/observe/observe_filter_test.go
+++ b/cmd/observe/observe_filter_test.go
@@ -257,3 +257,22 @@ func TestInvalidIdentity(t *testing.T) {
 	require.Error(t, cmd.Flags().Parse([]string{"--to-identity", "bad"}))
 	require.Error(t, cmd.Flags().Parse([]string{"--identity", "bad"}))
 }
+
+func TestTcpFlags(t *testing.T) {
+	f := newObserveFilter()
+	cmd := newObserveCmd(viper.New(), f)
+
+	// valid TCP flags
+	validflags := []string{"SYN", "syn", "FIN", "RST", "PSH", "ACK", "URG", "ECE", "CWR", "NS", "syn,ack"}
+	for _, f := range validflags {
+		require.NoError(t, cmd.Flags().Parse([]string{"--tcp-flags", f}))                               // single --tcp-flags
+		require.NoError(t, cmd.Flags().Parse([]string{"--tcp-flags", f, "--tcp-flags", "syn"}))         // multiple --tcp-flags
+		require.NoError(t, cmd.Flags().Parse([]string{"--tcp-flags", f, "--not", "--tcp-flags", "NS"})) // --not --tcp-flags
+	}
+
+	// invalid TCP flags
+	invalidflags := []string{"unknown", "syn,unknown", "unknown,syn", "syn,", ",syn"}
+	for _, f := range invalidflags {
+		require.Error(t, cmd.Flags().Parse([]string{"--tcp-flags", f}))
+	}
+}


### PR DESCRIPTION
Example Usage

**Note: the TCP flags values specified on the command line option are case-insensitive.**

#### To filter all the packets with SYN:
```
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ ./hubble observe --tcp-flags SYN
TIMESTAMP             SOURCE                                      DESTINATION                                 TYPE                     VERDICT     SUMMARY
Dec 18 17:10:40.696   [fd00::b]:37948                             [fd00::c]:4240                              Stale or unroutable IP   DROPPED     TCP Flags: SYN
Dec 18 17:10:40.765   kube-system/coredns-76dcd4bd85-mwtf7:8181   10.11.0.241:42142                           from-endpoint            FORWARDED   TCP Flags: SYN, ACK
Dec 18 17:10:41.720   [fd00::b]:37948                             [fd00::c]:4240                              from-host                FORWARDED   TCP Flags: SYN
```

#### To filter all the packets with SYN and ACK flags:
```
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ ./hubble observe --tcp-flags syn,ack
TIMESTAMP             SOURCE                                      DESTINATION         TYPE                     VERDICT     SUMMARY
Dec 18 17:09:13.816   [fd00::b]:4240                              [fd00::c]:32856     Stale or unroutable IP   DROPPED     TCP Flags: SYN, ACK
Dec 18 17:09:15.221   kube-system/coredns-76dcd4bd85-mwtf7:8080   10.11.0.241:53500   from-endpoint            FORWARDED   TCP Flags: SYN, ACK
Dec 18 17:09:15.823   [fd00::b]:4240                              [fd00::c]:32856     Stale or unroutable IP   DROPPED     TCP Flags: SYN, ACK
Dec 18 17:09:16.824   [fd00::b]:4240                              [fd00::c]:32856     from-host                FORWARDED   TCP Flags: SYN, ACK
...
```

#### To filter all the packets with SYN or ACK flags:
```
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ ./hubble observe --tcp-flags syn --tcp-flags ack
TIMESTAMP             SOURCE                                       DESTINATION                                  TYPE                     VERDICT     SUMMARY
Dec 18 17:17:30.765   10.11.0.241:43230                            kube-system/coredns-76dcd4bd85-mwtf7:8181   to-endpoint     FORWARDED   TCP Flags: SYN
Dec 18 17:17:30.765   kube-system/coredns-76dcd4bd85-mwtf7:8181    10.11.0.241:43230                           to-stack        FORWARDED   TCP Flags: SYN, ACK
Dec 18 17:17:30.765   10.11.0.241:43230                            kube-system/coredns-76dcd4bd85-mwtf7:8181   to-endpoint     FORWARDED   TCP Flags: ACK
Dec 18 17:17:30.766   10.11.0.241:43230                            kube-system/coredns-76dcd4bd85-mwtf7:8181   from-host       FORWARDED   TCP Flags: ACK, PSH
Dec 18 17:17:30.766   kube-system/coredns-76dcd4bd85-mwtf7:8181    10.11.0.241:43230                           to-stack        FORWARDED   TCP Flags: ACK, FIN
...
```

#### To filter packets with SYN but not SYN-ACK:
```
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ ./hubble observe --tcp-flags syn --not --tcp-flags ack
TIMESTAMP             SOURCE              DESTINATION                                 TYPE                     VERDICT     SUMMARY
Dec 18 17:18:42.712   [fd00::b]:39222     [fd00::c]:4240                              from-host                FORWARDED   TCP Flags: SYN
Dec 18 17:18:42.712   [fd00::b]:39222     [fd00::c]:4240                              Stale or unroutable IP   DROPPED     TCP Flags: SYN
Dec 18 17:18:43.224   [fd00::b]:39222     [fd00::c]:4240                              from-host                FORWARDED   TCP Flags: SYN
...
```

Fixes: #453 