### PR TITLE
cmd: Make `-o json` an alias for `-o jsobpb`

### DIFF
--- a/cmd/observe/events.go
+++ b/cmd/observe/events.go
@@ -21,9 +21,7 @@ func handleEventsArgs(debug bool) error {
 		opts = append(opts, hubprinter.Compact())
 	case "dict":
 		opts = append(opts, hubprinter.Dict())
-	case "json", "JSON":
-		opts = append(opts, hubprinter.JSON())
-	case "jsonpb":
+	case "json", "JSON", "jsonpb":
 		opts = append(opts, hubprinter.JSONPB())
 	case "tab", "table":
 		if selectorOpts.follow {

--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -461,8 +461,8 @@ more.`,
 		`Specify the output format, one of:
   compact:  Compact output
   dict:     Each flow is shown as KEY:VALUE pair
-  json:     JSON encoding (DEPRECATED: use --output=jsonpb instead)
-  jsonpb:   Output each GetFlowResponse according to proto3's JSON mapping
+  jsonpb:   JSON encoded GetFlowResponse according to proto3's JSON mapping
+  json:     Alias for jsonpb
   table:    Tab-aligned columns
 `)
 	formattingFlags.BoolVarP(&formattingOpts.nodeName, "print-node-name", "", false, "Print node name in output")
@@ -607,9 +607,7 @@ func handleFlowArgs(ofilter *flowFilter, debug bool) (err error) {
 		opts = append(opts, hubprinter.Compact())
 	case "dict":
 		opts = append(opts, hubprinter.Dict())
-	case "json", "JSON":
-		opts = append(opts, hubprinter.JSON())
-	case "jsonpb":
+	case "json", "JSON", "jsonpb":
 		opts = append(opts, hubprinter.JSONPB())
 	case "tab", "table":
 		if selectorOpts.follow {

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -99,9 +99,7 @@ func runStatus(conn *grpc.ClientConn, out io.Writer) error {
 		opts = append(opts, printer.Compact())
 	case "dict":
 		opts = append(opts, printer.Dict())
-	case "json", "JSON":
-		opts = append(opts, printer.JSON())
-	case "jsonpb":
+	case "json", "JSON", "jsonpb":
 		opts = append(opts, printer.JSONPB())
 	case "tab", "table":
 		opts = append(opts, printer.Tab())

--- a/pkg/printer/options.go
+++ b/pkg/printer/options.go
@@ -4,9 +4,7 @@
 package printer
 
 import (
-	"fmt"
 	"io"
-	"os"
 )
 
 // Output enum of the printer.
@@ -15,8 +13,6 @@ type Output int
 const (
 	// TabOutput prints flows in even tab-aligned columns.
 	TabOutput Output = iota
-	// JSONOutput prints flows as json.
-	JSONOutput
 	// CompactOutput prints flows as compact as possible (similar to monitor).
 	CompactOutput
 	// DictOutput presents the same information as TabOutput, but each flow is
@@ -40,14 +36,6 @@ type Options struct {
 
 // Option ...
 type Option func(*Options)
-
-// JSON encoded output from the printer.
-func JSON() Option {
-	fmt.Fprintln(os.Stderr, "WARNING: The --output=json option has been deprecated. Use --output=jsonpb instead")
-	return func(opts *Options) {
-		opts.output = JSONOutput
-	}
-}
 
 // JSONPB encodes GetFlowsResponse as JSON according to proto3's JSON mapping.
 func JSONPB() Option {

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -79,7 +79,7 @@ func New(fopts ...Option) *Printer {
 		// initialize tabwriter since it's going to be needed
 		p.tw = tabwriter.NewWriter(opts.w, 2, 0, 3, ' ', 0)
 		p.color.disable() // the tabwriter is not compatible with colors, thus disable coloring
-	case JSONOutput, JSONPBOutput:
+	case JSONPBOutput:
 		p.jsonEncoder = json.NewEncoder(p.opts.w)
 	}
 
@@ -361,8 +361,6 @@ func (p *Printer) WriteProtoFlow(res *observerpb.GetFlowsResponse) error {
 		if err != nil {
 			return fmt.Errorf("failed to write out packet: %v", err)
 		}
-	case JSONOutput:
-		return p.jsonEncoder.Encode(f)
 	case JSONPBOutput:
 		return p.jsonEncoder.Encode(res)
 	}
@@ -413,7 +411,7 @@ func (p *Printer) WriteProtoNodeStatusEvent(r *observerpb.GetFlowsResponse) erro
 	}
 
 	switch p.opts.output {
-	case JSONOutput, JSONPBOutput:
+	case JSONPBOutput:
 		return json.NewEncoder(p.opts.werr).Encode(r)
 	case DictOutput:
 		// this is a bit crude, but in case stdout and stderr are interleaved,
@@ -563,8 +561,6 @@ func (p *Printer) WriteProtoAgentEvent(r *observerpb.GetAgentEventsResponse) err
 	}
 
 	switch p.opts.output {
-	case JSONOutput:
-		return p.jsonEncoder.Encode(e)
 	case JSONPBOutput:
 		return p.jsonEncoder.Encode(r)
 	case DictOutput:
@@ -665,8 +661,6 @@ func (p *Printer) WriteProtoDebugEvent(r *observerpb.GetDebugEventsResponse) err
 	}
 
 	switch p.opts.output {
-	case JSONOutput:
-		return p.jsonEncoder.Encode(e)
 	case JSONPBOutput:
 		return p.jsonEncoder.Encode(r)
 	case DictOutput:
@@ -877,7 +871,7 @@ func (p *Printer) WriteServerStatusResponse(res *observerpb.ServerStatusResponse
 		if ew.err != nil {
 			return fmt.Errorf("failed to write out server status: %v", ew.err)
 		}
-	case JSONOutput, JSONPBOutput:
+	case JSONPBOutput:
 		return p.jsonEncoder.Encode(res)
 	}
 	return nil

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -183,7 +183,7 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 		{
 			name: "json",
 			options: []Option{
-				JSON(),
+				JSONPB(),
 				WithColor("never"),
 				Writer(&buf),
 			},
@@ -191,14 +191,14 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 				f: &f,
 			},
 			wantErr: false,
-			expected: `{"time":"1970-01-01T00:20:34.567800Z",` +
+			expected: `{"flow":{"time":"1970-01-01T00:20:34.567800Z",` +
 				`"verdict":"DROPPED",` +
 				`"IP":{"source":"1.1.1.1","destination":"2.2.2.2"},` +
 				`"l4":{"TCP":{"source_port":31793,"destination_port":8080}},` +
 				`"source":{"identity":4},"destination":{"identity":12345},` +
 				`"Type":"L3_L4","node_name":"k8s1",` +
 				`"event_type":{"type":1,"sub_type":133},` +
-				`"is_reply":false,"Summary":"TCP Flags: SYN"}`,
+				`"is_reply":false,"Summary":"TCP Flags: SYN"}}`,
 		},
 		{
 			name: "jsonpb",
@@ -1045,7 +1045,7 @@ Jan  1 00:20:34.567   k8s1   cilium-test/pod-to-a-denied-cnp-75cb89dfd-vqhd9 (ID
 		{
 			name: "json",
 			options: []Option{
-				JSON(),
+				JSONPB(),
 				Writer(&buf),
 			},
 			args: args{
@@ -1054,11 +1054,12 @@ Jan  1 00:20:34.567   k8s1   cilium-test/pod-to-a-denied-cnp-75cb89dfd-vqhd9 (ID
 				ts:   ts,
 			},
 			wantErr: false,
-			expected: `{"type":"DBG_CT_VERDICT","source":{"ID":690,"identity":1332,"namespace":"cilium-test","labels":` +
+			expected: `{"debug_event":{"type":"DBG_CT_VERDICT","source":{"ID":690,"identity":1332,"namespace":"cilium-test","labels":` +
 				`["k8s:io.cilium.k8s.policy.cluster=default","k8s:io.cilium.k8s.policy.serviceaccount=default",` +
 				`"k8s:io.kubernetes.pod.namespace=cilium-test","k8s:name=pod-to-a-denied-cnp"],` +
 				`"pod_name":"pod-to-a-denied-cnp-75cb89dfd-vqhd9"},` +
-				`"hash":180354257,"arg1":0,"arg2":0,"arg3":0,"message":"CT verdict: New, revnat=0","cpu":1}`,
+				`"hash":180354257,"arg1":0,"arg2":0,"arg3":0,"message":"CT verdict: New, revnat=0","cpu":1},` +
+				`"node_name":"k8s1","time":"1970-01-01T00:20:34.567800Z"}`,
 		},
 		{
 			name: "jsonpb",
@@ -1218,7 +1219,7 @@ Connected Nodes: 2/2`,
 		}, {
 			name: "json",
 			options: []Option{
-				JSON(),
+				JSONPB(),
 				WithColor("never"),
 				Writer(&buf),
 			},
@@ -1228,7 +1229,7 @@ Connected Nodes: 2/2`,
 		}, {
 			name: "json-with-nodes",
 			options: []Option{
-				JSON(),
+				JSONPB(),
 				WithColor("never"),
 				Writer(&buf),
 			},


### PR DESCRIPTION
This commit removes the old deprecated JSON output and fully replaces it with the newer JSONPB output (based on proto3's json mapping).

This is a breaking change, users of `-o json` will have to adopt the output parsing slightly: Each emitted object is now wrapped in a `GetFlowsResponse`, which means that the flow object (the root of the previous JSON output) is now accessible via the `.flow` attribute. 

For example, a query of the form `hubble observe -o json | jq .source.labels` now needs to be written as `hubble observe -o json | jq .flow.source.labels`.
