### PR TITLE
Small test cleanups

### DIFF
--- a/cmd/observe/agent_events_test.go
+++ b/cmd/observe/agent_events_test.go
@@ -19,10 +19,33 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/observer"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/hubble/pkg/defaults"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestAgentEventSubTypeMap(t *testing.T) {
+	// Make sure to keep agent event sub-types maps in sync. See
+	// agentEventSubtypes godoc for details.
+	require.Len(t, agentEventSubtypes, len(monitorAPI.AgentNotifications))
+	for _, v := range agentEventSubtypes {
+		require.Contains(t, monitorAPI.AgentNotifications, v)
+	}
+	agentEventSubtypesContainsValue := func(an monitorAPI.AgentNotification) bool {
+		for _, v := range agentEventSubtypes {
+			if v == an {
+				return true
+			}
+		}
+		return false
+	}
+	for k := range monitorAPI.AgentNotifications {
+		require.True(t, agentEventSubtypesContainsValue(k))
+	}
+}
 
 func Test_getAgentEventsRequest(t *testing.T) {
 	selectorOpts.since = ""

--- a/cmd/observe/observe_filter_test.go
+++ b/cmd/observe/observe_filter_test.go
@@ -180,26 +180,6 @@ func TestFilterLeftRight(t *testing.T) {
 	}
 }
 
-func TestAgentEventSubTypeMap(t *testing.T) {
-	// Make sure to keep agent event sub-types maps in sync. See agentEventSubtypes godoc for
-	// details.
-	require.Len(t, agentEventSubtypes, len(monitorAPI.AgentNotifications))
-	for _, v := range agentEventSubtypes {
-		require.Contains(t, monitorAPI.AgentNotifications, v)
-	}
-	agentEventSubtypesContainsValue := func(an monitorAPI.AgentNotification) bool {
-		for _, v := range agentEventSubtypes {
-			if v == an {
-				return true
-			}
-		}
-		return false
-	}
-	for k := range monitorAPI.AgentNotifications {
-		require.True(t, agentEventSubtypesContainsValue(k))
-	}
-}
-
 func TestFilterType(t *testing.T) {
 	f := newObserveFilter()
 	cmd := newObserveCmd(viper.New(), f)

--- a/cmd/observe/observe_test.go
+++ b/cmd/observe/observe_test.go
@@ -46,6 +46,8 @@ func TestEventTypes(t *testing.T) {
 }
 
 func Test_getRequest(t *testing.T) {
+	selectorOpts.since = ""
+	selectorOpts.until = ""
 	filter := newObserveFilter()
 	req, err := getRequest(filter)
 	assert.NoError(t, err)


### PR DESCRIPTION
* Make `Test_getRequest` resilient against test execution order changes:
   The test currently assumes to be run to be run with empty `selectorOpts`
   which might not be true depending on the order tests are executed. Reset
   `selectorOpts` since and until files like in the other `Test_get*Request`
   tests.
* Move `TestAgentEventSubTypeMap` to other tests related to agent events

Noticed while working on #543