### PR TITLE
printer: Display security identity in compact output

### DIFF
--- a/pkg/printer/color.go
+++ b/pkg/printer/color.go
@@ -96,6 +96,10 @@ func (c colorer) host(a interface{}) string {
 	return c.cyan.Sprint(a)
 }
 
+func (c colorer) identity(a interface{}) string {
+	return c.magenta.Sprint(a)
+}
+
 func (c colorer) verdictForwarded(a interface{}) string {
 	return c.green.Sprint(a)
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -31,6 +31,7 @@ import (
 	pb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	relaypb "github.com/cilium/cilium/api/v1/relay"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -173,6 +174,28 @@ func (p *Printer) GetHostNames(f *pb.Flow) (string, string) {
 	return p.color.host(src), p.color.host(dst)
 }
 
+func (p *Printer) fmtIdentity(i uint32) string {
+	numeric := identity.NumericIdentity(i)
+	if numeric.IsReservedIdentity() {
+		return p.color.identity(fmt.Sprintf("(%s)", numeric))
+	}
+
+	return p.color.identity(fmt.Sprintf("(identity:%d)", i))
+}
+
+// GetSecurityIdentities returns the source and destination numeric security
+// identity formatted as a string.
+func (p *Printer) GetSecurityIdentities(f *pb.Flow) (srcIdentity, dstIdentity string) {
+	if f == nil {
+		return "", ""
+	}
+
+	srcIdentity = p.fmtIdentity(f.GetSource().GetIdentity())
+	dstIdentity = p.fmtIdentity(f.GetDestination().GetIdentity())
+
+	return srcIdentity, dstIdentity
+}
+
 func fmtTimestamp(layout string, ts *timestamppb.Timestamp) string {
 	if !ts.IsValid() {
 		return "N/A"
@@ -295,6 +318,7 @@ func (p *Printer) WriteProtoFlow(res *observerpb.GetFlowsResponse) error {
 	case CompactOutput:
 		var node string
 		src, dst := p.GetHostNames(f)
+		srcIdentity, dstIdentity := p.GetSecurityIdentities(f)
 
 		if p.opts.nodeName {
 			node = fmt.Sprintf(" [%s]", f.GetNodeName())
@@ -306,15 +330,18 @@ func (p *Printer) WriteProtoFlow(res *observerpb.GetFlowsResponse) error {
 		} else if f.GetIsReply().Value {
 			// flip the arrow and src/dst for reply packets.
 			src, dst = dst, src
+			srcIdentity, dstIdentity = dstIdentity, srcIdentity
 			arrow = "<-"
 		}
 		_, err := fmt.Fprintf(p.opts.w,
-			"%s%s: %s %s %s %s %s (%s)\n",
+			"%s%s: %s %s %s %s %s %s %s (%s)\n",
 			fmtTimestamp(p.opts.timeFormat, f.GetTime()),
 			node,
 			src,
+			srcIdentity,
 			arrow,
 			dst,
+			dstIdentity,
 			GetFlowType(f),
 			p.getVerdict(f),
 			f.GetSummary())

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -44,6 +44,12 @@ func TestPrinter_WriteProtoFlow(t *testing.T) {
 			Source:      "1.1.1.1",
 			Destination: "2.2.2.2",
 		},
+		Source: &pb.Endpoint{
+			Identity: 4,
+		},
+		Destination: &pb.Endpoint{
+			Identity: 12345,
+		},
 		L4: &pb.Layer4{
 			Protocol: &pb.Layer4_TCP{
 				TCP: &pb.TCP{
@@ -112,7 +118,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 			},
 			wantErr: false,
 			expected: "Jan  1 00:20:34.567: " +
-				"1.1.1.1:31793 -> 2.2.2.2:8080 " +
+				"1.1.1.1:31793 (health) -> 2.2.2.2:8080 (identity:12345) " +
 				"Policy denied DROPPED (TCP Flags: SYN)\n",
 		},
 		{
@@ -128,7 +134,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 			},
 			wantErr: false,
 			expected: "Jan  1 00:20:34.567 [k8s1]: " +
-				"1.1.1.1:31793 -> 2.2.2.2:8080 " +
+				"1.1.1.1:31793 (health) -> 2.2.2.2:8080 (identity:12345) " +
 				"Policy denied DROPPED (TCP Flags: SYN)\n",
 		},
 		{
@@ -144,7 +150,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 			},
 			wantErr: false,
 			expected: "Jan  1 00:20:34.567 [k8s1]: " +
-				"2.2.2.2:8080 <- 1.1.1.1:31793 " +
+				"2.2.2.2:8080 (identity:12345) <- 1.1.1.1:31793 (health) " +
 				"Policy denied DROPPED (TCP Flags: SYN)\n",
 		},
 		{
@@ -160,7 +166,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 			},
 			wantErr: false,
 			expected: "Jan  1 00:20:34.567 [k8s1]: " +
-				"1.1.1.1:31793 <> 2.2.2.2:8080 " +
+				"1.1.1.1:31793 (health) <> 2.2.2.2:8080 (identity:12345) " +
 				"Policy denied DROPPED (TCP Flags: SYN)\n",
 		},
 		{
@@ -178,6 +184,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 				`"verdict":"DROPPED",` +
 				`"IP":{"source":"1.1.1.1","destination":"2.2.2.2"},` +
 				`"l4":{"TCP":{"source_port":31793,"destination_port":8080}},` +
+				`"source":{"identity":4},"destination":{"identity":12345},` +
 				`"Type":"L3_L4","node_name":"k8s1",` +
 				`"event_type":{"type":1,"sub_type":133},` +
 				`"is_reply":false,"Summary":"TCP Flags: SYN"}`,
@@ -197,6 +204,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 				`"verdict":"DROPPED",` +
 				`"IP":{"source":"1.1.1.1","destination":"2.2.2.2"},` +
 				`"l4":{"TCP":{"source_port":31793,"destination_port":8080}},` +
+				`"source":{"identity":4},"destination":{"identity":12345},` +
 				`"Type":"L3_L4","node_name":"k8s1",` +
 				`"event_type":{"type":1,"sub_type":133},` +
 				`"is_reply":false,"Summary":"TCP Flags: SYN"}}`,


### PR DESCRIPTION
This commit changes the default compact mode output to always display
the Cilium security identity. This is very useful when debugging policy
related issues, as those often occur when an endpoint does not have the
expected security identity assigned to it.

Screenshot below. Note the magenta `(identity)` fields which are added by this PR.

![image](https://user-images.githubusercontent.com/50564/168124741-6dc44404-69d3-4d31-8a06-1a944be2a24a.png)

There is no flag to disable those identities in compact mode. Users who rely on stable output are asked to use the `json` or `jsonpb` output.