### PR TITLE
update Go to v1.19.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
       with:
-        go-version: '1.19.4'
+        go-version: '1.19.5'
     - name: Run static checks
       uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376
       with:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ hubble:
 	$(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET)
 
 release:
-	docker run --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.19.4-alpine3.17 \
+	docker run --rm --workdir /hubble --volume `pwd`:/hubble docker.io/library/golang:1.19.5-alpine3.17 \
 		sh -c "apk add --no-cache setpriv make git && \
 			/usr/bin/setpriv --reuid=$(RELEASE_UID) --regid=$(RELEASE_GID) --clear-groups make GOCACHE=/tmp/gocache local-release"
 


### PR DESCRIPTION
> go1.19.5 (released 2023-01-10) includes fixes to the compiler, the
> linker, and the crypto/x509, net/http, sync/atomic, and syscall
> packages. See the Go 1.19.5 milestone on our issue tracker for
> details.

Release milestone:
https://github.com/golang/go/issues?q=milestone%3AGo1.19.5+label%3ACherryPickApproved