### PR TITLE
cmd/observer: add support for agent event sub-type filters

### DIFF
--- a/cmd/observe/observe_filter.go
+++ b/cmd/observe/observe_filter.go
@@ -403,19 +403,17 @@ func (of *observeFilter) set(f *filterTracker, name, val string, track bool) err
 		}
 
 		if len(s) > 1 {
-		OUTER:
 			switch t {
 			case monitorAPI.MessageTypeTrace:
 				for k, v := range monitorAPI.TraceObservationPoints {
 					if s[1] == v {
 						typeFilter.MatchSubType = true
 						typeFilter.SubType = int32(k)
-						break OUTER
+						break
 					}
 				}
-				// fallthrough to parse subtype as integer
-				fallthrough
-			default:
+			}
+			if !typeFilter.MatchSubType {
 				t, err := strconv.ParseUint(s[1], 10, 32)
 				if err != nil {
 					return fmt.Errorf("unable to parse event sub-type '%s', not a known sub-type name and unable to parse as numeric value: %s", s[1], err)


### PR DESCRIPTION
The first commit add test coverage for the functionality changed in the successive commits.
The second commit does some small refactoring to avoid duplicating numeric sub-type parsing.
The third commit introduces the actual agent event sub-type filtering. One caveat was that the monitor API (`github.com/cilium/cilium/pkg/monitor/api`) doesn't provide the sub-type strings a form which would be convenient for CLI arguments (i.e. they contain spaces). Thus, `github.com/cilium/cilium/pkg/monitor/api.AgentNotifications` is duplicated in `cmd/observe` in more convenient form. A test is added to ensure the two maps are kept in sync.

See individual commit messages for more details.