### PR TITLE
cmd/observe: add a new flag to allow specifying different time formats for timestamps

### DIFF
--- a/pkg/printer/options.go
+++ b/pkg/printer/options.go
@@ -43,6 +43,7 @@ type Options struct {
 	enableDebug         bool
 	enableIPTranslation bool
 	nodeName            bool
+	timeFormat          string
 }
 
 // Option ...
@@ -115,5 +116,15 @@ func WithIPTranslation() Option {
 func WithNodeName() Option {
 	return func(opts *Options) {
 		opts.nodeName = true
+	}
+}
+
+// WithTimeFormat specifies the time format layout to use when printing out
+// timestamps. This option has no effect if JSON or JSONPB option is used.
+// The layout must be a time format layout as specified in the standard
+// library's time package.
+func WithTimeFormat(layout string) Option {
+	return func(opts *Options) {
+		opts.timeFormat = layout
 	}
 }

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -428,7 +428,8 @@ func Test_getHostNames(t *testing.T) {
 
 func Test_fmtTimestamp(t *testing.T) {
 	type args struct {
-		t *timestamppb.Timestamp
+		layout string
+		t      *timestamppb.Timestamp
 	}
 	tests := []struct {
 		name string
@@ -438,6 +439,7 @@ func Test_fmtTimestamp(t *testing.T) {
 		{
 			name: "valid",
 			args: args{
+				layout: time.StampMilli,
 				t: &timestamppb.Timestamp{
 					Seconds: 0,
 					Nanos:   0,
@@ -448,6 +450,7 @@ func Test_fmtTimestamp(t *testing.T) {
 		{
 			name: "valid non-zero",
 			args: args{
+				layout: time.StampMilli,
 				t: &timestamppb.Timestamp{
 					Seconds: 1530984600,
 					Nanos:   123000000,
@@ -458,6 +461,7 @@ func Test_fmtTimestamp(t *testing.T) {
 		{
 			name: "invalid",
 			args: args{
+				layout: time.StampMilli,
 				t: &timestamppb.Timestamp{
 					Seconds: -1,
 					Nanos:   -1,
@@ -473,7 +477,7 @@ func Test_fmtTimestamp(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := fmtTimestamp(tt.args.t); got != tt.want {
+			if got := fmtTimestamp(tt.args.layout, tt.args.t); got != tt.want {
 				t.Errorf("getTimestamp() = %v, want %v", got, tt.want)
 			}
 		})
@@ -688,7 +692,7 @@ func TestPrinter_AgentEventDetails(t *testing.T) {
 					},
 				},
 			},
-			want: "start time: " + fmtTimestamp(startTS),
+			want: "start time: " + fmtTimestamp(time.StampMilli, startTS),
 		},
 		{
 			name: "policy update",
@@ -836,7 +840,7 @@ func TestPrinter_AgentEventDetails(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getAgentEventDetails(tt.ev); got != tt.want {
+			if got := getAgentEventDetails(tt.ev, time.StampMilli); got != tt.want {
 				t.Errorf("getAgentEventDetails()\ngot:  %v,\nwant: %v", got, tt.want)
 			}
 		})

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -19,6 +19,15 @@ import (
 	"time"
 )
 
+const (
+	// RFC3339Milli is a time format layout for use in time.Format and
+	// time.Parse. It follows the RFC3339 format with millisecond precision.
+	RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"
+	// RFC3339Micro is a time format layout for use in time.Format and
+	// time.Parse. It follows the RFC3339 format with microsecond precision.
+	RFC3339Micro = "2006-01-02T15:04:05.999999Z07:00"
+)
+
 var (
 	// Now is a hijackable function for time.Now() that makes unit testing a lot
 	// easier for stuff that relies on relative time.

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -34,6 +34,16 @@ var (
 	Now = time.Now
 )
 
+// layouts is a set of supported time format layouts. Format that only apply to
+// local times should not be added to this list.
+var layouts = []string{
+	time.RFC3339,
+	time.RFC3339Nano,
+	RFC3339Milli,
+	RFC3339Micro,
+	time.RFC1123Z,
+}
+
 // FromString takes as input a string in either RFC3339 or time.Duration
 // format in the past and converts it to a time.Time.
 func FromString(input string) (time.Time, error) {
@@ -43,10 +53,11 @@ func FromString(input string) (time.Time, error) {
 		return Now().Add(-d), nil
 	}
 
-	// try as rfc3339
-	t, err := time.Parse(time.RFC3339, input)
-	if err == nil {
-		return t, nil
+	for _, layout := range layouts {
+		t, err := time.Parse(layout, input)
+		if err == nil {
+			return t, nil
+		}
 	}
 
 	return time.Time{}, fmt.Errorf(


### PR DESCRIPTION
This PR adds a new option to the observe command (`--time-format`) to allow specifying a different time format for timestamps. The default is unchanged and remains `time.StampMilli`. The following formats are supported:
```
      --time-format string   Specify the time format for printing. This option does not apply to the json and jsonpb output type. One of:
                               StampMilli:   Jan _2 15:04:05.000
                               RFC3339:      2006-01-02T15:04:05Z07:00
                               RFC3339Milli: 2006-01-02T15:04:05.999Z07:00
                               RFC3339Micro: 2006-01-02T15:04:05.999999Z07:00
                               RFC3339Nano:  2006-01-02T15:04:05.999999999Z07:00
                               RFC1123Z:     Mon, 02 Jan 2006 15:04:05 -0700
                               (default "StampMilli")
```

In addition, new formats are supported for the `--since` and `--until` flags, namely `RFC3339` and `RFC3339[milli|micro|nano]` and `RFC1123Z`.