### PR TITLE
v0.9: Update Go to 1.17.12, alpine to 3.16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
     - uses: actions/setup-go@v2.1.4
       with:
-        go-version: '1.17.10'
+        go-version: '1.17.12'
     - name: Run static checks
       uses: golangci/golangci-lint-action@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.17.10-alpine3.14@sha256:7dee28aaabcbd25c4dcd0fa6663c01157c1cca061f903b69ecf0e6f0524634d1 as builder
+FROM docker.io/library/golang:1.17.12-alpine3.16@sha256:5996fe1cad19eec6fc1419794a16cb13a6caaf395b4362fdcd3e2ea06cf742b7 as builder
 WORKDIR /go/src/github.com/cilium/hubble
 RUN apk add --no-cache git make
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ hubble:
 	$(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET)
 
 release:
-	docker run --env "RELEASE_UID=$(RELEASE_UID)" --env "RELEASE_GID=$(RELEASE_GID)" --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.17.10-alpine3.14 \
+	docker run --env "RELEASE_UID=$(RELEASE_UID)" --env "RELEASE_GID=$(RELEASE_GID)" --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.17.12-alpine3.16 \
 		sh -c "apk add --no-cache make && make local-release"
 
 local-release: clean


### PR DESCRIPTION
This includes various security fixes, see
https://go.dev/doc/devel/release#go1.17.12 for details.

Also update to alpine 3.16 because 3.14 is EOL and there thus is no
golang:1.17.12-alpine3.14 image.