### PR TITLE
github: Enable dependabot for stable branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,12 +14,57 @@ updates:
     - kind/enhancement
     - release-note/misc
     - priority/release-blocker
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "vendor:"
+    # Setting open-pull-requests-limit to 0 means that dependabot will not
+    # update regular dependencies on this target branch, but still provide
+    # security updates for our gomod dependencies
+    open-pull-requests-limit: 0
+    target-branch: "v0.11"
+    rebase-strategy: disabled
+    ignore:
+      - dependency-name: "github.com/cilium/cilium"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+      - priority/release-blocker
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
     commit-message:
       prefix: "ci:"
+    open-pull-requests-limit: 5
+    rebase-strategy: disabled
+    labels:
+    - kind/enhancement
+    - release-note/misc
+    - priority/release-blocker
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "ci:"
+    open-pull-requests-limit: 5
+    rebase-strategy: disabled
+    target-branch: "v0.11"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+      - priority/release-blocker
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "dockerfile:"
     open-pull-requests-limit: 5
     rebase-strategy: disabled
     labels:
@@ -34,7 +79,12 @@ updates:
       prefix: "dockerfile:"
     open-pull-requests-limit: 5
     rebase-strategy: disabled
+    target-branch: "v0.11"
+    ignore:
+      # Only bump the patch version in stable branches
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     labels:
-    - kind/enhancement
-    - release-note/misc
-    - priority/release-blocker
+      - kind/enhancement
+      - release-note/misc
+      - priority/release-blocker

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -131,6 +131,12 @@ After `v$MAJOR.$MINOR.$PATCH` is released, the next commit should restore the
 `v$MAJOR.$MINOR` branch to the `v$MAJOR.$MINOR.{$PATCH+1}-dev` to separate
 unreleased hubble versions in a branch from releases.
 
+## Update the `dependabot` configuration
+
+After a new stable `v$MAJOR.$MINOR` release branch has been created, update
+the `.github/dependabot.yml` field for `target-branch` to point to the newly
+created branch, instead of the old stable branch.
+
 ## Announce the release on Slack
 
 Post a release announcement message in the [Cilium Slack #hubble


### PR DESCRIPTION
Hubble CLI currently maintains support for the last stable branch. To ensure security-relevant depencencies are updated, this commit introduces dependabot for the current (v0.11) stable branch with the following configuration:

  - gomod dependencies are only updated if there is a security vulnerability in one of our dependencies.
  - docker dependencies (i.e. the alpine base image)  are only updated to the next patch version
  - github actions are always updated (this mirrors cilium/cilium's configuration)

The goal of this configuration is to ensure we pull in security relevant updates, while keeping the moving parts as low as possible in the stable branch.