### PR TITLE
release: pin skx/github-action-publish-binaries to a specific sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
             Note for maintainers:: Please, update the desciption with the actual release notes (see RELEASE.md for instructions).
       - name: Upload artifacts 
         id: upload-release-artifacts
-        uses: skx/github-action-publish-binaries@master
+        uses: skx/github-action-publish-binaries@c881a3f8ffb80b684f367660178d38ceabc065c2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This prevents the github-action plugin repository owner from potentially
being able to tamper with data that is being uploaded.

Note that updates to the github action plugins is being handled by
dependabot.

Suggested-by: André Martins <andre@cilium.io>
Signed-off-by: Robin Hahling <robin.hahling@gw-computing.net>