### PR TITLE
ci: fix dependabot kind/enhancement label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,5 @@ updates:
     open-pull-requests-limit: 1
     rebase-strategy: disabled
     labels:
-    - kind/enhancement
-    - release-note/misc
+    - "📈 kind/enhancement"
+    - "release-note/misc"


### PR DESCRIPTION
Before this patch, because the kind/enhancement label is prefixed by the `chart_with_upwards_trend` icon, dependabot would complain to be unable to find the "kind/enhancement" label. See for example https://github.com/cilium/hubble/pull/476#issuecomment-773892140