### PR TITLE
compact: Use "ID" for security identity prefix

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -180,7 +180,7 @@ func (p *Printer) fmtIdentity(i uint32) string {
 		return p.color.identity(fmt.Sprintf("(%s)", numeric))
 	}
 
-	return p.color.identity(fmt.Sprintf("(identity:%d)", i))
+	return p.color.identity(fmt.Sprintf("(ID:%d)", i))
 }
 
 // GetSecurityIdentities returns the source and destination numeric security

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -118,7 +118,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 			},
 			wantErr: false,
 			expected: "Jan  1 00:20:34.567: " +
-				"1.1.1.1:31793 (health) -> 2.2.2.2:8080 (identity:12345) " +
+				"1.1.1.1:31793 (health) -> 2.2.2.2:8080 (ID:12345) " +
 				"Policy denied DROPPED (TCP Flags: SYN)\n",
 		},
 		{
@@ -134,7 +134,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 			},
 			wantErr: false,
 			expected: "Jan  1 00:20:34.567 [k8s1]: " +
-				"1.1.1.1:31793 (health) -> 2.2.2.2:8080 (identity:12345) " +
+				"1.1.1.1:31793 (health) -> 2.2.2.2:8080 (ID:12345) " +
 				"Policy denied DROPPED (TCP Flags: SYN)\n",
 		},
 		{
@@ -150,7 +150,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 			},
 			wantErr: false,
 			expected: "Jan  1 00:20:34.567 [k8s1]: " +
-				"2.2.2.2:8080 (identity:12345) <- 1.1.1.1:31793 (health) " +
+				"2.2.2.2:8080 (ID:12345) <- 1.1.1.1:31793 (health) " +
 				"Policy denied DROPPED (TCP Flags: SYN)\n",
 		},
 		{
@@ -166,7 +166,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 			},
 			wantErr: false,
 			expected: "Jan  1 00:20:34.567 [k8s1]: " +
-				"1.1.1.1:31793 (health) <> 2.2.2.2:8080 (identity:12345) " +
+				"1.1.1.1:31793 (health) <> 2.2.2.2:8080 (ID:12345) " +
 				"Policy denied DROPPED (TCP Flags: SYN)\n",
 		},
 		{


### PR DESCRIPTION
It's shorter than "identity", and still conveys enough information
about what these integers mean.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>