### PR TITLE
printer: fix dict outout newline

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -263,7 +263,7 @@ func (p *Printer) WriteProtoFlow(res *observerpb.GetFlowsResponse) error {
 
 		if p.line != 0 {
 			// TODO: line length?
-			ew.write(dictSeparator)
+			ew.write(dictSeparator, newline)
 		}
 
 		// this is a little crude, but will do for now. should probably find the


### PR DESCRIPTION
Commit 099da23a07b008fdc7d1524631b4968eeeef5011 broke the dict output by dropping the newline after the flow separator. This commit adds back the missing newline.