### PR TITLE
cmd: change 'peers watch' command to 'watch peers'

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,11 +25,11 @@ import (
 	cmdConfig "github.com/cilium/hubble/cmd/config"
 	"github.com/cilium/hubble/cmd/list"
 	"github.com/cilium/hubble/cmd/observe"
-	"github.com/cilium/hubble/cmd/peer"
 	"github.com/cilium/hubble/cmd/record"
 	"github.com/cilium/hubble/cmd/reflect"
 	"github.com/cilium/hubble/cmd/status"
 	"github.com/cilium/hubble/cmd/version"
+	"github.com/cilium/hubble/cmd/watch"
 	"github.com/cilium/hubble/pkg"
 	"github.com/cilium/hubble/pkg/logger"
 
@@ -94,11 +94,11 @@ func NewWithViper(vp *viper.Viper) *cobra.Command {
 		completion.New(),
 		list.New(vp),
 		observe.New(vp),
-		peer.New(vp),
 		record.New(vp),
 		reflect.New(vp),
 		status.New(vp),
 		version.New(),
+		watch.New(vp),
 	)
 	return rootCmd
 }

--- a/cmd/watch/peer.go
+++ b/cmd/watch/peer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package peer
+package watch
 
 import (
 	"context"
@@ -29,12 +29,11 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func newWatchCommand(vp *viper.Viper) *cobra.Command {
+func newPeerCommand(vp *viper.Viper) *cobra.Command {
 	return &cobra.Command{
-		Use:     "watch",
-		Aliases: []string{"w"},
+		Use:     "peers",
+		Aliases: []string{"peer"},
 		Short:   "Watch for Hubble peers updates",
-		Long:    `Watch for Hubble peers updates.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -43,12 +42,12 @@ func newWatchCommand(vp *viper.Viper) *cobra.Command {
 				return err
 			}
 			defer hubbleConn.Close()
-			return runWatch(ctx, peerpb.NewPeerClient(hubbleConn))
+			return runPeer(ctx, peerpb.NewPeerClient(hubbleConn))
 		},
 	}
 }
 
-func runWatch(ctx context.Context, client peerpb.PeerClient) error {
+func runPeer(ctx context.Context, client peerpb.PeerClient) error {
 	b, err := client.Notify(ctx, &peerpb.NotifyRequest{})
 	if err != nil {
 		return err

--- a/cmd/watch/peer_test.go
+++ b/cmd/watch/peer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package peer
+package watch
 
 import (
 	"bytes"

--- a/cmd/watch/watch.go
+++ b/cmd/watch/watch.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package peer
+package watch
 
 import (
 	"github.com/cilium/hubble/cmd/common/config"
@@ -24,10 +24,9 @@ import (
 // New creates a new hidden peer command.
 func New(vp *viper.Viper) *cobra.Command {
 	peerCmd := &cobra.Command{
-		Use:     "peers",
-		Aliases: []string{"peer"},
-		Short:   "Get information about Hubble peers",
-		Long:    `Get information about Hubble peers.`,
+		Use:     "watch",
+		Aliases: []string{"w"},
+		Short:   "Watch Hubble objects",
 		Hidden:  true, // this command is only useful for development/debugging purposes
 	}
 
@@ -36,7 +35,7 @@ func New(vp *viper.Viper) *cobra.Command {
 	peerCmd.SetUsageTemplate(template.Usage(config.ServerFlags))
 
 	peerCmd.AddCommand(
-		newWatchCommand(vp),
+		newPeerCommand(vp),
 	)
 	return peerCmd
 }


### PR DESCRIPTION
We recently decided to try and uniformize the Hubble CLI subcommands and
agreed on a `[verb] [noun]` approach. This is a breaking change as there
has been releases of the CLI with the `peers` subcommand. However, this
command is hidden and not mentioned anywhere in documentation as it is
only useful to developers. Therefore, this change shouldn't affect end
users.