### PR TITLE
ci: bump golangci-lint to v1.45.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,14 +24,11 @@ jobs:
       with:
         go-version: '1.18.0'
     - name: Run static checks
-      # TODO: uncomment config below and remove `run: make check` once a
-      # version of golangci-lint with support for Go 1.18 is released.
-      run: make check
-      # uses: golangci/golangci-lint-action@v3.1.0
-      # with:
-      #   version: v1.44.2
-      #   args: --config=.golangci.yml --verbose
-      #   skip-cache: true
+      uses: golangci/golangci-lint-action@v3.1.0
+      with:
+        version: v1.45.0
+        args: --config=.golangci.yml --verbose
+        skip-cache: true
     - name: Check module vendoring
       run: |
         go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ RELEASE_GID ?= $(shell id -g)
 
 TEST_TIMEOUT ?= 5s
 
-GOLANGCILINT_WANT_VERSION = 1.44.2
+GOLANGCILINT_WANT_VERSION = 1.45.0
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
 all: hubble


### PR DESCRIPTION
Version 1.45 brings support for Go 1.18 so our hack can be removed.