### PR TITLE
v0.8: printer: fix dict outout newline

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -263,7 +263,7 @@ func (p *Printer) WriteProtoFlow(res *observerpb.GetFlowsResponse) error {
 
 		if p.line != 0 {
 			// TODO: line length?
-			ew.write(dictSeparator)
+			ew.write(dictSeparator, newline)
 		}
 
 		// this is a little crude, but will do for now. should probably find the


### PR DESCRIPTION
This is backport of #615 to the v0.8 branch.