### PR TITLE
version: Drop the "v" prefix

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -37,7 +37,7 @@ func New() *cobra.Command {
 			case pkg.GitHash != "":
 				gitInfo = fmt.Sprintf("@%s", pkg.GitHash)
 			}
-			fmt.Printf("%s v%s%s compiled with %v on %v/%v\n", cmd.Root().Name(), pkg.Version, gitInfo, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			fmt.Printf("%s %s%s compiled with %v on %v/%v\n", cmd.Root().Name(), pkg.Version, gitInfo, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		},
 	}
 }


### PR DESCRIPTION
Don't add the "v" prefix so that the version shows up exactly as defined
in the VERSION file.

Also, if you don't need the git branch / commit SHA in the version
string, you can explicitly set them to be empty. For example:

    % make GIT_BRANCH= GIT_HASH=
    CGO_ENABLED=0 go build  -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=' -X 'github.com/cilium/hubble/pkg.GitHash=' -X 'github.com/cilium/hubble/pkg.Version=0.9.0-dev'" -o hubble
    % ./hubble version
    hubble 0.9.0-dev compiled with go1.17.2 on linux/amd64

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>