### PR TITLE
cmd/observe: remove depreacted formatting flags (json, compact, dict)

### DIFF
--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -265,18 +265,6 @@ more.`,
 	// formatting flags only to `hubble observe`, but not sub-commands. Will be added to
 	// generic formatting flags below.
 	observeFormattingFlags := pflag.NewFlagSet("", pflag.ContinueOnError)
-	observeFormattingFlags.BoolVarP(
-		&formattingOpts.jsonOutput, "json", "j", false, "Deprecated. Use '--output json' instead.",
-	)
-	observeFormattingFlags.MarkDeprecated("json", "use '--output json' instead")
-	observeFormattingFlags.BoolVar(
-		&formattingOpts.compactOutput, "compact", false, "Deprecated. Use '--output compact' instead.",
-	)
-	observeFormattingFlags.MarkDeprecated("compact", "use '--output compact' instead")
-	observeFormattingFlags.BoolVar(
-		&formattingOpts.dictOutput, "dict", false, "Deprecated. Use '--output dict' instead.",
-	)
-	observeFormattingFlags.MarkDeprecated("dict", "use '--output dict' instead")
 	observeFormattingFlags.BoolVar(
 		&formattingOpts.numeric,
 		"numeric",
@@ -405,16 +393,6 @@ func handleFlowArgs(ofilter *flowFilter, debug bool) (err error) {
 	var opts = []hubprinter.Option{
 		hubprinter.WithTimeFormat(hubtime.FormatNameToLayout(formattingOpts.timeFormat)),
 		hubprinter.WithColor(formattingOpts.color),
-	}
-
-	if formattingOpts.output == "" { // support deprecated output flags if provided
-		if formattingOpts.jsonOutput {
-			formattingOpts.output = "json"
-		} else if formattingOpts.dictOutput {
-			formattingOpts.output = "dict"
-		} else if formattingOpts.compactOutput {
-			formattingOpts.output = "compact"
-		}
 	}
 
 	switch formattingOpts.output {

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -29,10 +29,7 @@ var (
 	}
 
 	formattingOpts struct {
-		jsonOutput    bool
-		compactOutput bool
-		dictOutput    bool
-		output        string
+		output string
 
 		timeFormat string
 


### PR DESCRIPTION
This patch completely removes the `--json`, `--compact` and `--dict` flags that have been deprecated since version v0.5.0 release 1.5 year ago. See [this discussion](https://github.com/cilium/hubble/issues/602#issuecomment-895176283) for additional context.