### PR TITLE
v0.10: printer: fix argument order in strings.HasPrefix call

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -640,7 +640,7 @@ func fmtEndpointShort(ep *pb.Endpoint) string {
 	str := fmt.Sprintf("ID: %d", ep.GetID())
 	if ns, pod := ep.GetNamespace(), ep.GetPodName(); ns != "" && pod != "" {
 		str = fmt.Sprintf("%s/%s (%s)", ns, pod, str)
-	} else if lbls := ep.GetLabels(); len(lbls) == 1 && strings.HasPrefix("reserved:", lbls[0]) {
+	} else if lbls := ep.GetLabels(); len(lbls) == 1 && strings.HasPrefix(lbls[0], "reserved:") {
 		str = fmt.Sprintf("%s (%s)", lbls[0], str)
 	}
 


### PR DESCRIPTION
[ upstream commit d7910888d26abf817841a1904c5fc6e462f6861f ]

We should check for the "reserved:" prefix in the label string, not vice
versa.

Found by the gocritic linter.