### PR TITLE
Add unit tests for testing hubble args/flags handling

### DIFF
--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"testing"
+
+	"github.com/cilium/cilium/api/v1/observer"
+	"github.com/cilium/hubble/cmd/observe"
+	"github.com/cilium/hubble/pkg/defaults"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed observe_help.txt
+var expectedObserveHelp string
+
+func init() {
+	// Override the client so that it always returns an IOReaderObserver with no flows.
+	observe.GetHubbleClientFunc = func(_ context.Context, _ *viper.Viper) (client observer.ObserverClient, cleanup func() error, err error) {
+		cleanup = func() error { return nil }
+		return observe.NewIOReaderObserver(bytes.NewBuffer([]byte(``))), cleanup, nil
+	}
+
+	expectedObserveHelp = fmt.Sprintf(expectedObserveHelp, defaults.ConfigFile)
+}
+
+func TestTestHubbleObserve(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectErr      error
+		expectedOutput string
+	}{
+		{
+			name: "observe no flags",
+			args: []string{"observe"},
+		},
+		{
+			name: "observe formatting flags",
+			args: []string{"observe", "-o", "json"},
+		},
+		{
+			name: "observe server flags",
+			args: []string{"observe", "--server", "foo.example.org", "--tls", "--tls-allow-insecure"},
+		},
+		{
+			name: "observe filter flags",
+			args: []string{"observe", "--from-pod", "foo/test-pod-1234", "--type", "l7"},
+		},
+		{
+			name: "help",
+			args: []string{"--help"},
+			expectedOutput: fmt.Sprintf(`Hubble is a utility to observe and inspect recent Cilium routed traffic in a cluster.
+
+Usage:
+  hubble [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  config      Modify or view hubble config
+  help        Help about any command
+  list        List Hubble objects
+  observe     Observe flows of a Hubble server
+  status      Display status of Hubble server
+  version     Display detailed version information
+
+Global Flags:
+      --config string   Optional config file (default "%s")
+  -D, --debug           Enable debug messages
+
+Get help:
+  -h, --help	Help for any command or subcommand
+
+Use "hubble [command] --help" for more information about a command.
+`, defaults.ConfigFile),
+		},
+		{
+			name:           "observe help",
+			args:           []string{"observe", "--help"},
+			expectedOutput: expectedObserveHelp,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b bytes.Buffer
+			cli := New()
+			cli.SetOut(&b)
+			cli.SetArgs(tt.args)
+			err := cli.Execute()
+			require.Equal(t, tt.expectErr, err)
+			output := b.String()
+			if tt.expectedOutput != "" {
+				assert.Equal(t, tt.expectedOutput, output, "expected output does not match")
+			}
+		})
+	}
+}

--- a/cmd/observe/agent_events.go
+++ b/cmd/observe/agent_events.go
@@ -32,7 +32,7 @@ func newAgentEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.C
 		Short: "Observe Cilium agent events",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			debug := vp.GetBool(config.KeyDebug)
-			if err := handleEventsArgs(debug); err != nil {
+			if err := handleEventsArgs(cmd.OutOrStdout(), debug); err != nil {
 				return err
 			}
 			req, err := getAgentEventsRequest()

--- a/cmd/observe/debug_events.go
+++ b/cmd/observe/debug_events.go
@@ -32,7 +32,7 @@ func newDebugEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.C
 		Short: "Observe Cilium debug events",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			debug := vp.GetBool(config.KeyDebug)
-			if err := handleEventsArgs(debug); err != nil {
+			if err := handleEventsArgs(cmd.OutOrStdout(), debug); err != nil {
 				return err
 			}
 			req, err := getDebugEventsRequest()

--- a/cmd/observe/events.go
+++ b/cmd/observe/events.go
@@ -5,15 +5,17 @@ package observe
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/cilium/hubble/cmd/common/config"
 	hubprinter "github.com/cilium/hubble/pkg/printer"
 	hubtime "github.com/cilium/hubble/pkg/time"
 )
 
-func handleEventsArgs(debug bool) error {
+func handleEventsArgs(writer io.Writer, debug bool) error {
 	// initialize the printer with any options that were passed in
 	var opts = []hubprinter.Option{
+		hubprinter.Writer(writer),
 		hubprinter.WithTimeFormat(hubtime.FormatNameToLayout(formattingOpts.timeFormat)),
 	}
 

--- a/cmd/observe/flows_filter_test.go
+++ b/cmd/observe/flows_filter_test.go
@@ -4,6 +4,7 @@
 package observe
 
 import (
+	"os"
 	"strconv"
 	"testing"
 
@@ -64,7 +65,7 @@ func TestTrailingNot(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = handleFlowArgs(f, false)
+	err = handleFlowArgs(os.Stdout, f, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "trailing --not")
 }
@@ -82,7 +83,7 @@ func TestFilterDispatch(t *testing.T) {
 		"-t", "l7", // int:129 in cilium-land
 	}))
 
-	require.NoError(t, handleFlowArgs(f, false))
+	require.NoError(t, handleFlowArgs(os.Stdout, f, false))
 	if diff := cmp.Diff(
 		[]*flowpb.FlowFilter{
 			{
@@ -127,7 +128,7 @@ func TestFilterLeftRight(t *testing.T) {
 		"--node-name", "k8s*",
 	}))
 
-	require.NoError(t, handleFlowArgs(f, false))
+	require.NoError(t, handleFlowArgs(os.Stdout, f, false))
 
 	if diff := cmp.Diff(
 		[]*flowpb.FlowFilter{
@@ -198,7 +199,7 @@ func TestFilterType(t *testing.T) {
 		"-t", "agent:service-deleted",
 	}))
 
-	require.NoError(t, handleFlowArgs(f, false))
+	require.NoError(t, handleFlowArgs(os.Stdout, f, false))
 	if diff := cmp.Diff(
 		[]*flowpb.FlowFilter{
 			{

--- a/cmd/observe/io_reader_observer.go
+++ b/cmd/observe/io_reader_observer.go
@@ -18,35 +18,42 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-// ioReaderObserver implements ObserverClient interface. It reads flows
+// IOReaderObserver implements ObserverClient interface. It reads flows
 // in jsonpb format from an io.Reader.
-type ioReaderObserver struct {
+type IOReaderObserver struct {
 	scanner *bufio.Scanner
 }
 
-func newIOReaderObserver(reader io.Reader) *ioReaderObserver {
-	return &ioReaderObserver{
+// NewIOReaderObserver reads flows in jsonpb format from an io.Reader and
+// returns a IOReaderObserver that implements the ObserverClient interface.
+func NewIOReaderObserver(reader io.Reader) *IOReaderObserver {
+	return &IOReaderObserver{
 		scanner: bufio.NewScanner(reader),
 	}
 }
 
-func (o *ioReaderObserver) GetFlows(ctx context.Context, in *observer.GetFlowsRequest, _ ...grpc.CallOption) (observer.Observer_GetFlowsClient, error) {
+// GetFlows returns flows
+func (o *IOReaderObserver) GetFlows(ctx context.Context, in *observer.GetFlowsRequest, _ ...grpc.CallOption) (observer.Observer_GetFlowsClient, error) {
 	return newIOReaderClient(ctx, o.scanner, in)
 }
 
-func (o *ioReaderObserver) GetAgentEvents(_ context.Context, _ *observer.GetAgentEventsRequest, _ ...grpc.CallOption) (observer.Observer_GetAgentEventsClient, error) {
+// GetAgentEvents is not implemented, and will throw an error if used.
+func (o *IOReaderObserver) GetAgentEvents(_ context.Context, _ *observer.GetAgentEventsRequest, _ ...grpc.CallOption) (observer.Observer_GetAgentEventsClient, error) {
 	return nil, status.Errorf(codes.Unimplemented, "GetAgentEvents not implemented")
 }
 
-func (o *ioReaderObserver) GetDebugEvents(_ context.Context, _ *observer.GetDebugEventsRequest, _ ...grpc.CallOption) (observer.Observer_GetDebugEventsClient, error) {
+// GetDebugEvents is not implemented, and will throw an error if used.
+func (o *IOReaderObserver) GetDebugEvents(_ context.Context, _ *observer.GetDebugEventsRequest, _ ...grpc.CallOption) (observer.Observer_GetDebugEventsClient, error) {
 	return nil, status.Errorf(codes.Unimplemented, "GetDebugEvents not implemented")
 }
 
-func (o *ioReaderObserver) GetNodes(_ context.Context, _ *observer.GetNodesRequest, _ ...grpc.CallOption) (*observer.GetNodesResponse, error) {
+// GetNodes is not implemented, and will throw an error if used.
+func (o *IOReaderObserver) GetNodes(_ context.Context, _ *observer.GetNodesRequest, _ ...grpc.CallOption) (*observer.GetNodesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "GetNodes not implemented")
 }
 
-func (o *ioReaderObserver) ServerStatus(_ context.Context, _ *observer.ServerStatusRequest, _ ...grpc.CallOption) (*observer.ServerStatusResponse, error) {
+// ServerStatus is not implemented, and will throw an error if used.
+func (o *IOReaderObserver) ServerStatus(_ context.Context, _ *observer.ServerStatusRequest, _ ...grpc.CallOption) (*observer.ServerStatusResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "ServerStatus not implemented")
 }
 

--- a/cmd/observe/io_reader_observer_test.go
+++ b/cmd/observe/io_reader_observer_test.go
@@ -23,7 +23,7 @@ func Test_getFlowsBasic(t *testing.T) {
 		assert.NoError(t, err)
 		flowStrings = append(flowStrings, string(b))
 	}
-	server := newIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
+	server := NewIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
 	req := observer.GetFlowsRequest{}
 	client, err := server.GetFlows(context.Background(), &req)
 	assert.NoError(t, err)
@@ -56,7 +56,7 @@ func Test_getFlowsTimeRange(t *testing.T) {
 		assert.NoError(t, err)
 		flowStrings = append(flowStrings, string(b))
 	}
-	server := newIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
+	server := NewIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
 	req := observer.GetFlowsRequest{
 		Since: &timestamppb.Timestamp{Seconds: 50},
 		Until: &timestamppb.Timestamp{Seconds: 150},
@@ -91,7 +91,7 @@ func Test_getFlowsFilter(t *testing.T) {
 		assert.NoError(t, err)
 		flowStrings = append(flowStrings, string(b))
 	}
-	server := newIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
+	server := NewIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
 	req := observer.GetFlowsRequest{
 		Whitelist: []*flow.FlowFilter{
 			{

--- a/cmd/observe_help.txt
+++ b/cmd/observe_help.txt
@@ -1,0 +1,172 @@
+Observe provides visibility into flow information on the network and
+application level. Rich filtering enable observing specific flows related to
+individual pods, services, TCP connections, DNS queries, HTTP requests and
+more.
+
+Usage:
+  hubble observe [flags]
+  hubble observe [command]
+
+Examples:
+* Piping flows to hubble observe
+
+  Save output from 'hubble observe -o jsonpb' command to a file, and pipe it to
+  the observe command later for offline processing. For example:
+
+    hubble observe -o jsonpb --last 1000 > flows.json
+
+  Then,
+
+    cat flows.json | hubble observe
+
+  Note that the observe command ignores --follow, --last, and server flags when it
+  reads flows from stdin. The observe command processes and output flows in the same
+  order they are read from stdin without sorting them by timestamp.
+
+Available Commands:
+  agent-events Observe Cilium agent events
+  debug-events Observe Cilium debug events
+
+Selectors Flags:
+      --all            Get all flows stored in Hubble's buffer
+      --first uint     Get first N flows stored in Hubble's buffer
+  -f, --follow         Follow flows output
+      --last uint      Get last N flows stored in Hubble's buffer (default 20)
+      --since string   Filter flows since a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
+                         StampMilli:             Jan _2 15:04:05.000
+                         YearMonthDay:           2006-01-02
+                         YearMonthDayHour:       2006-01-02T15Z07:00
+                         YearMonthDayHourMinute: 2006-01-02T15:04Z07:00
+                         RFC3339:                2006-01-02T15:04:05Z07:00
+                         RFC3339Milli:           2006-01-02T15:04:05.999Z07:00
+                         RFC3339Micro:           2006-01-02T15:04:05.999999Z07:00
+                         RFC3339Nano:            2006-01-02T15:04:05.999999999Z07:00
+                         RFC1123Z:               Mon, 02 Jan 2006 15:04:05 -0700
+                        
+      --until string   Filter flows until a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
+                         StampMilli:             Jan _2 15:04:05.000
+                         YearMonthDay:           2006-01-02
+                         YearMonthDayHour:       2006-01-02T15Z07:00
+                         YearMonthDayHourMinute: 2006-01-02T15:04Z07:00
+                         RFC3339:                2006-01-02T15:04:05Z07:00
+                         RFC3339Milli:           2006-01-02T15:04:05.999Z07:00
+                         RFC3339Micro:           2006-01-02T15:04:05.999999Z07:00
+                         RFC3339Nano:            2006-01-02T15:04:05.999999999Z07:00
+                         RFC1123Z:               Mon, 02 Jan 2006 15:04:05 -0700
+                        
+
+Filters Flags:
+      --fqdn filter             Show all flows related to the given fully qualified domain name (e.g. "*.cilium.io").
+      --from-fqdn filter        Show all flows originating at the given fully qualified domain name (e.g. "*.cilium.io").
+      --from-identity filter    Show all flows originating at an endpoint with the given security identity
+      --from-ip filter          Show all flows originating at the given IP address. Each of the source IPs can be specified as an exact match (e.g. '1.1.1.1') or as a CIDR range (e.g.'1.1.1.0/24').
+      --from-label filter       Show only flows originating in an endpoint with the given labels (e.g. "key1=value1", "reserved:world")
+      --from-namespace filter   Show all flows originating in the given Kubernetes namespace.
+      --from-pod filter         Show all flows originating in the given pod name prefix([namespace/]<pod-name>). If namespace is not provided, 'default' is used
+      --from-port filter        Show only flows with the given source port (e.g. 8080)
+      --from-service filter     Shows flows where the source IP address matches the ClusterIP address of the given service name prefix([namespace/]<svc-name>). If namespace is not provided, 'default' is used
+      --from-workload filter    Show all flows originating at an endpoint with the given workload
+      --http-method filter      Show only flows which match this HTTP method (e.g. "get", "post")
+      --http-path filter        Show only flows which match this HTTP path regular expressions (e.g. "/page/\\d+")
+      --http-status filter      Show only flows which match this HTTP status code prefix (e.g. "404", "5+")
+      --identity filter         Show all flows related to an endpoint with the given security identity
+      --ip filter               Show all flows related to the given IP address. Each of the IPs can be specified as an exact match (e.g. '1.1.1.1') or as a CIDR range (e.g.'1.1.1.0/24').
+      --ip-version filter       Show only IPv4, IPv6 flows or non IP flows (e.g. ARP packets) (ie: "none", "v4", "v6")
+  -4, --ipv4 filter[=v4]        Show only IPv4 flows
+  -6, --ipv6 filter[=v6]        Show only IPv6 flows
+  -l, --label filter            Show only flows related to an endpoint with the given labels (e.g. "key1=value1", "reserved:world")
+  -n, --namespace filter        Show all flows related to the given Kubernetes namespace.
+      --node-name filter        Show all flows which match the given node names (e.g. "k8s*", "test-cluster/*.company.com")
+      --not filter[=true]       Reverses the next filter to be blacklist i.e. --not --from-ip 2.2.2.2
+      --pod filter              Show all flows related to the given pod name prefix ([namespace/]<pod-name>). If namespace is not provided, 'default' is used.
+      --port filter             Show only flows with given port in either source or destination (e.g. 8080)
+      --protocol filter         Show only flows which match the given L4/L7 flow protocol (e.g. "udp", "http")
+      --service filter          Shows flows where either the source or destination IP address matches the ClusterIP address of the given service name prefix ([namespace/]<svc-name>). If namespace is not provided, 'default' is used. 
+      --tcp-flags filter        Show only flows which match the given TCP flags (e.g. "syn", "ack", "fin")
+      --to-fqdn filter          Show all flows terminating at the given fully qualified domain name (e.g. "*.cilium.io").
+      --to-identity filter      Show all flows terminating at an endpoint with the given security identity
+      --to-ip filter            Show all flows terminating at the given IP address. Each of the destination IPs can be specified as an exact match (e.g. '1.1.1.1') or as a CIDR range (e.g.'1.1.1.0/24').
+      --to-label filter         Show only flows terminating in an endpoint with given labels (e.g. "key1=value1", "reserved:world")
+      --to-namespace filter     Show all flows terminating in the given Kubernetes namespace.
+      --to-pod filter           Show all flows terminating in the given pod name prefix([namespace/]<pod-name>). If namespace is not provided, 'default' is used
+      --to-port filter          Show only flows with the given destination port (e.g. 8080)
+      --to-service filter       Shows flows where the destination IP address matches the ClusterIP address of the given service name prefix ([namespace/]<svc-name>). If namespace is not provided, 'default' is used
+      --to-workload filter      Show all flows terminating at an endpoint with the given workload
+      --trace-id filter         Show only flows which match this trace ID
+  -t, --type filter             Filter by event types TYPE[:SUBTYPE]. Available types and subtypes:
+                                TYPE             SUBTYPE
+                                capture          n/a
+                                drop             n/a
+                                l7               n/a
+                                policy-verdict   n/a
+                                trace            from-endpoint
+                                                 from-host
+                                                 from-network
+                                                 from-overlay
+                                                 from-proxy
+                                                 from-stack
+                                                 to-endpoint
+                                                 to-host
+                                                 to-network
+                                                 to-overlay
+                                                 to-proxy
+                                                 to-stack
+                                trace-sock       n/a
+      --verdict filter          Show only flows with this verdict [FORWARDED, DROPPED, AUDIT, REDIRECTED, ERROR, TRACED, TRANSLATED]
+      --workload filter         Show all flows related to an endpoint with the given workload
+
+Raw-Filters Flags:
+      --allowlist stringArray   Specify allowlist as JSON encoded FlowFilters
+      --denylist stringArray    Specify denylist as JSON encoded FlowFilters
+
+Formatting Flags:
+      --color string         Colorize the output when the output format is one of 'compact' or 'dict'. The value is one of 'auto' (default), 'always' or 'never' (default "auto")
+      --ip-translation       Translate IP addresses to logical names such as pod name, FQDN, ... (default true)
+      --numeric              Display all information in numeric form
+  -o, --output string        Specify the output format, one of:
+                               compact:  Compact output
+                               dict:     Each flow is shown as KEY:VALUE pair
+                               jsonpb:   JSON encoded GetFlowResponse according to proto3's JSON mapping
+                               json:     Alias for jsonpb
+                               table:    Tab-aligned columns
+                              (default "compact")
+      --print-node-name      Print node name in output
+      --time-format string   Specify the time format for printing. This option does not apply to the json and jsonpb output type. One of:
+                               StampMilli:             Jan _2 15:04:05.000
+                               YearMonthDay:           2006-01-02
+                               YearMonthDayHour:       2006-01-02T15Z07:00
+                               YearMonthDayHourMinute: 2006-01-02T15:04Z07:00
+                               RFC3339:                2006-01-02T15:04:05Z07:00
+                               RFC3339Milli:           2006-01-02T15:04:05.999Z07:00
+                               RFC3339Micro:           2006-01-02T15:04:05.999999Z07:00
+                               RFC3339Nano:            2006-01-02T15:04:05.999999999Z07:00
+                               RFC1123Z:               Mon, 02 Jan 2006 15:04:05 -0700
+                               (default "StampMilli")
+
+Server Flags:
+      --server string                 Address of a Hubble server (default "localhost:4245")
+      --timeout duration              Hubble server dialing timeout (default 5s)
+      --tls                           Specify that TLS must be used when establishing a connection to a Hubble server.
+                                      By default, TLS is only enabled if the server address starts with 'tls://'.
+      --tls-allow-insecure            Allows the client to skip verifying the server's certificate chain and host name.
+                                      This option is NOT recommended as, in this mode, TLS is susceptible to machine-in-the-middle attacks.
+                                      See also the 'tls-server-name' option which allows setting the server name.
+      --tls-ca-cert-files strings     Paths to custom Certificate Authority (CA) certificate files.The files must contain PEM encoded data.
+      --tls-client-cert-file string   Path to the public key file for the client certificate to connect to a Hubble server (implies TLS).
+                                      The file must contain PEM encoded data.
+      --tls-client-key-file string    Path to the private key file for the client certificate to connect a Hubble server (implies TLS).
+                                      The file must contain PEM encoded data.
+      --tls-server-name string        Specify a server name to verify the hostname on the returned certificate (eg: 'instance.hubble-relay.cilium.io').
+
+Other Flags:
+      --print-raw-filters   Print allowlist/denylist filters and exit without sending the request to Hubble server
+  -s, --silent-errors       Silently ignores errors and warnings
+
+Global Flags:
+      --config string   Optional config file (default "%s")
+  -D, --debug           Enable debug messages
+
+Get help:
+  -h, --help	Help for any command or subcommand
+
+Use "hubble observe [command] --help" for more information about a command.

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -42,7 +42,7 @@ connectivity health check.`,
 				return err
 			}
 			defer hubbleConn.Close()
-			return runStatus(hubbleConn, cmd.OutOrStdout())
+			return runStatus(cmd.OutOrStdout(), hubbleConn)
 		},
 	}
 
@@ -74,7 +74,7 @@ connectivity health check.`,
 	return statusCmd
 }
 
-func runStatus(conn *grpc.ClientConn, out io.Writer) error {
+func runStatus(out io.Writer, conn *grpc.ClientConn) error {
 	// get the standard GRPC health check to see if the server is up
 	healthy, status, err := getHC(conn)
 	if err != nil {
@@ -93,7 +93,9 @@ func runStatus(conn *grpc.ClientConn, out io.Writer) error {
 		return fmt.Errorf("failed to get hubble server status: %v", err)
 	}
 
-	var opts = []printer.Option{}
+	var opts = []printer.Option{
+		printer.Writer(out),
+	}
 	switch formattingOpts.output {
 	case "compact":
 		opts = append(opts, printer.Compact())


### PR DESCRIPTION
Add unit tests that just test the flag/command handling.

This should help prevent what happened in https://github.com/cilium/hubble/pull/851#issuecomment-1402002694.