### PR TITLE
Revert "ci: fix dependabot kind/enhancement label"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,5 @@ updates:
     open-pull-requests-limit: 1
     rebase-strategy: disabled
     labels:
-    - "📈 kind/enhancement"
-    - "release-note/misc"
+    - kind/enhancement
+    - release-note/misc


### PR DESCRIPTION
This reverts commit 0d7fbb978f880e9c345cd3966f3669aecbdaa778.

See https://github.com/cilium/hubble/pull/492#issuecomment-783141026, the attempted fix introduced by https://github.com/cilium/hubble/pull/477 did not work. Consequently, I'm proposing to remove the icon from the `kind/enhancement` label and reverting the buggy dependabot fix.