### PR TITLE
Fix observe command not supporting --until without --since

### DIFF
--- a/cmd/observe/agent_events.go
+++ b/cmd/observe/agent_events.go
@@ -91,18 +91,18 @@ func getAgentEventsRequest() (*observerpb.GetAgentEventsRequest, error) {
 		if err := since.CheckValid(); err != nil {
 			return nil, fmt.Errorf("failed to convert `since` timestamp to proto: %v", err)
 		}
-		// Set the until field if both --since and --until options are specified and --follow
-		// is not specified. If --since is specified but --until is not, the server sets the
-		// --until option to the current timestamp.
-		if selectorOpts.until != "" && !selectorOpts.follow {
-			ut, err := hubtime.FromString(selectorOpts.until)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse the until time: %v", err)
-			}
-			until = timestamppb.New(ut)
-			if err := until.CheckValid(); err != nil {
-				return nil, fmt.Errorf("failed to convert `until` timestamp to proto: %v", err)
-			}
+	}
+	// Set the until field if --until option is specified and --follow
+	// is not specified. If --since is specified but --until is not, the server sets the
+	// --until option to the current timestamp.
+	if selectorOpts.until != "" && !selectorOpts.follow {
+		ut, err := hubtime.FromString(selectorOpts.until)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse the until time: %v", err)
+		}
+		until = timestamppb.New(ut)
+		if err := until.CheckValid(); err != nil {
+			return nil, fmt.Errorf("failed to convert `until` timestamp to proto: %v", err)
 		}
 	}
 

--- a/cmd/observe/agent_events_test.go
+++ b/cmd/observe/agent_events_test.go
@@ -67,3 +67,21 @@ func Test_getAgentEventsRequest(t *testing.T) {
 		Until:  timestamppb.New(until),
 	}, req)
 }
+
+func Test_getAgentEventsRequestWithoutSince(t *testing.T) {
+	selectorOpts.since = ""
+	selectorOpts.until = ""
+	req, err := getAgentEventsRequest()
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetAgentEventsRequest{Number: defaults.EventsPrintCount}, req)
+	selectorOpts.until = "2021-04-26T00:01:00Z"
+	req, err = getAgentEventsRequest()
+	assert.NoError(t, err)
+	assert.NoError(t, err)
+	until, err := time.Parse(time.RFC3339, selectorOpts.until)
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetAgentEventsRequest{
+		Number: defaults.EventsPrintCount,
+		Until:  timestamppb.New(until),
+	}, req)
+}

--- a/cmd/observe/debug_events.go
+++ b/cmd/observe/debug_events.go
@@ -91,18 +91,18 @@ func getDebugEventsRequest() (*observerpb.GetDebugEventsRequest, error) {
 		if err := since.CheckValid(); err != nil {
 			return nil, fmt.Errorf("failed to convert `since` timestamp to proto: %v", err)
 		}
-		// Set the until field if both --since and --until options are specified and --follow
-		// is not specified. If --since is specified but --until is not, the server sets the
-		// --until option to the current timestamp.
-		if selectorOpts.until != "" && !selectorOpts.follow {
-			ut, err := hubtime.FromString(selectorOpts.until)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse the until time: %v", err)
-			}
-			until = timestamppb.New(ut)
-			if err := until.CheckValid(); err != nil {
-				return nil, fmt.Errorf("failed to convert `until` timestamp to proto: %v", err)
-			}
+	}
+	// Set the until field if --until option is specified and --follow
+	// is not specified. If --since is specified but --until is not, the server sets the
+	// --until option to the current timestamp.
+	if selectorOpts.until != "" && !selectorOpts.follow {
+		ut, err := hubtime.FromString(selectorOpts.until)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse the until time: %v", err)
+		}
+		until = timestamppb.New(ut)
+		if err := until.CheckValid(); err != nil {
+			return nil, fmt.Errorf("failed to convert `until` timestamp to proto: %v", err)
 		}
 	}
 

--- a/cmd/observe/debug_events_test.go
+++ b/cmd/observe/debug_events_test.go
@@ -44,3 +44,20 @@ func Test_getDebugEventsRequest(t *testing.T) {
 		Until:  timestamppb.New(until),
 	}, req)
 }
+
+func Test_getDebugEventsRequestWithoutSince(t *testing.T) {
+	selectorOpts.since = ""
+	selectorOpts.until = ""
+	req, err := getDebugEventsRequest()
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetDebugEventsRequest{Number: defaults.EventsPrintCount}, req)
+	selectorOpts.until = "2021-04-26T01:01:00Z"
+	req, err = getDebugEventsRequest()
+	assert.NoError(t, err)
+	until, err := time.Parse(time.RFC3339, selectorOpts.until)
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetDebugEventsRequest{
+		Number: defaults.EventsPrintCount,
+		Until:  timestamppb.New(until),
+	}, req)
+}

--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -676,18 +676,18 @@ func getFlowsRequest(ofilter *flowFilter, allowlist []string, denylist []string)
 		if err := since.CheckValid(); err != nil {
 			return nil, fmt.Errorf("failed to convert `since` timestamp to proto: %v", err)
 		}
-		// Set the until field if both --since and --until options are specified and --follow
-		// is not specified. If --since is specified but --until is not, the server sets the
-		// --until option to the current timestamp.
-		if selectorOpts.until != "" && !selectorOpts.follow {
-			ut, err := hubtime.FromString(selectorOpts.until)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse the until time: %v", err)
-			}
-			until = timestamppb.New(ut)
-			if err := until.CheckValid(); err != nil {
-				return nil, fmt.Errorf("failed to convert `until` timestamp to proto: %v", err)
-			}
+	}
+	// Set the until field if --until option is specified and --follow
+	// is not specified. If --since is specified but --until is not, the server sets the
+	// --until option to the current timestamp.
+	if selectorOpts.until != "" && !selectorOpts.follow {
+		ut, err := hubtime.FromString(selectorOpts.until)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse the until time: %v", err)
+		}
+		until = timestamppb.New(ut)
+		if err := until.CheckValid(); err != nil {
+			return nil, fmt.Errorf("failed to convert `until` timestamp to proto: %v", err)
 		}
 	}
 

--- a/cmd/observe/flows_test.go
+++ b/cmd/observe/flows_test.go
@@ -71,6 +71,24 @@ func Test_getFlowsRequest(t *testing.T) {
 	}, req)
 }
 
+func Test_getFlowsRequestWithoutSince(t *testing.T) {
+	selectorOpts.since = ""
+	selectorOpts.until = ""
+	filter := newFlowFilter()
+	req, err := getFlowsRequest(filter, nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetFlowsRequest{Number: defaults.FlowPrintCount}, req)
+	selectorOpts.until = "2021-03-24T00:00:00Z"
+	req, err = getFlowsRequest(filter, nil, nil)
+	assert.NoError(t, err)
+	until, err := time.Parse(time.RFC3339, selectorOpts.until)
+	assert.NoError(t, err)
+	assert.Equal(t, &observer.GetFlowsRequest{
+		Number: defaults.FlowPrintCount,
+		Until:  timestamppb.New(until),
+	}, req)
+}
+
 func Test_getFlowsRequestWithRawFilters(t *testing.T) {
 	allowlist := []string{
 		`{"source_label":["k8s:io.kubernetes.pod.namespace=kube-system","reserved:host"]}`,


### PR DESCRIPTION
At the moment, `hubble observe` command ignores `--until` flag if `--since` is not specified. It would be expected `--since` flag to not be a hard requirement for `--until` flag to be used on its own.

This patch makes `--until` flag to be consider without  having  `--since` flag as a prerequisite.

Fixes https://github.com/cilium/hubble/issues/519

Signed-off-by: ChrsMark <chrismarkou92@gmail.com>