### PR TITLE
observe: Add --allowlist / --denylist flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,29 @@ Alternatively, you can also specify these flags as `HUBBLE_{ALLOWLIST,DENYLIST}`
 
     hubble observe
 
+Note that `--allowlist` and `--denylist` filters get included in the request **in addition to**
+regular flow filters like `--label` or `--namespace`. Use `--print-raw-filters` flag to verify
+the exact filters that the Hubble CLI generates. For example:
+
+    % hubble observe --print-raw-filters \
+        -t drop \
+        -n kube-system \
+        --not --label "k8s:k8s-app=kube-dns" \
+        --allowlist '{"source_label":["k8s:k8s-app=my-app"]}'
+    allowlist:
+    - '{"source_pod":["kube-system/"],"event_type":[{"type":1}]}'
+    - '{"destination_pod":["kube-system/"],"event_type":[{"type":1}]}'
+    - '{"source_label":["k8s:k8s-app=my-app"]}'
+    denylist:
+    - '{"source_label":["k8s:k8s-app=kube-dns"]}'
+    - '{"destination_label":["k8s:k8s-app=kube-dns"]}'
+
+The output YAML can be saved to a file and passed to `hubble observe` command with `--config`
+flag. For example:
+
+    % hubble observe --print-raw-filters --allowlist '{"source_label":["k8s:k8s-app=my-app"]}' > filters.yaml
+    % hubble observe --config ./filters.yaml
+
 # Community
 
 Join the [Cilium Slack #hubble channel](https://cilium.herokuapp.com/) to chat

--- a/cmd/observe/flows_test.go
+++ b/cmd/observe/flows_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/observer"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/hubble/pkg/defaults"
@@ -101,4 +102,19 @@ func Test_getFlowsRequestWithInvalidRawFilters(t *testing.T) {
 	assert.Equal(t, `invalid --allowlist flag: failed to decode '{"invalid":["filters"]}': unknown field "invalid" in flow.FlowFilter`, err.Error())
 	_, err = getFlowsRequest(newFlowFilter(), nil, filters)
 	assert.Equal(t, `invalid --denylist flag: failed to decode '{"invalid":["filters"]}': unknown field "invalid" in flow.FlowFilter`, err.Error())
+}
+
+func Test_getFlowFiltersYAML(t *testing.T) {
+	req := observer.GetFlowsRequest{
+		Whitelist: []*flowpb.FlowFilter{{SourceIp: []string{"1.2.3.4/16"}}},
+		Blacklist: []*flowpb.FlowFilter{{SourcePort: []string{"80"}}},
+	}
+	out, err := getFlowFiltersYAML(&req)
+	expected := `allowlist:
+- '{"source_ip":["1.2.3.4/16"]}'
+denylist:
+- '{"source_port":["80"]}'
+`
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
 }

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -40,7 +40,8 @@ var (
 	}
 
 	otherOpts struct {
-		ignoreStderr bool
+		ignoreStderr    bool
+		printRawFilters bool
 	}
 
 	printer *hubprinter.Printer


### PR DESCRIPTION
These flags let you specify filters directly as JSON-encoded FlowFilters
in case the filters cannot be expressed using the filter flags. Please
see README.md for usage.

Fixes: #554

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>