### PR TITLE
cmd/observe: Print the entire request in debug mode

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/hubble/cmd/common/conn"
 	"github.com/cilium/hubble/cmd/common/template"
 	"github.com/cilium/hubble/pkg/defaults"
+	"github.com/cilium/hubble/pkg/logger"
 	hubprinter "github.com/cilium/hubble/pkg/printer"
 	hubtime "github.com/cilium/hubble/pkg/time"
 	"github.com/spf13/cobra"
@@ -120,9 +121,6 @@ more.`,
 			if err := handleArgs(ofilter, debug); err != nil {
 				return err
 			}
-			if debug {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Using filters:\n=> include: %s\n=> exclude: %s\n", ofilter.whitelist, ofilter.blacklist)
-			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
@@ -134,6 +132,7 @@ more.`,
 			if err != nil {
 				return err
 			}
+			logger.Logger.WithField("request", req).Debug("Sending GetFlows request")
 			client := observer.NewObserverClient(hubbleConn)
 			if err := getFlows(client, req); err != nil {
 				msg := err.Error()

--- a/cmd/observe/observe_test.go
+++ b/cmd/observe/observe_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/api/v1/observer"
+	"github.com/cilium/hubble/pkg/defaults"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func Test_getRequest(t *testing.T) {
+	filter := newObserveFilter()
+	req, err := getRequest(filter)
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetFlowsRequest{Number: defaults.FlowPrintCount}, req)
+	selectorOpts.since = "2021-03-23T00:00:00Z"
+	selectorOpts.until = "2021-03-24T00:00:00Z"
+	req, err = getRequest(filter)
+	assert.NoError(t, err)
+	since, err := time.Parse(time.RFC3339, selectorOpts.since)
+	assert.NoError(t, err)
+	until, err := time.Parse(time.RFC3339, selectorOpts.until)
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetFlowsRequest{
+		Number: defaults.FlowPrintCount,
+		Since:  timestamppb.New(since),
+		Until:  timestamppb.New(until),
+	}, req)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/cilium/hubble/cmd/common/config"
@@ -31,6 +30,7 @@ import (
 	"github.com/cilium/hubble/cmd/status"
 	"github.com/cilium/hubble/cmd/version"
 	"github.com/cilium/hubble/pkg"
+	"github.com/cilium/hubble/pkg/logger"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -63,8 +63,11 @@ func NewWithViper(vp *viper.Viper) *cobra.Command {
 			vp.SetConfigFile(cfg)
 		}
 		// if a config file is found, read it in.
-		if err := vp.ReadInConfig(); err == nil && vp.GetBool(config.KeyDebug) {
-			fmt.Fprintln(rootCmd.ErrOrStderr(), "Using config file:", vp.ConfigFileUsed())
+		err := vp.ReadInConfig()
+		// initialize the logger after all the config parameters get loaded to viper.
+		logger.Initialize(vp)
+		if err == nil {
+			logger.Logger.WithField("config-file", vp.ConfigFileUsed()).Debug("Using config file")
 		}
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cilium/cilium v1.9.0-rc1.0.20210209141502-b944040a9ec8
 	github.com/google/go-cmp v0.5.5
 	github.com/gordonklaus/ineffassign v0.0.0-20210209182638-d0e41b2fc8ed
+	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"sync"
+
+	"github.com/cilium/hubble/cmd/common/config"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+var (
+	// Logger is a logger that is configured based on viper parameters.
+	// Initialize() must be called before accessing it.
+	Logger *logrus.Logger
+	once   sync.Once
+)
+
+// Initialize initializes Logger based on config values in viper.
+func Initialize(vp *viper.Viper) {
+	once.Do(func() {
+		Logger = logrus.New()
+		Logger.SetFormatter(&logrus.TextFormatter{
+			DisableColors: true,
+			FullTimestamp: true,
+		})
+		if vp.GetBool(config.KeyDebug) {
+			Logger.SetLevel(logrus.DebugLevel)
+		} else {
+			Logger.SetLevel(logrus.InfoLevel)
+		}
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -67,6 +67,7 @@ github.com/pmezard/go-difflib/difflib
 # github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa
 github.com/sasha-s/go-deadlock
 # github.com/sirupsen/logrus v1.7.0
+## explicit
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
 # github.com/spf13/afero v1.3.3


### PR DESCRIPTION
Following up on 63d154c, print the entire GetFlowsRequest instead of
only printing filters.

Here is a sample output:

    % ./hubble observe --since 2021-03-02T01:09:31Z --last 1 -t drop --debug
    Sending a request: {"number":"1","whitelist":[{"event_type":[{"type":1}]}],"since":"2021-03-02T01:09:31Z"}

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>