### PR TITLE
Makefile: Fix potential uid/gid collision by using setpriv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,8 @@ hubble:
 
 release:
 	docker run --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.19.3-alpine3.16 \
-		sh -c "apk add --no-cache make git && \
-			addgroup -g $(RELEASE_GID) release && \
-			adduser -u $(RELEASE_UID) -D -G release release && \
-			su release -c 'make local-release'"
+		sh -c "apk add --no-cache setpriv make git && \
+			/usr/bin/setpriv --reuid=$(RELEASE_UID) --regid=$(RELEASE_GID) --clear-groups make GOCACHE=/tmp/gocache local-release"
 
 local-release: clean
 	set -o errexit; \


### PR DESCRIPTION
The release build should run with the same numeric user and group id as the caller of the Makefile. This solves two problems:

 1. The generated artefacts should be owned by the user who invoked the Makefile
 2. `go build -buildvcs=true` (the default since Go 1.18) invokes git, and git requires that the .git folder is owned by the user invoking it.

Previously, we achieved this by creating a new user and group inside the container with the wanted uid/gid. The problem with that approach is it fails if the uid/gid is already taken (such as e.g. gid 123, which seems to be used by the GitHub runner as of recently). Therefore, instead of trying to create a new user, this commit now uses `setpriv` from util-linux to force the `make` process (and all its children) to run as the RELEASE_{UID/GID}. This ensures that both `git` can access the `.git` directory owned by the host user, and that the host user can access the generated artifacts. One limitation of `setpriv` is that it runs the child process without an accessible `$HOME` directory, which `go build` needs for the GOCACHE. To solve this for now, we point it to a temporary directory. In the future, we could consider using a GOCACHE owned by the host, to allow cache-reuse across builds.

This fixes an issue where the GitHub release workflow fails with `addgroup: gid '123' in use`