### PR TITLE
.github: Cancel outdated PR and push workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,6 @@
 name: codeql
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   push:
     branches:
@@ -12,6 +13,10 @@ on:
     - master
   schedule:
     - cron: "45 7 * * 3"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || 'scheduled' }}
+  cancel-in-progress: true
 
 jobs:
   analyze:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Run static checks and unit tests
+
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   push:
     branches:
@@ -8,6 +10,11 @@ on:
     branches:
     - master
     - v*
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When updating a pull request, workflows associated with the previous version continue to run. A way to prevent that and cancel outdated workflows is to use concurrency groups.

This commit handles workflows triggered by pull requests and pushes. We define each concurrency group such that they are unique to the pull request (via PR number) if triggered by event `pull_request` or to the commit (via SHA) if triggered by event `push`.