### PR TITLE
cmd: change "node list" command for "list node"

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package node
+package list
 
 import (
 	"github.com/cilium/hubble/cmd/common/config"
@@ -21,21 +21,19 @@ import (
 	"github.com/spf13/viper"
 )
 
-// New creates a new hidden peer command.
+// New creates a new list command.
 func New(vp *viper.Viper) *cobra.Command {
-	nodeCmd := &cobra.Command{
-		Use:     "nodes",
-		Aliases: []string{"node"},
-		Short:   "Get information about Hubble nodes",
-		Long:    `Get information about Hubble nodes.`,
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Hubble objects",
 	}
 
 	// add config.ServerFlags to the help template as these flags are used by
 	// this command
-	nodeCmd.SetUsageTemplate(template.Usage(config.ServerFlags))
+	listCmd.SetUsageTemplate(template.Usage(config.ServerFlags))
 
-	nodeCmd.AddCommand(
-		newListCommand(vp),
+	listCmd.AddCommand(
+		newNodeCommand(vp),
 	)
-	return nodeCmd
+	return listCmd
 }

--- a/cmd/list/node.go
+++ b/cmd/list/node.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package node
+package list
 
 import (
 	"context"
@@ -41,10 +41,11 @@ var listOpts struct {
 	output string
 }
 
-func newListCommand(vp *viper.Viper) *cobra.Command {
+func newNodeCommand(vp *viper.Viper) *cobra.Command {
 	listCmd := &cobra.Command{
-		Use:   "list",
-		Short: "List Hubble nodes",
+		Use:     "nodes",
+		Aliases: []string{"node"},
+		Short:   "List Hubble nodes",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -53,7 +54,7 @@ func newListCommand(vp *viper.Viper) *cobra.Command {
 				return err
 			}
 			defer hubbleConn.Close()
-			return runList(ctx, cmd, hubbleConn)
+			return runListNodes(ctx, cmd, hubbleConn)
 		},
 	}
 
@@ -80,7 +81,7 @@ func newListCommand(vp *viper.Viper) *cobra.Command {
 	return listCmd
 }
 
-func runList(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
+func runListNodes(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 	req := &observerpb.GetNodesRequest{}
 	res, err := observerpb.NewObserverClient(conn).GetNodes(ctx, req)
 	if err != nil {

--- a/cmd/list/node_test.go
+++ b/cmd/list/node_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package node
+package list
 
 import (
 	"bytes"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cilium/hubble/cmd/common/validate"
 	"github.com/cilium/hubble/cmd/completion"
 	cmdConfig "github.com/cilium/hubble/cmd/config"
-	"github.com/cilium/hubble/cmd/node"
+	"github.com/cilium/hubble/cmd/list"
 	"github.com/cilium/hubble/cmd/observe"
 	"github.com/cilium/hubble/cmd/peer"
 	"github.com/cilium/hubble/cmd/record"
@@ -92,7 +92,7 @@ func NewWithViper(vp *viper.Viper) *cobra.Command {
 	rootCmd.AddCommand(
 		cmdConfig.New(vp),
 		completion.New(),
-		node.New(vp),
+		list.New(vp),
 		observe.New(vp),
 		peer.New(vp),
 		record.New(vp),


### PR DESCRIPTION
We recently decided to try and uniformize the Hubble CLI subcommands and
agreed on a `[verb] [noun]` approach. Given that there hasn't been any
release of Hubble CLI with the `nodes` subcommand yet, change the
`hubble nodes list` command for `hubble list nodes`.