### PR TITLE
Add hubble observe flows

### DIFF
--- a/cmd/observe/agent_events.go
+++ b/cmd/observe/agent_events.go
@@ -19,14 +19,13 @@ import (
 	"github.com/cilium/hubble/pkg/logger"
 	hubtime "github.com/cilium/hubble/pkg/time"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func newAgentEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.Command {
+func newAgentEventsCommand(vp *viper.Viper) *cobra.Command {
 	agentEventsCmd := &cobra.Command{
 		Use:   "agent-events",
 		Short: "Observe Cilium agent events",
@@ -62,8 +61,7 @@ func newAgentEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.C
 		},
 	}
 
-	template.RegisterFlagSets(agentEventsCmd, flagSets...)
-
+	template.RegisterFlagSets(agentEventsCmd, selectorFlags, formattingFlags, config.ServerFlags, otherFlags)
 	return agentEventsCmd
 }
 

--- a/cmd/observe/debug_events.go
+++ b/cmd/observe/debug_events.go
@@ -19,14 +19,13 @@ import (
 	"github.com/cilium/hubble/pkg/logger"
 	hubtime "github.com/cilium/hubble/pkg/time"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func newDebugEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.Command {
+func newDebugEventsCommand(vp *viper.Viper) *cobra.Command {
 	debugEventsCmd := &cobra.Command{
 		Use:   "debug-events",
 		Short: "Observe Cilium debug events",
@@ -62,7 +61,7 @@ func newDebugEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.C
 		},
 	}
 
-	template.RegisterFlagSets(debugEventsCmd, flagSets...)
+	template.RegisterFlagSets(debugEventsCmd, selectorFlags, formattingFlags, config.ServerFlags, otherFlags)
 
 	return debugEventsCmd
 }

--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -14,7 +14,6 @@ import (
 	"os/signal"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/observer"
@@ -136,9 +135,30 @@ func getFlowFiltersYAML(req *observer.GetFlowsRequest) (string, error) {
 	return string(out), nil
 }
 
-func newFlowsCmd(vp *viper.Viper, ofilter *flowFilter) *cobra.Command {
-	observeCmd := &cobra.Command{
-		Example: `* Piping flows to hubble observe
+type cmdUsage struct {
+	use     string
+	short   string
+	long    string
+	example string
+}
+
+func newObserveCmd(vp *viper.Viper) *cobra.Command {
+	ofilter := newFlowFilter()
+	usage := cmdUsage{
+		use:   "observe",
+		short: "Alias for 'hubble observe flows'",
+	}
+	return newFlowsCmdHelper(usage, vp, ofilter)
+}
+
+func newFlowsCmd(vp *viper.Viper) *cobra.Command {
+	ofilter := newFlowFilter()
+	return newFlowsCmdWithFilter(vp, ofilter)
+}
+
+func newFlowsCmdWithFilter(vp *viper.Viper, ofilter *flowFilter) *cobra.Command {
+	usage := cmdUsage{
+		example: `* Piping flows to hubble observe
 
   Save output from 'hubble observe -o jsonpb' command to a file, and pipe it to
   the observe command later for offline processing. For example:
@@ -152,12 +172,23 @@ func newFlowsCmd(vp *viper.Viper, ofilter *flowFilter) *cobra.Command {
   Note that the observe command ignores --follow, --last, and server flags when it
   reads flows from stdin. The observe command processes and output flows in the same
   order they are read from stdin without sorting them by timestamp.`,
-		Use:   "observe",
-		Short: "Observe flows of a Hubble server",
-		Long: `Observe provides visibility into flow information on the network and
+		use:   "flows",
+		short: "Observe flows of a Hubble server",
+		long: `Observe provides visibility into flow information on the network and
 application level. Rich filtering enable observing specific flows related to
 individual pods, services, TCP connections, DNS queries, HTTP requests and
 more.`,
+	}
+
+	return newFlowsCmdHelper(usage, vp, ofilter)
+}
+
+func newFlowsCmdHelper(usage cmdUsage, vp *viper.Viper, ofilter *flowFilter) *cobra.Command {
+	flowsCmd := &cobra.Command{
+		Example: usage.example,
+		Use:     usage.use,
+		Short:   usage.short,
+		Long:    usage.long,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			debug := vp.GetBool(config.KeyDebug)
 			if err := handleFlowArgs(ofilter, debug); err != nil {
@@ -210,62 +241,6 @@ more.`,
 			return nil
 		},
 	}
-
-	// selector flags
-	selectorFlags := pflag.NewFlagSet("selectors", pflag.ContinueOnError)
-	selectorFlags.BoolVar(&selectorOpts.all, "all", false, "Get all flows stored in Hubble's buffer")
-	selectorFlags.Uint64Var(&selectorOpts.last, "last", 0, fmt.Sprintf("Get last N flows stored in Hubble's buffer (default %d)", defaults.FlowPrintCount))
-	selectorFlags.Uint64Var(&selectorOpts.first, "first", 0, "Get first N flows stored in Hubble's buffer")
-	selectorFlags.BoolVarP(&selectorOpts.follow, "follow", "f", false, "Follow flows output")
-	selectorFlags.StringVar(&selectorOpts.since,
-		"since", "",
-		fmt.Sprintf(`Filter flows since a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
-  StampMilli:             %s
-  YearMonthDay:           %s
-  YearMonthDayHour:       %s
-  YearMonthDayHourMinute: %s
-  RFC3339:                %s
-  RFC3339Milli:           %s
-  RFC3339Micro:           %s
-  RFC3339Nano:            %s
-  RFC1123Z:               %s
- `,
-			time.StampMilli,
-			hubtime.YearMonthDay,
-			hubtime.YearMonthDayHour,
-			hubtime.YearMonthDayHourMinute,
-			time.RFC3339,
-			hubtime.RFC3339Milli,
-			hubtime.RFC3339Micro,
-			time.RFC3339Nano,
-			time.RFC1123Z,
-		),
-	)
-	selectorFlags.StringVar(&selectorOpts.until,
-		"until", "",
-		fmt.Sprintf(`Filter flows until a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
-  StampMilli:             %s
-  YearMonthDay:           %s
-  YearMonthDayHour:       %s
-  YearMonthDayHourMinute: %s
-  RFC3339:                %s
-  RFC3339Milli:           %s
-  RFC3339Micro:           %s
-  RFC3339Nano:            %s
-  RFC1123Z:               %s
- `,
-			time.StampMilli,
-			hubtime.YearMonthDay,
-			hubtime.YearMonthDayHour,
-			hubtime.YearMonthDayHourMinute,
-			time.RFC3339,
-			hubtime.RFC3339Milli,
-			hubtime.RFC3339Micro,
-			time.RFC3339Nano,
-			time.RFC1123Z,
-		),
-	)
-	observeCmd.PersistentFlags().AddFlagSet(selectorFlags)
 
 	// filter flags
 	filterFlags := pflag.NewFlagSet("filters", pflag.ContinueOnError)
@@ -423,90 +398,41 @@ more.`,
 	filterFlags.Var(filterVar(
 		"to-identity", ofilter,
 		"Show all flows terminating at an endpoint with the given security identity"))
-	observeCmd.Flags().AddFlagSet(filterFlags)
+	flowsCmd.Flags().AddFlagSet(filterFlags)
 
 	rawFilterFlags := pflag.NewFlagSet("raw-filters", pflag.ContinueOnError)
 	rawFilterFlags.StringArray(allowlistFlag, []string{}, "Specify allowlist as JSON encoded FlowFilters")
 	rawFilterFlags.StringArray(denylistFlag, []string{}, "Specify denylist as JSON encoded FlowFilters")
-	observeCmd.Flags().AddFlagSet(rawFilterFlags)
+	flowsCmd.Flags().AddFlagSet(rawFilterFlags)
 	// bind these flags to viper so that they can be specified as environment variables.
 	vp.BindPFlags(rawFilterFlags)
 
-	// formatting flags only to `hubble observe`, but not sub-commands. Will be added to
-	// generic formatting flags below.
-	observeFormattingFlags := pflag.NewFlagSet("", pflag.ContinueOnError)
-	observeFormattingFlags.BoolVar(
+	// formatting flags specific to flows
+	flowsFormattingFlags := pflag.NewFlagSet("Flow Format", pflag.ContinueOnError)
+	flowsFormattingFlags.BoolVar(
 		&formattingOpts.numeric,
 		"numeric",
 		false,
 		"Display all information in numeric form",
 	)
-	observeFormattingFlags.BoolVar(
+	flowsFormattingFlags.BoolVar(
 		&formattingOpts.enableIPTranslation,
 		"ip-translation",
 		true,
 		"Translate IP addresses to logical names such as pod name, FQDN, ...",
 	)
-	observeFormattingFlags.StringVar(
+	flowsFormattingFlags.StringVar(
 		&formattingOpts.color,
 		"color", "auto",
 		"Colorize the output when the output format is one of 'compact' or 'dict'. The value is one of 'auto' (default), 'always' or 'never'",
 	)
-	observeCmd.Flags().AddFlagSet(observeFormattingFlags)
-
-	// generic formatting flags, available to `hubble observe`, including sub-commands.
-	formattingFlags := pflag.NewFlagSet("Formatting", pflag.ContinueOnError)
-	formattingFlags.StringVarP(
-		&formattingOpts.output, "output", "o", "compact",
-		`Specify the output format, one of:
-  compact:  Compact output
-  dict:     Each flow is shown as KEY:VALUE pair
-  jsonpb:   JSON encoded GetFlowResponse according to proto3's JSON mapping
-  json:     Alias for jsonpb
-  table:    Tab-aligned columns
-`)
-	formattingFlags.BoolVarP(&formattingOpts.nodeName, "print-node-name", "", false, "Print node name in output")
-	formattingFlags.StringVar(
-		&formattingOpts.timeFormat, "time-format", "StampMilli",
-		fmt.Sprintf(`Specify the time format for printing. This option does not apply to the json and jsonpb output type. One of:
-  StampMilli:             %s
-  YearMonthDay:           %s
-  YearMonthDayHour:       %s
-  YearMonthDayHourMinute: %s
-  RFC3339:                %s
-  RFC3339Milli:           %s
-  RFC3339Micro:           %s
-  RFC3339Nano:            %s
-  RFC1123Z:               %s
- `,
-			time.StampMilli,
-			hubtime.YearMonthDay,
-			hubtime.YearMonthDayHour,
-			hubtime.YearMonthDayHourMinute,
-			time.RFC3339,
-			hubtime.RFC3339Milli,
-			hubtime.RFC3339Micro,
-			time.RFC3339Nano,
-			time.RFC1123Z,
-		),
-	)
-	observeCmd.PersistentFlags().AddFlagSet(formattingFlags)
-
-	// other flags
-	otherFlags := pflag.NewFlagSet("other", pflag.ContinueOnError)
-	otherFlags.BoolVarP(&otherOpts.ignoreStderr,
-		"silent-errors", "s", false,
-		"Silently ignores errors and warnings")
-	otherFlags.BoolVar(&otherOpts.printRawFilters,
-		"print-raw-filters", false,
-		"Print allowlist/denylist filters and exit without sending the request to Hubble server")
-	observeCmd.PersistentFlags().AddFlagSet(otherFlags)
+	flowsCmd.Flags().AddFlagSet(flowsFormattingFlags)
 
 	// advanced completion for flags
-	observeCmd.RegisterFlagCompletionFunc("ip-version", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("ip-version", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"none", "v4", "v6"}, cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		var completions []string
 		for _, ftype := range flowEventTypes {
 			completions = append(completions, ftype)
@@ -516,13 +442,13 @@ more.`,
 		}
 		return completions, cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("verdict", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("verdict", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return verdicts, cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("protocol", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("protocol", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return protocols, cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("http-status", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("http-status", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		httpStatus := []string{
 			"100", "101", "102", "103",
 			"200", "201", "202", "203", "204", "205", "206", "207", "208",
@@ -538,7 +464,7 @@ more.`,
 		}
 		return httpStatus, cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("http-method", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("http-method", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{
 			http.MethodConnect,
 			http.MethodDelete,
@@ -551,16 +477,16 @@ more.`,
 			http.MethodTrace,
 		}, cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("identity", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("identity", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return reservedIdentitiesNames(), cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("to-identity", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("to-identity", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return reservedIdentitiesNames(), cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("from-identity", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("from-identity", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return reservedIdentitiesNames(), cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{
 			"compact",
 			"dict",
@@ -569,26 +495,19 @@ more.`,
 			"table",
 		}, cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("color", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("color", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"auto", "always", "never"}, cobra.ShellCompDirectiveDefault
 	})
-	observeCmd.RegisterFlagCompletionFunc("time-format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	flowsCmd.RegisterFlagCompletionFunc("time-format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return hubtime.FormatNames, cobra.ShellCompDirectiveDefault
 	})
 
 	// default value for when the flag is on the command line without any options
-	observeCmd.Flags().Lookup("not").NoOptDefVal = "true"
+	flowsCmd.Flags().Lookup("not").NoOptDefVal = "true"
 
-	observeCmd.AddCommand(
-		newAgentEventsCommand(vp, selectorFlags, formattingFlags, config.ServerFlags, otherFlags),
-		newDebugEventsCommand(vp, selectorFlags, formattingFlags, config.ServerFlags, otherFlags),
-	)
-
-	formattingFlags.AddFlagSet(observeFormattingFlags)
-
-	template.RegisterFlagSets(observeCmd, selectorFlags, filterFlags, rawFilterFlags, formattingFlags, config.ServerFlags, otherFlags)
-
-	return observeCmd
+	flagSets := []*pflag.FlagSet{selectorFlags, formattingFlags, flowsFormattingFlags, config.ServerFlags, otherFlags}
+	template.RegisterFlagSets(flowsCmd, flagSets...)
+	return flowsCmd
 }
 
 func handleFlowArgs(ofilter *flowFilter, debug bool) (err error) {

--- a/cmd/observe/flows_filter_test.go
+++ b/cmd/observe/flows_filter_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestNoBlacklist(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{
 		"--from-ip", "1.2.3.4",
@@ -31,7 +31,7 @@ func TestNoBlacklist(t *testing.T) {
 // The default filter should be empty.
 func TestDefaultFilter(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{}))
 	assert.Nil(t, f.whitelist)
@@ -40,7 +40,7 @@ func TestDefaultFilter(t *testing.T) {
 
 func TestConflicts(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	err := cmd.Flags().Parse([]string{
 		"--from-ip", "1.2.3.4",
@@ -56,7 +56,7 @@ func TestConflicts(t *testing.T) {
 
 func TestTrailingNot(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	err := cmd.Flags().Parse([]string{
 		"--from-ip", "1.2.3.4",
@@ -71,7 +71,7 @@ func TestTrailingNot(t *testing.T) {
 
 func TestFilterDispatch(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{
 		"--from-ip", "1.2.3.4",
@@ -114,7 +114,7 @@ func TestFilterDispatch(t *testing.T) {
 
 func TestFilterLeftRight(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{
 		"--ip", "1.2.3.4",
@@ -172,7 +172,7 @@ func TestFilterLeftRight(t *testing.T) {
 
 func TestFilterType(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.Error(t, cmd.Flags().Parse([]string{
 		"-t", "some-invalid-type",
@@ -258,7 +258,7 @@ func TestFilterType(t *testing.T) {
 
 func TestLabels(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	err := cmd.Flags().Parse([]string{
 		"--label", "k1=v1,k2=v2",
@@ -280,7 +280,7 @@ func TestLabels(t *testing.T) {
 
 func TestIdentity(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{"--identity", "1", "--identity", "2"}))
 	if diff := cmp.Diff(
@@ -299,7 +299,7 @@ func TestIdentity(t *testing.T) {
 	for _, id := range identity.GetAllReservedIdentities() {
 		t.Run(id.String(), func(t *testing.T) {
 			f := newFlowFilter()
-			cmd := newFlowsCmd(viper.New(), f)
+			cmd := newFlowsCmdWithFilter(viper.New(), f)
 			require.NoError(t, cmd.Flags().Parse([]string{"--identity", id.String()}))
 			if diff := cmp.Diff(
 				[]*flowpb.FlowFilter{
@@ -318,7 +318,7 @@ func TestIdentity(t *testing.T) {
 
 func TestFromIdentity(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{"--from-identity", "1", "--from-identity", "2"}))
 	if diff := cmp.Diff(
@@ -336,7 +336,7 @@ func TestFromIdentity(t *testing.T) {
 	for _, id := range identity.GetAllReservedIdentities() {
 		t.Run(id.String(), func(t *testing.T) {
 			f := newFlowFilter()
-			cmd := newFlowsCmd(viper.New(), f)
+			cmd := newFlowsCmdWithFilter(viper.New(), f)
 			require.NoError(t, cmd.Flags().Parse([]string{"--from-identity", id.String()}))
 			if diff := cmp.Diff(
 				[]*flowpb.FlowFilter{
@@ -354,7 +354,7 @@ func TestFromIdentity(t *testing.T) {
 
 func TestToIdentity(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{"--to-identity", "1", "--to-identity", "2"}))
 	if diff := cmp.Diff(
@@ -372,7 +372,7 @@ func TestToIdentity(t *testing.T) {
 	for _, id := range identity.GetAllReservedIdentities() {
 		t.Run(id.String(), func(t *testing.T) {
 			f := newFlowFilter()
-			cmd := newFlowsCmd(viper.New(), f)
+			cmd := newFlowsCmdWithFilter(viper.New(), f)
 			require.NoError(t, cmd.Flags().Parse([]string{"--to-identity", id.String()}))
 			if diff := cmp.Diff(
 				[]*flowpb.FlowFilter{
@@ -390,7 +390,7 @@ func TestToIdentity(t *testing.T) {
 
 func TestInvalidIdentity(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.Error(t, cmd.Flags().Parse([]string{"--from-identity", "bad"}))
 	require.Error(t, cmd.Flags().Parse([]string{"--to-identity", "bad"}))
@@ -399,7 +399,7 @@ func TestInvalidIdentity(t *testing.T) {
 
 func TestTcpFlags(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	// valid TCP flags
 	validflags := []string{"SYN", "syn", "FIN", "RST", "PSH", "ACK", "URG", "ECE", "CWR", "NS", "syn,ack"}

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -4,8 +4,14 @@
 package observe
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/cilium/hubble/pkg/defaults"
 	hubprinter "github.com/cilium/hubble/pkg/printer"
+	hubtime "github.com/cilium/hubble/pkg/time"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -35,9 +41,122 @@ var (
 	}
 
 	printer *hubprinter.Printer
+
+	// selector flags
+	selectorFlags = pflag.NewFlagSet("selectors", pflag.ContinueOnError)
+	// generic formatting flags, available to `hubble observe`, including sub-commands.
+	formattingFlags = pflag.NewFlagSet("Formatting", pflag.ContinueOnError)
+	// other flags
+	otherFlags = pflag.NewFlagSet("other", pflag.ContinueOnError)
 )
+
+func init() {
+	selectorFlags.BoolVar(&selectorOpts.all, "all", false, "Get all flows stored in Hubble's buffer")
+	selectorFlags.Uint64Var(&selectorOpts.last, "last", 0, fmt.Sprintf("Get last N flows stored in Hubble's buffer (default %d)", defaults.FlowPrintCount))
+	selectorFlags.Uint64Var(&selectorOpts.first, "first", 0, "Get first N flows stored in Hubble's buffer")
+	selectorFlags.BoolVarP(&selectorOpts.follow, "follow", "f", false, "Follow flows output")
+	selectorFlags.StringVar(&selectorOpts.since,
+		"since", "",
+		fmt.Sprintf(`Filter flows since a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
+  StampMilli:             %s
+  YearMonthDay:           %s
+  YearMonthDayHour:       %s
+  YearMonthDayHourMinute: %s
+  RFC3339:                %s
+  RFC3339Milli:           %s
+  RFC3339Micro:           %s
+  RFC3339Nano:            %s
+  RFC1123Z:               %s
+ `,
+			time.StampMilli,
+			hubtime.YearMonthDay,
+			hubtime.YearMonthDayHour,
+			hubtime.YearMonthDayHourMinute,
+			time.RFC3339,
+			hubtime.RFC3339Milli,
+			hubtime.RFC3339Micro,
+			time.RFC3339Nano,
+			time.RFC1123Z,
+		),
+	)
+	selectorFlags.StringVar(&selectorOpts.until,
+		"until", "",
+		fmt.Sprintf(`Filter flows until a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
+  StampMilli:             %s
+  YearMonthDay:           %s
+  YearMonthDayHour:       %s
+  YearMonthDayHourMinute: %s
+  RFC3339:                %s
+  RFC3339Milli:           %s
+  RFC3339Micro:           %s
+  RFC3339Nano:            %s
+  RFC1123Z:               %s
+ `,
+			time.StampMilli,
+			hubtime.YearMonthDay,
+			hubtime.YearMonthDayHour,
+			hubtime.YearMonthDayHourMinute,
+			time.RFC3339,
+			hubtime.RFC3339Milli,
+			hubtime.RFC3339Micro,
+			time.RFC3339Nano,
+			time.RFC1123Z,
+		),
+	)
+
+	formattingFlags.StringVarP(
+		&formattingOpts.output, "output", "o", "compact",
+		`Specify the output format, one of:
+  compact:  Compact output
+  dict:     Each flow is shown as KEY:VALUE pair
+  jsonpb:   JSON encoded GetFlowResponse according to proto3's JSON mapping
+  json:     Alias for jsonpb
+  table:    Tab-aligned columns
+`)
+	formattingFlags.BoolVarP(&formattingOpts.nodeName, "print-node-name", "", false, "Print node name in output")
+	formattingFlags.StringVar(
+		&formattingOpts.timeFormat, "time-format", "StampMilli",
+		fmt.Sprintf(`Specify the time format for printing. This option does not apply to the json and jsonpb output type. One of:
+  StampMilli:             %s
+  YearMonthDay:           %s
+  YearMonthDayHour:       %s
+  YearMonthDayHourMinute: %s
+  RFC3339:                %s
+  RFC3339Milli:           %s
+  RFC3339Micro:           %s
+  RFC3339Nano:            %s
+  RFC1123Z:               %s
+ `,
+			time.StampMilli,
+			hubtime.YearMonthDay,
+			hubtime.YearMonthDayHour,
+			hubtime.YearMonthDayHourMinute,
+			time.RFC3339,
+			hubtime.RFC3339Milli,
+			hubtime.RFC3339Micro,
+			time.RFC3339Nano,
+			time.RFC1123Z,
+		),
+	)
+
+	otherFlags.BoolVarP(&otherOpts.ignoreStderr,
+		"silent-errors", "s", false,
+		"Silently ignores errors and warnings")
+	otherFlags.BoolVar(&otherOpts.printRawFilters,
+		"print-raw-filters", false,
+		"Print allowlist/denylist filters and exit without sending the request to Hubble server")
+}
 
 // New observer command.
 func New(vp *viper.Viper) *cobra.Command {
-	return newFlowsCmd(vp, newFlowFilter())
+	observeCmd := newObserveCmd(vp)
+	flowsCmd := newFlowsCmd(vp)
+
+	observeCmd.AddCommand(
+		newAgentEventsCommand(vp),
+		newDebugEventsCommand(vp),
+		flowsCmd,
+	)
+
+	return observeCmd
 }


### PR DESCRIPTION
Hubble observe is now an alias for `hubble observe flows`. The only major difference is the help text for `hubble observe` is now briefer and indicates it is an alias for `hubble observe flows`. Additionally, while refactoring, I removed the flow formatting flags from the general formatting flagset and just moved it to it's own flagset.

Fixes #543