### PR TITLE
cmd/observe: match only Hubble-specific part of error in Test_getFlowsRequestWithInvalidRawFilters

### DIFF
--- a/cmd/observe/flows_test.go
+++ b/cmd/observe/flows_test.go
@@ -99,9 +99,9 @@ func Test_getFlowsRequestWithInvalidRawFilters(t *testing.T) {
 		`{"invalid":["filters"]}`,
 	}
 	_, err := getFlowsRequest(newFlowFilter(), filters, nil)
-	assert.Equal(t, `invalid --allowlist flag: failed to decode '{"invalid":["filters"]}': proto:`+"\u00a0"+`(line 1:2): unknown field "invalid"`, err.Error())
+	assert.Contains(t, err.Error(), `invalid --allowlist flag: failed to decode '{"invalid":["filters"]}': `)
 	_, err = getFlowsRequest(newFlowFilter(), nil, filters)
-	assert.Equal(t, `invalid --denylist flag: failed to decode '{"invalid":["filters"]}': proto:`+"\u00a0"+`(line 1:2): unknown field "invalid"`, err.Error())
+	assert.Contains(t, err.Error(), `invalid --denylist flag: failed to decode '{"invalid":["filters"]}': `)
 }
 
 func Test_getFlowFiltersYAML(t *testing.T) {


### PR DESCRIPTION
protobuf-go deliberately introduces instability into their error message
strings to discourage users from matching on error strings [1]. This
breaks Test_getFlowsRequestWithInvalidRawFilters in unpredictable ways.
This was e.g. the case for https://github.com/cilium/hubble/pull/650
where the error message was updated. Due to the instability, he test
again broke on https://github.com/cilium/hubble/pull/653

[1] https://github.com/protocolbuffers/protobuf-go/blob/01b51b4f96e6f04345af6153c1b69345f8e075b9/internal/errors/errors.go#L26-L34

Make the test resilient against this behavior by matching only against
the Hubble-specific part of the error string.

Fixes: 18dbc6c51bf7 ("observe: Add --allowlist / --denylist flags")
Fixes: 771bb4ad3441 ("vendor: Bump github.com/cilium/cilium to v1.11.0-rc3")