### PR TITLE
observe: Add --dry-run flag

### DIFF
--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -16,6 +16,7 @@ package observe
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -93,6 +94,14 @@ more.`,
 			req, err := getFlowsRequest(ofilter)
 			if err != nil {
 				return err
+			}
+			if otherOpts.dryRun {
+				output, err := json.MarshalIndent(req, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Print(string(output))
+				return nil
 			}
 
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
@@ -315,6 +324,8 @@ more.`,
 	otherFlags := pflag.NewFlagSet("other", pflag.ContinueOnError)
 	otherFlags.BoolVarP(
 		&otherOpts.ignoreStderr, "silent-errors", "s", false, "Silently ignores errors and warnings")
+	otherFlags.BoolVar(
+		&otherOpts.dryRun, "dry-run", false, "Print GetFlowsRequest and exit without sending the request to Hubble server")
 	observeCmd.PersistentFlags().AddFlagSet(otherFlags)
 
 	// advanced completion for flags

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -41,6 +41,7 @@ var (
 
 	otherOpts struct {
 		ignoreStderr bool
+		dryRun       bool
 	}
 
 	printer *hubprinter.Printer


### PR DESCRIPTION
When --dry-run flag is specified, hubble observe command prints out 
GetFlowsRequest and exists without actually sending the request to
Hubble server.

Sample output:

    % ./hubble observe --dry-run -t drop -n kube-system
    {   
      "number": "20",
      "whitelist": [
        {   
          "source_pod": [
            "kube-system/"
          ],  
          "event_type": [
            {   
              "type": 1
            }   
          ]   
        },  
        {   
          "destination_pod": [
            "kube-system/"
          ],  
          "event_type": [
            {   
              "type": 1
            }   
          ]   
        }   
      ]   
    }   

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>