### PR TITLE
named reserved identites support for `--{,from-,to-}identity`

### DIFF
--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -494,6 +494,15 @@ more.`,
 			http.MethodTrace,
 		}, cobra.ShellCompDirectiveDefault
 	})
+	observeCmd.RegisterFlagCompletionFunc("identity", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return reservedIdentitiesNames(), cobra.ShellCompDirectiveDefault
+	})
+	observeCmd.RegisterFlagCompletionFunc("to-identity", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return reservedIdentitiesNames(), cobra.ShellCompDirectiveDefault
+	})
+	observeCmd.RegisterFlagCompletionFunc("from-identity", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return reservedIdentitiesNames(), cobra.ShellCompDirectiveDefault
+	})
 	observeCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{
 			"compact",

--- a/cmd/observe/flows_filter.go
+++ b/cmd/observe/flows_filter.go
@@ -493,7 +493,7 @@ func (of *flowFilter) set(f *filterTracker, name, val string, track bool) error 
 	case "identity":
 		i, err := strconv.ParseUint(val, 10, 32)
 		if err != nil {
-			return fmt.Errorf("invalid security identity: %s: %s", val, err)
+			return errors.New("invalid security identity")
 		}
 		identity := uint32(i)
 		f.applyLeft(func(f *flowpb.FlowFilter) {
@@ -505,7 +505,7 @@ func (of *flowFilter) set(f *filterTracker, name, val string, track bool) error 
 	case "from-identity":
 		i, err := strconv.ParseUint(val, 10, 32)
 		if err != nil {
-			return fmt.Errorf("invalid security identity: %s: %s", val, err)
+			return errors.New("invalid security identity")
 		}
 		identity := uint32(i)
 		f.apply(func(f *flowpb.FlowFilter) {
@@ -514,7 +514,7 @@ func (of *flowFilter) set(f *filterTracker, name, val string, track bool) error 
 	case "to-identity":
 		i, err := strconv.ParseUint(val, 10, 32)
 		if err != nil {
-			return fmt.Errorf("invalid security identity: %s: %s", val, err)
+			return errors.New("invalid security identity")
 		}
 		identity := uint32(i)
 		f.apply(func(f *flowpb.FlowFilter) {

--- a/cmd/observe/flows_filter.go
+++ b/cmd/observe/flows_filter.go
@@ -491,34 +491,31 @@ func (of *flowFilter) set(f *filterTracker, name, val string, track bool) error 
 
 	// identity filters
 	case "identity":
-		i, err := strconv.ParseUint(val, 10, 32)
+		identity, err := parseIdentity(val)
 		if err != nil {
-			return errors.New("invalid security identity")
+			return fmt.Errorf("invalid security identity, expected one of %v or a numeric value", reservedIdentitiesNames())
 		}
-		identity := uint32(i)
 		f.applyLeft(func(f *flowpb.FlowFilter) {
-			f.SourceIdentity = append(f.SourceIdentity, identity)
+			f.SourceIdentity = append(f.SourceIdentity, identity.Uint32())
 		})
 		f.applyRight(func(f *flowpb.FlowFilter) {
-			f.DestinationIdentity = append(f.DestinationIdentity, identity)
+			f.DestinationIdentity = append(f.DestinationIdentity, identity.Uint32())
 		})
 	case "from-identity":
-		i, err := strconv.ParseUint(val, 10, 32)
+		identity, err := parseIdentity(val)
 		if err != nil {
-			return errors.New("invalid security identity")
+			return fmt.Errorf("invalid security identity, expected one of %v or a numeric value", reservedIdentitiesNames())
 		}
-		identity := uint32(i)
-		f.apply(func(f *flowpb.FlowFilter) {
-			f.SourceIdentity = append(f.SourceIdentity, identity)
+		f.applyLeft(func(f *flowpb.FlowFilter) {
+			f.SourceIdentity = append(f.SourceIdentity, identity.Uint32())
 		})
 	case "to-identity":
-		i, err := strconv.ParseUint(val, 10, 32)
+		identity, err := parseIdentity(val)
 		if err != nil {
-			return errors.New("invalid security identity")
+			return fmt.Errorf("invalid security identity, expected one of %v or a numeric value", reservedIdentitiesNames())
 		}
-		identity := uint32(i)
-		f.apply(func(f *flowpb.FlowFilter) {
-			f.DestinationIdentity = append(f.DestinationIdentity, identity)
+		f.applyRight(func(f *flowpb.FlowFilter) {
+			f.DestinationIdentity = append(f.DestinationIdentity, identity.Uint32())
 		})
 
 	// node name filters

--- a/cmd/observe/identity.go
+++ b/cmd/observe/identity.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"sort"
+
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+// reservedIdentitiesNames returns a slice of all the reserved identity
+// strings.
+func reservedIdentitiesNames() []string {
+	identities := identity.GetAllReservedIdentities()
+	// NOTE: identity.GetAllReservedIdentities() returned values are sorted in
+	// a random order due to be sourced from a map. We sort them here in
+	// identity order to ensure consistency before converting them to strings.
+	// Once https://github.com/cilium/cilium/pull/20048 is merged and vendored,
+	// we can remove this sort.
+	sort.Slice(identities, func(i, j int) bool {
+		return identities[i].Uint32() < identities[j].Uint32()
+	})
+
+	names := make([]string, len(identities))
+	for i, id := range identities {
+		names[i] = id.String()
+	}
+
+	return names
+}
+
+// parseIdentity parse and return both numeric and reserved identities, or an
+// error.
+func parseIdentity(s string) (identity.NumericIdentity, error) {
+	if id := identity.GetReservedID(s); id != identity.IdentityUnknown {
+		return id, nil
+	}
+	return identity.ParseNumericIdentity(s)
+}


### PR DESCRIPTION
https://github.com/cilium/hubble/pull/717 introduced display of security identity in the (default) compact output, which is awesome. While trying to copy/paste identities from the Hubble CLI output to its `--identity` flag, I found that named reserved identities were not supported.

After this patch, we can write `hubble observe --identity world` instead of `hubble observe --label reserved:world`. 