### PR TITLE
update Go to v1.17.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run static checks
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.42.0
+        version: v1.42.1
         args: --config=.golangci.yml --verbose
         skip-go-installation: true
         skip-pkg-cache: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         path: go/src/github.com/cilium/hubble
     - uses: actions/setup-go@v2.1.4
       with:
-        go-version: '1.17.0'
+        go-version: '1.17.1'
     - name: Run static checks
       uses: golangci/golangci-lint-action@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN make clean && make hubble
 # thread[1].
 # [0]: https://bugs.busybox.net/show_bug.cgi?id=12541
 # [1]: https://github.com/gliderlabs/docker-alpine/issues/539
-FROM docker.io/library/alpine:3.14.0@sha256:1775bebec23e1f3ce486989bfc9ff3c4e951690df84aa9f926497d82f2ffca9d
+FROM docker.io/library/alpine:3.14.2@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a
 RUN apk add --no-cache bash curl jq
 COPY --from=builder /go/src/github.com/cilium/hubble/hubble /usr/bin
 CMD ["/usr/bin/hubble"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.17.0-alpine3.14@sha256:8c7994cfdf4d488799d40d85d83bd41c7fd290e8eed1affc2abd386150750d2d as builder
+FROM docker.io/library/golang:1.17.1-alpine3.14@sha256:55f55d3232f63391e0797acaf145ade8f6fca2ff36795dd5ae446de360724dec as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache git make
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ RELEASE_GID ?= $(shell id -g)
 
 TEST_TIMEOUT ?= 5s
 
-GOLANGCILINT_WANT_VERSION = 1.42.0
+GOLANGCILINT_WANT_VERSION = 1.42.1
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
 all: hubble

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ hubble:
 	$(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET)
 
 release:
-	docker run --env "RELEASE_UID=$(RELEASE_UID)" --env "RELEASE_GID=$(RELEASE_GID)" --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.17.0-alpine3.14 \
+	docker run --env "RELEASE_UID=$(RELEASE_UID)" --env "RELEASE_GID=$(RELEASE_GID)" --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.17.1-alpine3.14 \
 		sh -c "apk add --no-cache make && make local-release"
 
 local-release: clean


### PR DESCRIPTION
While here, also bump the base Alpine image and golangci-lint.