### PR TITLE
build release binaries for Windows ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ local-release: clean
 				ARCHS='386 amd64 arm arm64'; \
 				;; \
 			windows) \
-				ARCHS='386 amd64'; \
+				ARCHS='386 amd64 arm64'; \
 				EXT=".exe"; \
 				;; \
 		esac; \


### PR DESCRIPTION
Go 1.17 added support for `windows/arm64`. This means we can now create binaries for Windows on ARM64.