### PR TITLE
cmd/observe: do not set `--last` to 20 by default in follow mode

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -519,8 +519,9 @@ func getRequest(ofilter *observeFilter) (*observer.GetFlowsRequest, error) {
 		case selectorOpts.all:
 			// all is an alias for last=uint64_max
 			selectorOpts.last = ^uint64(0)
-		case selectorOpts.last == 0:
-			// no specific parameters were provided, just a vanilla `hubble observe`
+		case selectorOpts.last == 0 && !selectorOpts.follow:
+			// no specific parameters were provided, just a vanilla
+			// `hubble observe` in non-follow mode
 			selectorOpts.last = defaults.FlowPrintCount
 		}
 	}


### PR DESCRIPTION
Change the default behavior with regard to `--last` when in follow mode.
Previously, running `hubble --debug observe --follow` resulted in the
following:

    $ hubble --debug observe --follow
    time="2021-06-17T16:20:25+02:00" level=debug msg="Sending GetFlows request" request="number:20 follow:true"

The new behavior is changed for the following (notice that `number` is
not set, ie 0):

    $ hubble --debug observe --follow
    time="2021-06-17T16:21:02+02:00" level=debug msg="Sending GetFlows request" request="follow:true"

There are use-cases where a user is not interested in events that are
already in Hubble's ring buffer cache but only in new ones. A typical
example is when using hubble for testing, e.g. for the connectivity
test.

Note that this PR is a slight change of behavior as, when `--last` is
not provided, it used to always default to 20 unless `--since` or
`--until` is provided.