### PR TITLE
change default address to localhost:4245

### DIFF
--- a/cmd/common/config/flags.go
+++ b/cmd/common/config/flags.go
@@ -54,7 +54,7 @@ func initGlobalFlags() {
 }
 
 func initServerFlags() {
-	ServerFlags.String(KeyServer, defaults.GetSocketPath(), "Address of a Hubble server")
+	ServerFlags.String(KeyServer, defaults.ServerAddress, "Address of a Hubble server")
 	ServerFlags.Duration(KeyTimeout, defaults.DialTimeout, "Hubble server dialing timeout")
 	ServerFlags.Bool(
 		KeyTLS,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -21,6 +21,9 @@ import (
 )
 
 const (
+	// ServerAddress is the default server address.
+	ServerAddress = "localhost:4245"
+
 	// DialTimeout is the default timeout for dialing the server.
 	DialTimeout = 5 * time.Second
 


### PR DESCRIPTION
The default server address was set to the UNIX domain socket of Hubble
server for historical reasons. This socket is only available when
running the Hubble CLI from within a Cilium container, which is not the
recommended way to use Hubble nowadays. Users are typically recommended
to port forward the Hubble Relay service port locally to access Hubble
via the CLI. As Hubble Relay is available since Cilium v1.8, it makes
sense to change the default to the address that is the most commonly
use.

For Hubble CLI to continue working as before when within the Cilium
container, the `HUBBLE_SERVER` environment variable should be set to the
UNIX domain socket address.