### PR TITLE
ci: enable checks for missing Go documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run static checks
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.40.1
+        version: v1.41.1
         args: --config=.golangci.yml --verbose
         skip-go-installation: true
         skip-pkg-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,13 @@ linters-settings:
     go: "1.16"
 
 issues:
+  # Default rules exclude Go doc comments check, which is rather unfortunate.
+  # In order to enable Go doc checks, defaults rules have to be disabled.
+  # See https://github.com/golangci/golangci-lint/issues/456 for details.
+  exclude-use-default: false
+  exclude:
+    - (G104|G307) # EXC0008 gosec: Duplicated errcheck checks
+
   exclude-rules:
     - linters: [staticcheck]
       text: "SA1019" # deprecated methods

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ RELEASE_GID ?= $(shell id -g)
 
 TEST_TIMEOUT ?= 5s
 
-GOLANGCILINT_WANT_VERSION = 1.40.1
+GOLANGCILINT_WANT_VERSION = 1.41.1
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
 all: hubble


### PR DESCRIPTION
Checks for missing Go documentation used to be covered by the now defunct project `golint`. Revive is a replacement for golint that is used by `golangci-lint`. However, `golangci-lint` [disables checks for missing Go documentation by default](https://github.com/golangci/golangci-lint/issues/456). The only way to re-enable them is apparently to suppress golangci-lint's default rules, which is what this commit does. Rules that triggered false-positive on this codebase have been manually added. The list of default exclude rules can be found by running `golangci-lint run --help`.