### PR TITLE
Dockerfile: use alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM docker.io/library/golang:1.16.3-alpine3.13 as builder
+# Do not upgrade to alpine 3.13 as its nslookup tool returns 1, instead of 0
+# for domain name lookups.
+FROM docker.io/library/golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061 as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache git make
 COPY . .
 RUN make clean && make hubble
 
-FROM docker.io/library/alpine:3.13
+# Do not upgrade to alpine 3.13 as its nslookup tool returns 1, instead of 0
+# for domain name lookups.
+FROM docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
 RUN apk add --no-cache bash curl jq
 COPY --from=builder /go/src/github.com/cilium/hubble/hubble /usr/bin
 CMD ["/usr/bin/hubble"]


### PR DESCRIPTION
In Alpine 3.11 and 3.13, 'nslookup' exits with the error code 1 if it
can't resolve all IPs for the search list defined in /etc/resolv.conf

However, it seems that Alpine 3.10 and 3.12 are not affected by this bug
and continue return the error code 0 if at least on of the domains in
the search list is resolved into an IP address. Thus, we will use the
latest Alpine image available for the 3.12 release series.

Signed-off-by: André Martins <andre@cilium.io>