### PR TITLE
cmd/observe: print filters in debug mode

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -95,8 +95,12 @@ application level. Rich filtering enable observing specific flows related to
 individual pods, services, TCP connections, DNS queries, HTTP requests and
 more.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := handleArgs(ofilter, vp.GetBool(config.KeyDebug)); err != nil {
+			debug := vp.GetBool(config.KeyDebug)
+			if err := handleArgs(ofilter, debug); err != nil {
 				return err
+			}
+			if debug {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Using filters:\n=> include: %s\n=> exclude: %s\n", ofilter.whitelist, ofilter.blacklist)
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/cmd/observe/observe_filter.go
+++ b/cmd/observe/observe_filter.go
@@ -16,6 +16,7 @@ package observe
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -41,6 +42,14 @@ type filterTracker struct {
 	// the defaults need to be wiped the first time user touches a []string
 	// value.
 	changed []string
+}
+
+func (f filterTracker) String() string {
+	ff := f.flowFilters()
+	if bs, err := json.Marshal(ff); err == nil {
+		return fmt.Sprintf("%v", string(bs))
+	}
+	return fmt.Sprintf("%v", ff)
 }
 
 func (f *filterTracker) add(name string) bool {


### PR DESCRIPTION
When debugging, it can be really useful to know about the filters that have been generated.

Example:

    $ hubble --debug observe --ip 9.9.9.9  > /dev/null
    Using config file: /home/user/.config/hubble/config.yaml
    Using filters:
    => include: [{"source_ip":["9.9.9.9"]},{"destination_ip":["9.9.9.9"]}]
    => exclude: <nil>