### PR TITLE
CODEOWNERS: assign GH actions to github-sec team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,12 @@
 # Code owners groups assigned to this repository and a brief description of their areas:
 # @cilium/ci-structure       Continuous integration, testing
 # @cilium/contributing       Developer documentation & tools
+# @cilium/github-sec         GitHub security (handling of secrets, consequences of pull_request_target, etc.)
 # @cilium/hubble             All related to Hubble (client and server)
 
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
 * @cilium/hubble
-/.github/workflows/ @cilium/ci-structure @cilium/hubble
-/CODEOWNERS @cilium/contributing
+/.github/workflows/ @cilium/github-sec @cilium/ci-structure @cilium/hubble
+/CODEOWNERS @cilium/contributing @cilium/hubble


### PR DESCRIPTION
Reviewed #576 a little too late: https://github.com/cilium/hubble/pull/576#pullrequestreview-689709536