### PR TITLE
Update Go to 1.18.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923
       with:
-        go-version: '1.18.3'
+        go-version: '1.18.4'
     - name: Run static checks
       uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.18.3-alpine3.16@sha256:7cc62574fcf9c5fb87ad42a9789d5539a6a085971d58ee75dd2ee146cb8a8695 as builder
+FROM docker.io/library/golang:1.18.4-alpine3.16@sha256:46f1fa18ca1ec228f7ea4978ad717f0a8c5e51436e7b8efaf64011f7729886df as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache git make
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ hubble:
 	$(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET)
 
 release:
-	docker run --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.18.3-alpine3.16 \
+	docker run --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.18.4-alpine3.16 \
 		sh -c "apk add --no-cache make git && \
 			addgroup -g $(RELEASE_GID) release && \
 			adduser -u $(RELEASE_UID) -D -G release release && \


### PR DESCRIPTION
This includes various security fixes, see
https://go.dev/doc/devel/release#go1.18.4 for details.