### PR TITLE
ipcache: Accept metadata from any source

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/source"
 )
 
 // IPIdentity contains the data associated with an IP address
@@ -160,7 +159,7 @@ func (ipc *IPCache) InitializeFrom(entries []*models.IPListEntry) error {
 		}
 
 		var ns, pod string
-		if e.Metadata != nil && e.Metadata.Source == string(source.Kubernetes) {
+		if e.Metadata != nil {
 			ns = e.Metadata.Namespace
 			pod = e.Metadata.Name
 		}

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -480,7 +480,7 @@ func TestIPCache_InitializeFrom(t *testing.T) {
 						Metadata: &models.IPListEntryMetadata{
 							Source:    "other",
 							Name:      "whoknows",
-							Namespace: "none",
+							Namespace: "any-source-is-ok",
 						},
 					},
 				},
@@ -503,6 +503,8 @@ func TestIPCache_InitializeFrom(t *testing.T) {
 						CIDR:       cidr3333,
 						Identity:   300,
 						EncryptKey: 12,
+						Namespace:  "any-source-is-ok",
+						PodName:    "whoknows",
 					},
 				},
 			},


### PR DESCRIPTION
The metadata source field in ipcache is not necessarily set to "k8s" in
newer versions of Cilium. This patch updates the ipcache initialization
logic to accept pod information from any metadata source.

Ref: https://github.com/cilium/cilium/issues/15698
Ref: https://github.com/cilium/cilium/pull/15706

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>