### PR TITLE
update Go to v1.16.6, alpine to 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         path: go/src/github.com/cilium/hubble
     - uses: actions/setup-go@v2.1.3
       with:
-        go-version: '1.16.5'
+        go-version: '1.16.6'
     - name: Run static checks
       uses: golangci/golangci-lint-action@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-# Do not upgrade to alpine 3.13 as its nslookup tool returns 1, instead of 0
-# for domain name lookups.
-FROM docker.io/library/golang:1.16.5-alpine3.12@sha256:039c10dc2a216f9ac7962d3fb532f7823284133eef708950d7caf2b5c427dfae as builder
+FROM docker.io/library/golang:1.16.6-alpine3.14@sha256:a8df40ad1380687038af912378f91cf26aeabb05046875df0bfedd38a79b5499 as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache git make
 COPY . .
 RUN make clean && make hubble
 
-# Do not upgrade to alpine 3.13 as its nslookup tool returns 1, instead of 0
-# for domain name lookups.
-FROM docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
+FROM docker.io/library/alpine:3.14.0@sha256:1775bebec23e1f3ce486989bfc9ff3c4e951690df84aa9f926497d82f2ffca9d
 RUN apk add --no-cache bash curl jq
 COPY --from=builder /go/src/github.com/cilium/hubble/hubble /usr/bin
 CMD ["/usr/bin/hubble"]

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ hubble:
 	$(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET)
 
 release:
-	docker run --env "RELEASE_UID=$(RELEASE_UID)" --env "RELEASE_GID=$(RELEASE_GID)" --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.16.5-alpine3.13 \
+	docker run --env "RELEASE_UID=$(RELEASE_UID)" --env "RELEASE_GID=$(RELEASE_GID)" --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.16.6-alpine3.14 \
 		sh -c "apk add --no-cache make && make local-release"
 
 local-release: clean


### PR DESCRIPTION
Note that the Alpine had been downgraded from 3.13 to 3.12 at some point
due to a bug with busybox's nslookup implementation. This commit bumps
it to 3.14 as it seems that the bug is fixed(*) and that Alpine based
versions of Go images are only provided with Alpine 3.13 and 3.14.

(*): With Alpine 3.11 and 3.13, busybox's nslookup would return with
exit code 1 when at least one of the IP address for the search list
defined in `/etc/resolve.conf` cannot be resolved. With Alpine 3.10 and
3.12, nslookup would return exit code 0 instead. It seems that Alpine
3.14 shares the same behavior as Alpine versions 3.10 and 3.12.