### PR TITLE
.github: let dependabot ignore Cilium dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: weekly
     open-pull-requests-limit: 1
     rebase-strategy: disabled
+    ignore:
+      - dependency-name: "github.com/cilium/cilium"
     labels:
     - kind/enhancement
     - release-note/misc


### PR DESCRIPTION
To properly update Cilium, the replace directive in go.mod needs to be
updated as well, something dependabot can't do.

