### PR TITLE
improve cli help text for service filtering

### DIFF
--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -345,13 +345,13 @@ more.`,
 
 	filterFlags.Var(filterVar(
 		"from-service", ofilter,
-		"Show all flows originating in the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used"))
+		"Shows flows where the source IP address matches the ClusterIP address of the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used"))
 	filterFlags.Var(filterVar(
 		"service", ofilter,
-		"Show all flows related to the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used"))
+		"Shows flows where either the source or destination IP address matches the ClusterIP address of the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used"))
 	filterFlags.Var(filterVar(
 		"to-service", ofilter,
-		"Show all flows terminating in the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used"))
+		"Shows flows where the destination IP address matches the ClusterIP address of the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used"))
 
 	filterFlags.Var(filterVar(
 		"from-port", ofilter,


### PR DESCRIPTION
The way the service field in Hubble flows has been implemented so far is that it only works if the destination IP is the service ClusterIP. This makes the following lines from hubble observe --help misleading:

--from-service filter     Show all flows originating in the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used
--service filter          Show all flows related to the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used
--to-service filter       Show all flows terminating in the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used

This patch changes the help message to address the inaccuracy described above.

Fixes: #713

Signed-off-by: Dominique Illi illi.dominique.v@gmail.com