### PR TITLE
ci: Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    rebase-strategy: disabled
+    labels:
+    - kind/enhancement
+    - release-note/misc
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    rebase-strategy: disabled
+    labels:
+    - kind/enhancement
+    - release-note/misc


### PR DESCRIPTION
This adds Dependabot for Hubble, like https://github.com/cilium/cilium/pull/14694.