### PR TITLE
Use command path when registering flagsets

### DIFF
--- a/cmd/common/template/usage_test.go
+++ b/cmd/common/template/usage_test.go
@@ -39,7 +39,7 @@ func TestUsage(t *testing.T) {
 	flags.String("baz", "", "baz usage")
 	cmd.Flags().AddFlagSet(flags)
 
-	RegisterFlagSets(cmd.Name(), flags)
+	RegisterFlagSets(cmd, flags)
 	cmd.SetUsageTemplate(Usage)
 
 	subCmd := &cobra.Command{
@@ -49,6 +49,8 @@ func TestUsage(t *testing.T) {
 		},
 	}
 	cmd.AddCommand(subCmd)
+
+	Initialize()
 
 	var out strings.Builder
 	cmd.SetOut(&out)

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -30,7 +30,7 @@ func New(vp *viper.Viper) *cobra.Command {
 
 	// add config.ServerFlags to the help template as these flags are used by
 	// this command
-	template.RegisterFlagSets(listCmd.Name(), config.ServerFlags)
+	template.RegisterFlagSets(listCmd, config.ServerFlags)
 
 	listCmd.AddCommand(
 		newNodeCommand(vp),

--- a/cmd/list/node.go
+++ b/cmd/list/node.go
@@ -77,7 +77,7 @@ func newNodeCommand(vp *viper.Viper) *cobra.Command {
 		}, cobra.ShellCompDirectiveDefault
 	})
 
-	template.RegisterFlagSets(listCmd.Name(), formattingFlags, config.ServerFlags)
+	template.RegisterFlagSets(listCmd, formattingFlags, config.ServerFlags)
 	return listCmd
 }
 

--- a/cmd/observe/agent_events.go
+++ b/cmd/observe/agent_events.go
@@ -73,7 +73,7 @@ func newAgentEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.C
 		},
 	}
 
-	template.RegisterFlagSets(agentEventsCmd.Name(), flagSets...)
+	template.RegisterFlagSets(agentEventsCmd, flagSets...)
 
 	return agentEventsCmd
 }

--- a/cmd/observe/debug_events.go
+++ b/cmd/observe/debug_events.go
@@ -73,7 +73,7 @@ func newDebugEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.C
 		},
 	}
 
-	template.RegisterFlagSets(debugEventsCmd.Name(), flagSets...)
+	template.RegisterFlagSets(debugEventsCmd, flagSets...)
 
 	return debugEventsCmd
 }

--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -578,7 +578,7 @@ more.`,
 
 	formattingFlags.AddFlagSet(observeFormattingFlags)
 
-	template.RegisterFlagSets(observeCmd.Name(), selectorFlags, filterFlags, rawFilterFlags, formattingFlags, config.ServerFlags, otherFlags)
+	template.RegisterFlagSets(observeCmd, selectorFlags, filterFlags, rawFilterFlags, formattingFlags, config.ServerFlags, otherFlags)
 
 	return observeCmd
 }

--- a/cmd/record/record.go
+++ b/cmd/record/record.go
@@ -26,14 +26,15 @@ import (
 	"time"
 
 	recorderpb "github.com/cilium/cilium/api/v1/recorder"
-	"github.com/cilium/hubble/cmd/common/config"
-	"github.com/cilium/hubble/cmd/common/conn"
-	"github.com/cilium/hubble/cmd/common/template"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/cilium/hubble/cmd/common/config"
+	"github.com/cilium/hubble/cmd/common/conn"
+	"github.com/cilium/hubble/cmd/common/template"
 )
 
 const (
@@ -91,7 +92,7 @@ protocols are TCP, UDP and ANY.`,
 	recorderFlags.DurationVar(&timeLimit, "time-limit", 0, "Sets a limit on how long to capture on each node")
 
 	recordCmd.Flags().AddFlagSet(recorderFlags)
-	template.RegisterFlagSets(recordCmd.Name(), config.ServerFlags, recorderFlags)
+	template.RegisterFlagSets(recordCmd, config.ServerFlags, recorderFlags)
 
 	return recordCmd
 }

--- a/cmd/reflect/reflect.go
+++ b/cmd/reflect/reflect.go
@@ -50,7 +50,7 @@ func New(vp *viper.Viper) *cobra.Command {
 
 	// add config.ServerFlags to the help template as these flags are used by
 	// this command
-	template.RegisterFlagSets(reflectCmd.Name(), config.ServerFlags)
+	template.RegisterFlagSets(reflectCmd, config.ServerFlags)
 
 	return reflectCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,9 @@ func New() *cobra.Command {
 
 // NewWithViper creates a new root command with the given viper.
 func NewWithViper(vp *viper.Viper) *cobra.Command {
+	// Initialize must be called after the sub-commands are all added
+	defer template.Initialize()
+
 	rootCmd := &cobra.Command{
 		Use:           "hubble",
 		Short:         "CLI",
@@ -83,7 +86,7 @@ func NewWithViper(vp *viper.Viper) *cobra.Command {
 	// add it by default in the help template
 	// config.GlobalFlags is always added to the help template as it's global
 	// to all commands
-	template.RegisterFlagSets(rootCmd.Name())
+	template.RegisterFlagSets(rootCmd)
 	rootCmd.SetUsageTemplate(template.Usage)
 
 	rootCmd.SetErr(os.Stderr)
@@ -99,6 +102,7 @@ func NewWithViper(vp *viper.Viper) *cobra.Command {
 		version.New(),
 		watch.New(vp),
 	)
+
 	return rootCmd
 }
 

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -80,7 +80,7 @@ connectivity health check.`,
 
 	// add config.ServerFlags to the help template as these flags are used by
 	// this command
-	template.RegisterFlagSets(statusCmd.Name(), config.ServerFlags)
+	template.RegisterFlagSets(statusCmd, config.ServerFlags)
 
 	return statusCmd
 }

--- a/cmd/watch/watch.go
+++ b/cmd/watch/watch.go
@@ -32,7 +32,7 @@ func New(vp *viper.Viper) *cobra.Command {
 
 	// add config.ServerFlags to the help template as these flags are used by
 	// this command
-	template.RegisterFlagSets(peerCmd.Name(), config.ServerFlags)
+	template.RegisterFlagSets(peerCmd, config.ServerFlags)
 
 	peerCmd.AddCommand(
 		newPeerCommand(vp),


### PR DESCRIPTION
Avoids conflicts when different sub-commands have the same command name.
(Eg: hubble status vs hubble foobar status).

Since commands paths rely on having parent-commands, we must initialize
the map containing the flagsets after all sub-commands have been added.

This was something I discovered after trying to add new sub-commands that have the same name as other sub-sub-commands.