### PR TITLE
Refactor usage template to determine --help flags using a registration pattern

### DIFF
--- a/cmd/common/template/usage_test.go
+++ b/cmd/common/template/usage_test.go
@@ -38,7 +38,9 @@ func TestUsage(t *testing.T) {
 	flags := pflag.NewFlagSet("bar", pflag.ContinueOnError)
 	flags.String("baz", "", "baz usage")
 	cmd.Flags().AddFlagSet(flags)
-	cmd.SetUsageTemplate(Usage(flags))
+
+	RegisterFlagSets(cmd.Name(), flags)
+	cmd.SetUsageTemplate(Usage)
 
 	subCmd := &cobra.Command{
 		Use: "subcmd",

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -30,7 +30,7 @@ func New(vp *viper.Viper) *cobra.Command {
 
 	// add config.ServerFlags to the help template as these flags are used by
 	// this command
-	listCmd.SetUsageTemplate(template.Usage(config.ServerFlags))
+	template.RegisterFlagSets(listCmd.Name(), config.ServerFlags)
 
 	listCmd.AddCommand(
 		newNodeCommand(vp),

--- a/cmd/list/node.go
+++ b/cmd/list/node.go
@@ -77,7 +77,7 @@ func newNodeCommand(vp *viper.Viper) *cobra.Command {
 		}, cobra.ShellCompDirectiveDefault
 	})
 
-	listCmd.SetUsageTemplate(template.Usage(formattingFlags, config.ServerFlags))
+	template.RegisterFlagSets(listCmd.Name(), formattingFlags, config.ServerFlags)
 	return listCmd
 }
 

--- a/cmd/observe/agent_events.go
+++ b/cmd/observe/agent_events.go
@@ -73,7 +73,7 @@ func newAgentEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.C
 		},
 	}
 
-	agentEventsCmd.SetUsageTemplate(template.Usage(flagSets...))
+	template.RegisterFlagSets(agentEventsCmd.Name(), flagSets...)
 
 	return agentEventsCmd
 }

--- a/cmd/observe/debug_events.go
+++ b/cmd/observe/debug_events.go
@@ -73,7 +73,7 @@ func newDebugEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.C
 		},
 	}
 
-	debugEventsCmd.SetUsageTemplate(template.Usage(flagSets...))
+	template.RegisterFlagSets(debugEventsCmd.Name(), flagSets...)
 
 	return debugEventsCmd
 }

--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -502,7 +502,8 @@ more.`,
 	)
 
 	formattingFlags.AddFlagSet(observeFormattingFlags)
-	observeCmd.SetUsageTemplate(template.Usage(selectorFlags, filterFlags, rawFilterFlags, formattingFlags, config.ServerFlags, otherFlags))
+
+	template.RegisterFlagSets(observeCmd.Name(), selectorFlags, filterFlags, rawFilterFlags, formattingFlags, config.ServerFlags, otherFlags)
 
 	return observeCmd
 }

--- a/cmd/record/record.go
+++ b/cmd/record/record.go
@@ -91,7 +91,7 @@ protocols are TCP, UDP and ANY.`,
 	recorderFlags.DurationVar(&timeLimit, "time-limit", 0, "Sets a limit on how long to capture on each node")
 
 	recordCmd.Flags().AddFlagSet(recorderFlags)
-	recordCmd.SetUsageTemplate(template.Usage(config.ServerFlags, recorderFlags))
+	template.RegisterFlagSets(recordCmd.Name(), config.ServerFlags, recorderFlags)
 
 	return recordCmd
 }

--- a/cmd/reflect/reflect.go
+++ b/cmd/reflect/reflect.go
@@ -50,7 +50,7 @@ func New(vp *viper.Viper) *cobra.Command {
 
 	// add config.ServerFlags to the help template as these flags are used by
 	// this command
-	reflectCmd.SetUsageTemplate(template.Usage(config.ServerFlags))
+	template.RegisterFlagSets(reflectCmd.Name(), config.ServerFlags)
 
 	return reflectCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,7 +83,8 @@ func NewWithViper(vp *viper.Viper) *cobra.Command {
 	// add it by default in the help template
 	// config.GlobalFlags is always added to the help template as it's global
 	// to all commands
-	rootCmd.SetUsageTemplate(template.Usage())
+	template.RegisterFlagSets(rootCmd.Name())
+	rootCmd.SetUsageTemplate(template.Usage)
 
 	rootCmd.SetErr(os.Stderr)
 	rootCmd.SetVersionTemplate("{{with .Name}}{{printf \"%s \" .}}{{end}}{{printf \"v%s\" .Version}}\r\n")

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -80,7 +80,7 @@ connectivity health check.`,
 
 	// add config.ServerFlags to the help template as these flags are used by
 	// this command
-	statusCmd.SetUsageTemplate(template.Usage(config.ServerFlags))
+	template.RegisterFlagSets(statusCmd.Name(), config.ServerFlags)
 
 	return statusCmd
 }

--- a/cmd/watch/watch.go
+++ b/cmd/watch/watch.go
@@ -32,7 +32,7 @@ func New(vp *viper.Viper) *cobra.Command {
 
 	// add config.ServerFlags to the help template as these flags are used by
 	// this command
-	peerCmd.SetUsageTemplate(template.Usage(config.ServerFlags))
+	template.RegisterFlagSets(peerCmd.Name(), config.ServerFlags)
 
 	peerCmd.AddCommand(
 		newPeerCommand(vp),


### PR DESCRIPTION
Removes the need to set the usage template per subcommand by registering
the commands which should be displayed in --help for each subcommand.