### PR TITLE
all: avoid using the deprecated io/ioutil package

### DIFF
--- a/cmd/common/conn/tls.go
+++ b/cmd/common/conn/tls.go
@@ -19,7 +19,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/cilium/hubble/cmd/common/config"
@@ -49,7 +49,7 @@ func grpcOptionTLS(vp *viper.Viper) (grpc.DialOption, error) {
 	if len(caFiles) > 0 {
 		ca := x509.NewCertPool()
 		for _, path := range caFiles {
-			certPEM, err := ioutil.ReadFile(path)
+			certPEM, err := os.ReadFile(path)
 			if err != nil {
 				return nil, fmt.Errorf("cannot load cert '%s': %s", path, err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/hubble
 
-go 1.14
+go 1.16
 
 require (
 	github.com/cilium/cilium v1.9.0-rc1.0.20210209141502-b944040a9ec8

--- a/go.sum
+++ b/go.sum
@@ -411,7 +411,6 @@ github.com/google/renameio v1.0.0/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWU
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -737,7 +736,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -1194,6 +1192,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3-0.20201124161302-9f9c77085dec h1:4kolm8sIE3+p1GEdaLN4/J5Kcup/JoaypByWkoJ4odk=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3-0.20201124161302-9f9c77085dec/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
-sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@
 
 // Ensure build fails on versions of Go that are not supported by Hubble.
 // This build tag should be kept in sync with the version specified in go.mod.
-// +build go1.14
+// +build go1.16
 
 package main
 

--- a/pkg/printer/options.go
+++ b/pkg/printer/options.go
@@ -16,7 +16,6 @@ package printer
 
 import (
 	"io"
-	"io/ioutil"
 )
 
 // Output enum of the printer.
@@ -94,7 +93,7 @@ func Writer(w io.Writer) Option {
 // IgnoreStderr configures the output to not print any
 func IgnoreStderr() Option {
 	return func(opts *Options) {
-		opts.werr = ioutil.Discard
+		opts.werr = io.Discard
 	}
 }
 


### PR DESCRIPTION
As of Go 1.16, the `io/ioutil` package has been deprecated. Corresponding functions have moved to the `os` and `io` packages.
This in turns means that Go 1.16 is now required to build Hubble.