### PR TITLE
Add subcommands for agent and debug events

### DIFF
--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -21,8 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	completionExample = `
+const completionExample = `
 # Installing bash completion on macOS using homebrew
 ## If running Bash 3.2 included with macOS
 	brew install bash-completion
@@ -59,7 +58,6 @@ var (
         hubble completion fish | source
 ## Write fish completion code to a file
         hubble completion fish > ~/.config/fish/completions/hubble.fish`
-)
 
 // New creates a new shell completion command.
 func New() *cobra.Command {

--- a/cmd/observe/agent_events.go
+++ b/cmd/observe/agent_events.go
@@ -1,0 +1,152 @@
+// Copyright 2021 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+
+	observerpb "github.com/cilium/cilium/api/v1/observer"
+	"github.com/cilium/hubble/cmd/common/config"
+	"github.com/cilium/hubble/cmd/common/conn"
+	"github.com/cilium/hubble/cmd/common/template"
+	"github.com/cilium/hubble/pkg/defaults"
+	"github.com/cilium/hubble/pkg/logger"
+	hubtime "github.com/cilium/hubble/pkg/time"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func newAgentEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.Command {
+	agentEventsCmd := &cobra.Command{
+		Use:   "agent-events",
+		Short: "Observe Cilium agent events",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			debug := vp.GetBool(config.KeyDebug)
+			if err := handleEventsArgs(debug); err != nil {
+				return err
+			}
+			req, err := getAgentEventsRequest()
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+			defer cancel()
+
+			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			if err != nil {
+				return err
+			}
+			defer hubbleConn.Close()
+			client := observerpb.NewObserverClient(hubbleConn)
+			logger.Logger.WithField("request", req).Debug("Sending GetAgentEvents request")
+			if err := getAgentEvents(ctx, client, req); err != nil {
+				msg := err.Error()
+				// extract custom error message from failed grpc call
+				if s, ok := status.FromError(err); ok && s.Code() == codes.Unknown {
+					msg = s.Message()
+				}
+				return errors.New(msg)
+			}
+			return nil
+		},
+	}
+
+	agentEventsCmd.SetUsageTemplate(template.Usage(flagSets...))
+
+	return agentEventsCmd
+}
+
+func getAgentEventsRequest() (*observerpb.GetAgentEventsRequest, error) {
+	// convert selectorOpts.since into a param for GetAgentEvents
+	var since, until *timestamppb.Timestamp
+	if selectorOpts.since != "" {
+		st, err := hubtime.FromString(selectorOpts.since)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse the since time: %v", err)
+		}
+
+		since = timestamppb.New(st)
+		if err := since.CheckValid(); err != nil {
+			return nil, fmt.Errorf("failed to convert `since` timestamp to proto: %v", err)
+		}
+		// Set the until field if both --since and --until options are specified and --follow
+		// is not specified. If --since is specified but --until is not, the server sets the
+		// --until option to the current timestamp.
+		if selectorOpts.until != "" && !selectorOpts.follow {
+			ut, err := hubtime.FromString(selectorOpts.until)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse the until time: %v", err)
+			}
+			until = timestamppb.New(ut)
+			if err := until.CheckValid(); err != nil {
+				return nil, fmt.Errorf("failed to convert `until` timestamp to proto: %v", err)
+			}
+		}
+	}
+
+	if since == nil && until == nil {
+		switch {
+		case selectorOpts.all:
+			// all is an alias for last=uint64_max
+			selectorOpts.last = ^uint64(0)
+		case selectorOpts.last == 0:
+			// no specific parameters were provided, just a vanilla `hubble events agent`
+			selectorOpts.last = defaults.EventsPrintCount
+		}
+	}
+
+	return &observerpb.GetAgentEventsRequest{
+		Number: selectorOpts.last,
+		Follow: selectorOpts.follow,
+		Since:  since,
+		Until:  until,
+	}, nil
+}
+
+func getAgentEvents(ctx context.Context, client observerpb.ObserverClient, req *observerpb.GetAgentEventsRequest) error {
+	b, err := client.GetAgentEvents(ctx, req)
+	if err != nil {
+		return err
+	}
+	defer printer.Close()
+
+	for {
+		resp, err := b.Recv()
+		switch err {
+		case io.EOF, context.Canceled:
+			return nil
+		case nil:
+		default:
+			if status.Code(err) == codes.Canceled {
+				return nil
+			}
+			return err
+		}
+
+		if err = printer.WriteProtoAgentEvent(resp); err != nil {
+			return err
+		}
+	}
+}

--- a/cmd/observe/agent_events_test.go
+++ b/cmd/observe/agent_events_test.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/api/v1/observer"
+	"github.com/cilium/hubble/pkg/defaults"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func Test_getAgentEventsRequest(t *testing.T) {
+	selectorOpts.since = ""
+	selectorOpts.until = ""
+	req, err := getAgentEventsRequest()
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetAgentEventsRequest{Number: defaults.EventsPrintCount}, req)
+	selectorOpts.since = "2021-04-26T00:00:00Z"
+	selectorOpts.until = "2021-04-26T00:01:00Z"
+	req, err = getAgentEventsRequest()
+	assert.NoError(t, err)
+	since, err := time.Parse(time.RFC3339, selectorOpts.since)
+	assert.NoError(t, err)
+	until, err := time.Parse(time.RFC3339, selectorOpts.until)
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetAgentEventsRequest{
+		Number: defaults.EventsPrintCount,
+		Since:  timestamppb.New(since),
+		Until:  timestamppb.New(until),
+	}, req)
+}

--- a/cmd/observe/debug_events.go
+++ b/cmd/observe/debug_events.go
@@ -1,0 +1,153 @@
+// Copyright 2021 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+
+	observerpb "github.com/cilium/cilium/api/v1/observer"
+	"github.com/cilium/hubble/cmd/common/config"
+	"github.com/cilium/hubble/cmd/common/conn"
+	"github.com/cilium/hubble/cmd/common/template"
+	"github.com/cilium/hubble/pkg/defaults"
+	"github.com/cilium/hubble/pkg/logger"
+	hubtime "github.com/cilium/hubble/pkg/time"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func newDebugEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.Command {
+	debugEventsCmd := &cobra.Command{
+		Use:   "debug-events",
+		Short: "Observe Cilium debug events",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			debug := vp.GetBool(config.KeyDebug)
+			if err := handleEventsArgs(debug); err != nil {
+				return err
+			}
+			req, err := getDebugEventsRequest()
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+			defer cancel()
+
+			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			if err != nil {
+				return err
+			}
+			defer hubbleConn.Close()
+			client := observerpb.NewObserverClient(hubbleConn)
+			logger.Logger.WithField("request", req).Debug("Sending GetDebugEvents request")
+			if err := getDebugEvents(ctx, client, req); err != nil {
+				msg := err.Error()
+				// extract custom error message from failed grpc call
+				if s, ok := status.FromError(err); ok && s.Code() == codes.Unknown {
+					msg = s.Message()
+				}
+				return errors.New(msg)
+			}
+			return nil
+		},
+	}
+
+	debugEventsCmd.SetUsageTemplate(template.Usage(flagSets...))
+
+	return debugEventsCmd
+}
+
+func getDebugEventsRequest() (*observerpb.GetDebugEventsRequest, error) {
+	// convert selectorOpts.since into a param for GetDebugEvents
+	var since, until *timestamppb.Timestamp
+	if selectorOpts.since != "" {
+		st, err := hubtime.FromString(selectorOpts.since)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse the since time: %v", err)
+		}
+
+		since = timestamppb.New(st)
+		if err := since.CheckValid(); err != nil {
+			return nil, fmt.Errorf("failed to convert `since` timestamp to proto: %v", err)
+		}
+		// Set the until field if both --since and --until options are specified and --follow
+		// is not specified. If --since is specified but --until is not, the server sets the
+		// --until option to the current timestamp.
+		if selectorOpts.until != "" && !selectorOpts.follow {
+			ut, err := hubtime.FromString(selectorOpts.until)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse the until time: %v", err)
+			}
+			until = timestamppb.New(ut)
+			if err := until.CheckValid(); err != nil {
+				return nil, fmt.Errorf("failed to convert `until` timestamp to proto: %v", err)
+			}
+		}
+	}
+
+	if since == nil && until == nil {
+		switch {
+		case selectorOpts.all:
+			// all is an alias for last=uint64_max
+			selectorOpts.last = ^uint64(0)
+		case selectorOpts.last == 0:
+			// no specific parameters were provided, just a vanilla `hubble events debug`
+			selectorOpts.last = defaults.EventsPrintCount
+		}
+	}
+
+	return &observerpb.GetDebugEventsRequest{
+		Number: selectorOpts.last,
+		Follow: selectorOpts.follow,
+		Since:  since,
+		Until:  until,
+	}, nil
+}
+
+func getDebugEvents(ctx context.Context, client observerpb.ObserverClient, req *observerpb.GetDebugEventsRequest) error {
+	b, err := client.GetDebugEvents(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	defer printer.Close()
+
+	for {
+		resp, err := b.Recv()
+		switch err {
+		case io.EOF, context.Canceled:
+			return nil
+		case nil:
+		default:
+			if status.Code(err) == codes.Canceled {
+				return nil
+			}
+			return err
+		}
+
+		if err = printer.WriteProtoDebugEvent(resp); err != nil {
+			return err
+		}
+	}
+}

--- a/cmd/observe/debug_events_test.go
+++ b/cmd/observe/debug_events_test.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/api/v1/observer"
+	"github.com/cilium/hubble/pkg/defaults"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func Test_getDebugEventsRequest(t *testing.T) {
+	selectorOpts.since = ""
+	selectorOpts.until = ""
+	req, err := getDebugEventsRequest()
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetDebugEventsRequest{Number: defaults.EventsPrintCount}, req)
+	selectorOpts.since = "2021-04-26T01:00:00Z"
+	selectorOpts.until = "2021-04-26T01:01:00Z"
+	req, err = getDebugEventsRequest()
+	assert.NoError(t, err)
+	since, err := time.Parse(time.RFC3339, selectorOpts.since)
+	assert.NoError(t, err)
+	until, err := time.Parse(time.RFC3339, selectorOpts.until)
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetDebugEventsRequest{
+		Number: defaults.EventsPrintCount,
+		Since:  timestamppb.New(since),
+		Until:  timestamppb.New(until),
+	}, req)
+}

--- a/cmd/observe/events.go
+++ b/cmd/observe/events.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"fmt"
+
+	hubprinter "github.com/cilium/hubble/pkg/printer"
+	hubtime "github.com/cilium/hubble/pkg/time"
+)
+
+func handleEventsArgs(debug bool) error {
+	// initialize the printer with any options that were passed in
+	var opts = []hubprinter.Option{
+		hubprinter.WithTimeFormat(hubtime.FormatNameToLayout(formattingOpts.timeFormat)),
+	}
+
+	switch formattingOpts.output {
+	case "compact":
+		opts = append(opts, hubprinter.Compact())
+	case "dict":
+		opts = append(opts, hubprinter.Dict())
+	case "json", "JSON":
+		opts = append(opts, hubprinter.JSON())
+	case "jsonpb":
+		opts = append(opts, hubprinter.JSONPB())
+	case "tab", "table":
+		if selectorOpts.follow {
+			return fmt.Errorf("table output format is not compatible with follow mode")
+		}
+		opts = append(opts, hubprinter.Tab())
+	default:
+		return fmt.Errorf("invalid output format: %s", formattingOpts.output)
+	}
+
+	if otherOpts.ignoreStderr {
+		opts = append(opts, hubprinter.IgnoreStderr())
+	}
+	if debug {
+		opts = append(opts, hubprinter.WithDebug())
+	}
+	if formattingOpts.nodeName {
+		opts = append(opts, hubprinter.WithNodeName())
+	}
+
+	printer = hubprinter.New(opts...)
+	return nil
+}

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -411,6 +411,7 @@ more.`,
 
 	observeCmd.AddCommand(
 		newAgentEventsCommand(vp, selectorFlags, formattingFlags, config.ServerFlags, otherFlags),
+		newDebugEventsCommand(vp, selectorFlags, formattingFlags, config.ServerFlags, otherFlags),
 	)
 
 	formattingFlags.AddFlagSet(observeFormattingFlags)

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -89,25 +89,6 @@ var eventTypes = []string{
 	monitorAPI.MessageTypeNamePolicyVerdict,
 }
 
-func timeFormatNameToLayout(name string) string {
-	switch strings.ToLower(name) {
-	case "rfc3339":
-		return time.RFC3339
-	case "rfc3339milli":
-		return hubtime.RFC3339Milli
-	case "rfc3339micro":
-		return hubtime.RFC3339Micro
-	case "rfc3339nano":
-		return time.RFC3339Nano
-	case "rfc1123z":
-		return time.RFC1123Z
-	case "stampmilli":
-		fallthrough
-	default:
-		return time.StampMilli
-	}
-}
-
 // New observer command.
 func New(vp *viper.Viper) *cobra.Command {
 	return newObserveCmd(vp, newObserveFilter())
@@ -417,14 +398,7 @@ more.`,
 		}, cobra.ShellCompDirectiveDefault
 	})
 	observeCmd.RegisterFlagCompletionFunc("time-format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return []string{
-			"StampMilli",
-			"RFC3339",
-			"RFC3339Milli",
-			"RFC3339Micro",
-			"RFC3339Nano",
-			"RFC1123Z",
-		}, cobra.ShellCompDirectiveDefault
+		return hubtime.FormatNames, cobra.ShellCompDirectiveDefault
 	})
 
 	// default value for when the flag is on the command line without any options
@@ -442,7 +416,7 @@ func handleArgs(ofilter *observeFilter, debug bool) (err error) {
 
 	// initialize the printer with any options that were passed in
 	var opts = []hubprinter.Option{
-		hubprinter.WithTimeFormat(timeFormatNameToLayout(formattingOpts.timeFormat)),
+		hubprinter.WithTimeFormat(hubtime.FormatNameToLayout(formattingOpts.timeFormat)),
 	}
 
 	if formattingOpts.output == "" { // support deprecated output flags if provided

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -34,6 +34,10 @@ const (
 	// observe CLI.
 	FlowPrintCount = 20
 
+	// EventsPrintCount is the default number of agent/debug events to print
+	// on the hubble events CLI.
+	EventsPrintCount = 20
+
 	// TargetTLSPrefix is a scheme that indicates that the target connection
 	// requires TLS.
 	TargetTLSPrefix = "tls://"

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -16,6 +16,7 @@ package time
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -63,4 +64,34 @@ func FromString(input string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf(
 		"failed to convert %s to time", input,
 	)
+}
+
+// FormatNames are the valid time format names accepted by this package.
+var FormatNames = []string{
+	"StampMilli",
+	"RFC3339",
+	"RFC3339Milli",
+	"RFC3339Micro",
+	"RFC3339Nano",
+	"RFC1123Z",
+}
+
+// FormatNameToLayout returns the time format layout for the time format name.
+func FormatNameToLayout(name string) string {
+	switch strings.ToLower(name) {
+	case "rfc3339":
+		return time.RFC3339
+	case "rfc3339milli":
+		return RFC3339Milli
+	case "rfc3339micro":
+		return RFC3339Micro
+	case "rfc3339nano":
+		return time.RFC3339Nano
+	case "rfc1123z":
+		return time.RFC1123Z
+	case "stampmilli":
+		fallthrough
+	default:
+		return time.StampMilli
+	}
 }


### PR DESCRIPTION
This PR adds the `hubble observe agent-events` and `hubble observe debug-events` sub-commands to retrieve agent and debug events, respectively. These use the new `GetAgentEvents`/`GetDebugEvents` API introduced in cilium/cilium#15715.

Flags such as `--since`, `--until`,  `--follow` or `--time-format` are available for the sub-commands as well. Flow-specific flags (e.g. `--from-*`, `--http-*` or `--ip-translation` are restricted to `hubble observe` and not available in the sub-commands. See `hubble observe -h`, `hubble observe agent-events -h` and `hubble observe debug-events -h`.

Examples:

```
$ hubble observe agent-events
TIMESTAMP             TYPE                          DETAILS
Apr 26 13:32:03.225   ENDPOINT_CREATED              id: 3478
Apr 26 13:32:14.281   IPCACHE_UPSERTED              cidr: 10.244.2.221/32, identity: 2806, host ip: 172.18.0.4, encrypt key: 0
Apr 26 13:32:14.805   IPCACHE_UPSERTED              cidr: 10.244.0.80/32, identity: 5027, host ip: 172.18.0.3, encrypt key: 0
Apr 26 13:32:14.866   IPCACHE_UPSERTED              cidr: 10.244.0.164/32, identity: 5882, host ip: 172.18.0.3, encrypt key: 0
Apr 26 13:32:14.923   IPCACHE_UPSERTED              cidr: 10.244.0.174/32, identity: 5027, host ip: 172.18.0.3, encrypt key: 0
Apr 26 13:32:17.620   ENDPOINT_REGENERATE_SUCCESS   id: 142, labels: [reserved:host]
Apr 26 13:32:17.624   ENDPOINT_REGENERATE_SUCCESS   id: 142, labels: [reserved:host]
Apr 26 13:32:18.683   ENDPOINT_REGENERATE_SUCCESS   id: 3478, labels: [reserved:health]
Apr 26 13:32:18.686   ENDPOINT_REGENERATE_SUCCESS   id: 3478, labels: [reserved:health]
Apr 26 13:32:24.296   SERVICE_UPSERTED              id: 2, frontend: 10.96.0.10:53, backends: [10.244.0.174:53], type: ClusterIP, traffic policy: Cluster, namespace: kube-system, name: kube-dns
Apr 26 13:32:24.297   SERVICE_UPSERTED              id: 3, frontend: 10.96.0.10:9153, backends: [10.244.0.174:9153], type: ClusterIP, traffic policy: Cluster, namespace: kube-system, name: kube-dns
Apr 26 13:32:26.475   SERVICE_UPSERTED              id: 4, frontend: 10.96.214.93:80, backends: [10.244.2.221:4245], type: ClusterIP, traffic policy: Cluster, namespace: kube-system, name: hubble-relay
Apr 26 13:32:27.986   SERVICE_UPSERTED              id: 2, frontend: 10.96.0.10:53, backends: [10.244.0.174:53,10.244.0.80:53], type: ClusterIP, traffic policy: Cluster, namespace: kube-system, name: kube-dns
Apr 26 13:32:27.986   SERVICE_UPSERTED              id: 3, frontend: 10.96.0.10:9153, backends: [10.244.0.174:9153,10.244.0.80:9153], type: ClusterIP, traffic policy: Cluster, namespace: kube-system, name: kube-dns
Apr 26 13:33:02.147   IPCACHE_UPSERTED              cidr: 172.18.0.2/32, identity: 1, old identity: 1, encrypt key: 0
Apr 26 13:33:02.147   IPCACHE_UPSERTED              cidr: 10.244.1.116/32, identity: 1, old identity: 1, encrypt key: 0
Apr 26 13:33:02.148   IPCACHE_UPSERTED              cidr: 0.0.0.0/0, identity: 2, old identity: 2, encrypt key: 0
Apr 26 13:34:02.149   IPCACHE_UPSERTED              cidr: 172.18.0.2/32, identity: 1, old identity: 1, encrypt key: 0
Apr 26 13:34:02.149   IPCACHE_UPSERTED              cidr: 10.244.1.116/32, identity: 1, old identity: 1, encrypt key: 0
Apr 26 13:34:02.150   IPCACHE_UPSERTED              cidr: 0.0.0.0/0, identity: 2, old identity: 2, encrypt key: 0
```

```
$ hubble observe debug-events
TIMESTAMP             FROM         TYPE                     CPU/MARK        MESSAGE
Apr 26 15:58:41.050   ID: 142      DBG_CT_MATCH             01 0x3cbea25    CT entry found lifetime=16811869, revnat=0
Apr 26 15:58:41.050   ID: 142      DBG_CT_VERDICT           01 0x3cbea25    CT verdict: Reply, revnat=0
Apr 26 15:58:41.050   ID: 142      DBG_CT_LOOKUP4_1         01 0x3cbea25    Conntrack lookup 1/2: src=172.18.0.3:6443 dst=172.18.0.2:44656
Apr 26 15:58:41.050   ID: 142      DBG_CT_LOOKUP4_2         01 0x3cbea25    Conntrack lookup 2/2: nexthdr=6 flags=0
Apr 26 15:58:41.050   ID: 142      DBG_CT_MATCH             01 0x3cbea25    CT entry found lifetime=16811869, revnat=0
Apr 26 15:58:41.050   ID: 142      DBG_CT_VERDICT           01 0x3cbea25    CT verdict: Reply, revnat=0
Apr 26 15:58:41.050   ID: 142      DBG_CT_LOOKUP4_1         01 0x60902282   Conntrack lookup 1/2: src=172.18.0.2:44656 dst=172.18.0.3:6443
Apr 26 15:58:41.050   ID: 142      DBG_CT_LOOKUP4_2         01 0x60902282   Conntrack lookup 2/2: nexthdr=6 flags=1
Apr 26 15:58:41.050   ID: 142      DBG_CT_MATCH             01 0x60902282   CT entry found lifetime=16811869, revnat=0
Apr 26 15:58:41.050   ID: 142      DBG_CT_VERDICT           01 0x60902282   CT verdict: Established, revnat=0
Apr 26 15:58:41.266   ID: 142      DBG_IP_ID_MAP_SUCCEED4   01 0x9ec04f8c   Successfully mapped addr=172.18.0.3 to identity=6
Apr 26 15:58:41.266   ID: 142      DBG_IP_ID_MAP_SUCCEED4   01 0x9ec04f8c   Successfully mapped addr=172.18.0.3 to identity=6
Apr 26 15:58:41.266   ID: 142      DBG_IP_ID_MAP_SUCCEED4   01 0x9ec04f8c   Successfully mapped addr=172.18.0.3 to identity=6
Apr 26 15:58:41.267   ID: 142      DBG_IP_ID_MAP_SUCCEED4   04 0x9ec04f8c   Successfully mapped addr=172.18.0.3 to identity=6
Apr 26 15:58:41.267   ID: 142      DBG_IP_ID_MAP_SUCCEED4   04 0x9ec04f8c   Successfully mapped addr=172.18.0.3 to identity=6
Apr 26 15:58:42.036   ID: 142      DBG_IP_ID_MAP_SUCCEED4   04 0xf142bcaf   Successfully mapped addr=172.18.0.3 to identity=6
Apr 26 15:58:42.275   ID: 142      DBG_IP_ID_MAP_SUCCEED4   04 0x9ec04f8c   Successfully mapped addr=172.18.0.3 to identity=6
Apr 26 15:58:42.275   ID: 142      DBG_IP_ID_MAP_SUCCEED4   04 0x9ec04f8c   Successfully mapped addr=172.18.0.3 to identity=6
Apr 26 15:58:42.275   ID: 142      DBG_IP_ID_MAP_SUCCEED4   04 0x9ec04f8c   Successfully mapped addr=172.18.0.3 to identity=6
Apr 26 15:58:42.275   ID: 142      DBG_IP_ID_MAP_SUCCEED4   00 0x9ec04f8c   Successfully mapped addr=172.18.0.3 to identity=6
```

See individual commits for details.