### PR TITLE
docker: add note about bogus busybox's nslookup implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ RUN apk add --no-cache git make
 COPY . .
 RUN make clean && make hubble
 
+# NOTE: As of 2021-07-14, Alpine 3.11, 3.13 and 3.14 suffer from a bug in
+# busybox[0] that affects busybox's nslookup implementation. Under certain
+# conditions that typically depend on `/etc/resolv.conf` configuration,
+# nslookup returns with exit code 1 instead of 0 even when the given name is
+# resolved successfully. More information about the bug can be found on this
+# thread[1].
+# [0]: https://bugs.busybox.net/show_bug.cgi?id=12541
+# [1]: https://github.com/gliderlabs/docker-alpine/issues/539
 FROM docker.io/library/alpine:3.14.0@sha256:1775bebec23e1f3ce486989bfc9ff3c4e951690df84aa9f926497d82f2ffca9d
 RUN apk add --no-cache bash curl jq
 COPY --from=builder /go/src/github.com/cilium/hubble/hubble /usr/bin


### PR DESCRIPTION
Commit 32cdf60b8a7b795f579bb3317094bb1cfd63f0fb wrongly stated that the bug described in the note below is fixed in Alpine 3.14. It turns out that it is not.