### PR TITLE
cmd/observe: don't list agent/debug events and recorder captures in event type filter

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -77,11 +77,16 @@ var verdicts = []string{
 	pb.Verdict_ERROR.String(),
 }
 
-func eventTypes() (l []string) {
-	for t := range monitorAPI.MessageTypeNames {
-		l = append(l, t)
-	}
-	return
+// eventTypes are the valid event types supported by observe. This corresponds
+// to monitorAPI.MessageTypeNames, excluding MessageTypeNameAgent,
+// MessageTypeNameDebug and MessageTypeNameRecCapture. These excluded message
+// message types are not supported by observe but have separate sub-commands.
+var eventTypes = []string{
+	monitorAPI.MessageTypeNameDrop,
+	monitorAPI.MessageTypeNameCapture,
+	monitorAPI.MessageTypeNameTrace,
+	monitorAPI.MessageTypeNameL7,
+	monitorAPI.MessageTypeNamePolicyVerdict,
 }
 
 func timeFormatNameToLayout(name string) string {
@@ -198,7 +203,7 @@ more.`,
 		`Show only flows which match the given TCP flags (e.g. "syn", "ack", "fin")`))
 	filterFlags.VarP(filterVarP(
 		"type", "t", ofilter, []string{},
-		fmt.Sprintf("Filter by event types TYPE[:SUBTYPE] (%v)", eventTypes())))
+		fmt.Sprintf("Filter by event types TYPE[:SUBTYPE] (%v)", eventTypes)))
 	filterFlags.Var(filterVar(
 		"verdict", ofilter,
 		fmt.Sprintf("Show only flows with this verdict [%s]", strings.Join(verdicts, ", ")),
@@ -366,7 +371,7 @@ more.`,
 		return []string{"none", "v4", "v6"}, cobra.ShellCompDirectiveDefault
 	})
 	observeCmd.RegisterFlagCompletionFunc("type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return eventTypes(), cobra.ShellCompDirectiveDefault
+		return eventTypes, cobra.ShellCompDirectiveDefault
 	})
 	observeCmd.RegisterFlagCompletionFunc("verdict", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return verdicts, cobra.ShellCompDirectiveDefault

--- a/cmd/observe/observe_test.go
+++ b/cmd/observe/observe_test.go
@@ -19,10 +19,31 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/observer"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/hubble/pkg/defaults"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestEventTypes(t *testing.T) {
+	// Make sure to keep event type slices in sync. Agent events, debug
+	// events and recorder captures have separate subcommands and are not
+	// supported in observe, thus the -3. See eventTypes godoc for details.
+	require.Len(t, eventTypes, len(monitorAPI.MessageTypeNames)-3)
+	for _, v := range eventTypes {
+		require.Contains(t, monitorAPI.MessageTypeNames, v)
+	}
+	for k := range monitorAPI.MessageTypeNames {
+		switch k {
+		case monitorAPI.MessageTypeNameAgent,
+			monitorAPI.MessageTypeNameDebug,
+			monitorAPI.MessageTypeNameRecCapture:
+			continue
+		}
+		require.Contains(t, eventTypes, k)
+	}
+}
 
 func Test_getRequest(t *testing.T) {
 	filter := newObserveFilter()


### PR DESCRIPTION
As of commit 5071eca2f964 ("Bump github.com/cilium/cilium to pull in
reworked agent/debug event API"), the agent and debug event types are no
longer handled by the GetFlows API and the newly introduced recorder
capture has its own API as well, see commit df71f17a5be6 ("cmd: Add
record subcommand").

Thus, also the filtering on these in "hubble observe" which uses the
GetFlows API doesn't work. Omit these types from the --type/-t option.
Also add a test to ensure the list of supported event types are in sync
with the respective event types supported by the monitor API.

Before:

```
$ hubble observe -h
...
  -t, --type filter             Filter by event types TYPE[:SUBTYPE] ([l7 agent policy-verdict recorder drop debug capture trace])
...
```

After:

```
$ hubble observe -h
...
  -t, --type filter             Filter by event types TYPE[:SUBTYPE] ([drop capture trace l7 policy-verdict])
...
```