### PR TITLE
compact: Always print original source on the left

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -272,11 +272,21 @@ func (p *Printer) WriteProtoFlow(res *observerpb.GetFlowsResponse) error {
 		if p.opts.nodeName {
 			node = fmt.Sprintf(" [%s]", f.GetNodeName())
 		}
+		arrow := "->"
+		if f.GetIsReply() == nil {
+			// direction is unknown.
+			arrow = "<>"
+		} else if f.GetIsReply().Value {
+			// flip the arrow and src/dst for reply packets.
+			src, dst = dst, src
+			arrow = "<-"
+		}
 		_, err := fmt.Fprintf(p.opts.w,
-			"%s%s: %s -> %s %s %s (%s)\n",
+			"%s%s: %s %s %s %s %s (%s)\n",
 			fmtTimestamp(p.opts.timeFormat, f.GetTime()),
 			node,
 			src,
+			arrow,
 			dst,
 			GetFlowType(f),
 			f.GetVerdict().String(),


### PR DESCRIPTION
Keep the original source on the left and use "<-" for reply packets.

Before:
```
2021-04-22T03:51:42Z: 10.168.0.11:33192 -> kube-system/kube-dns-5d54b45645-p9kvw:8081 to-endpoint FORWARDED (TCP Flags: SYN)
2021-04-22T03:51:42Z: kube-system/kube-dns-5d54b45645-p9kvw:8081 -> 10.168.0.11:33192 to-stack FORWARDED (TCP Flags: SYN, ACK)
2021-04-22T03:51:42Z: 10.168.0.11:33192 -> kube-system/kube-dns-5d54b45645-p9kvw:8081 to-endpoint FORWARDED (TCP Flags: ACK)
2021-04-22T03:51:42Z: 10.168.0.11:33192 -> kube-system/kube-dns-5d54b45645-p9kvw:8081 to-endpoint FORWARDED (TCP Flags: ACK, PSH)
2021-04-22T03:51:42Z: kube-system/kube-dns-5d54b45645-p9kvw:8081 -> 10.168.0.11:33192 to-stack FORWARDED (TCP Flags: ACK, PSH)
2021-04-22T03:51:42Z: kube-system/kube-dns-5d54b45645-p9kvw:8081 -> 10.168.0.11:33192 to-stack FORWARDED (TCP Flags: ACK, FIN)
2021-04-22T03:51:42Z: 10.168.0.11:33192 -> kube-system/kube-dns-5d54b45645-p9kvw:8081 to-endpoint FORWARDED (TCP Flags: ACK, FIN)
```

After:
```
2021-04-22T03:50:02Z: 10.168.0.11:60982 -> kube-system/kube-dns-5d54b45645-p9kvw:8081 to-endpoint FORWARDED (TCP Flags: SYN)
2021-04-22T03:50:02Z: 10.168.0.11:60982 <- kube-system/kube-dns-5d54b45645-p9kvw:8081 to-stack FORWARDED (TCP Flags: SYN, ACK)
2021-04-22T03:50:02Z: 10.168.0.11:60982 -> kube-system/kube-dns-5d54b45645-p9kvw:8081 to-endpoint FORWARDED (TCP Flags: ACK)
2021-04-22T03:50:02Z: 10.168.0.11:60982 -> kube-system/kube-dns-5d54b45645-p9kvw:8081 to-endpoint FORWARDED (TCP Flags: ACK, PSH)
2021-04-22T03:50:02Z: 10.168.0.11:60982 <- kube-system/kube-dns-5d54b45645-p9kvw:8081 to-stack FORWARDED (TCP Flags: ACK, PSH)
2021-04-22T03:50:02Z: 10.168.0.11:60982 <- kube-system/kube-dns-5d54b45645-p9kvw:8081 to-stack FORWARDED (TCP Flags: ACK, FIN)
2021-04-22T03:50:02Z: 10.168.0.11:60982 -> kube-system/kube-dns-5d54b45645-p9kvw:8081 to-endpoint FORWARDED (TCP Flags: ACK, FIN)
```

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>