### PR TITLE
Hubble observe flows

### DIFF
--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -67,7 +67,7 @@ Available Commands:
   config      Modify or view hubble config
   help        Help about any command
   list        List Hubble objects
-  observe     Observe flows of a Hubble server
+  observe     Observe flows and events of a Hubble server
   status      Display status of Hubble server
   version     Display detailed version information
 

--- a/cmd/observe/agent_events.go
+++ b/cmd/observe/agent_events.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func newAgentEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.Command {
+func newAgentEventsCommand(vp *viper.Viper) *cobra.Command {
 	agentEventsCmd := &cobra.Command{
 		Use:   "agent-events",
 		Short: "Observe Cilium agent events",
@@ -62,8 +62,11 @@ func newAgentEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.C
 		},
 	}
 
+	flagSets := []*pflag.FlagSet{selectorFlags, formattingFlags, config.ServerFlags, otherFlags}
+	for _, fs := range flagSets {
+		agentEventsCmd.Flags().AddFlagSet(fs)
+	}
 	template.RegisterFlagSets(agentEventsCmd, flagSets...)
-
 	return agentEventsCmd
 }
 

--- a/cmd/observe/debug_events.go
+++ b/cmd/observe/debug_events.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func newDebugEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.Command {
+func newDebugEventsCommand(vp *viper.Viper) *cobra.Command {
 	debugEventsCmd := &cobra.Command{
 		Use:   "debug-events",
 		Short: "Observe Cilium debug events",
@@ -62,8 +62,11 @@ func newDebugEventsCommand(vp *viper.Viper, flagSets ...*pflag.FlagSet) *cobra.C
 		},
 	}
 
+	flagSets := []*pflag.FlagSet{selectorFlags, formattingFlags, config.ServerFlags, otherFlags}
+	for _, fs := range flagSets {
+		debugEventsCmd.Flags().AddFlagSet(fs)
+	}
 	template.RegisterFlagSets(debugEventsCmd, flagSets...)
-
 	return debugEventsCmd
 }
 

--- a/cmd/observe/flows_filter_test.go
+++ b/cmd/observe/flows_filter_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestNoBlacklist(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{
 		"--from-ip", "1.2.3.4",
@@ -32,7 +32,7 @@ func TestNoBlacklist(t *testing.T) {
 // The default filter should be empty.
 func TestDefaultFilter(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{}))
 	assert.Nil(t, f.whitelist)
@@ -41,7 +41,7 @@ func TestDefaultFilter(t *testing.T) {
 
 func TestConflicts(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	err := cmd.Flags().Parse([]string{
 		"--from-ip", "1.2.3.4",
@@ -57,7 +57,7 @@ func TestConflicts(t *testing.T) {
 
 func TestTrailingNot(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	err := cmd.Flags().Parse([]string{
 		"--from-ip", "1.2.3.4",
@@ -72,7 +72,7 @@ func TestTrailingNot(t *testing.T) {
 
 func TestFilterDispatch(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{
 		"--from-ip", "1.2.3.4",
@@ -115,7 +115,7 @@ func TestFilterDispatch(t *testing.T) {
 
 func TestFilterLeftRight(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{
 		"--ip", "1.2.3.4",
@@ -173,7 +173,7 @@ func TestFilterLeftRight(t *testing.T) {
 
 func TestFilterType(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.Error(t, cmd.Flags().Parse([]string{
 		"-t", "some-invalid-type",
@@ -259,7 +259,7 @@ func TestFilterType(t *testing.T) {
 
 func TestLabels(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	err := cmd.Flags().Parse([]string{
 		"--label", "k1=v1,k2=v2",
@@ -281,7 +281,7 @@ func TestLabels(t *testing.T) {
 
 func TestIdentity(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{"--identity", "1", "--identity", "2"}))
 	if diff := cmp.Diff(
@@ -300,7 +300,7 @@ func TestIdentity(t *testing.T) {
 	for _, id := range identity.GetAllReservedIdentities() {
 		t.Run(id.String(), func(t *testing.T) {
 			f := newFlowFilter()
-			cmd := newFlowsCmd(viper.New(), f)
+			cmd := newFlowsCmdWithFilter(viper.New(), f)
 			require.NoError(t, cmd.Flags().Parse([]string{"--identity", id.String()}))
 			if diff := cmp.Diff(
 				[]*flowpb.FlowFilter{
@@ -319,7 +319,7 @@ func TestIdentity(t *testing.T) {
 
 func TestFromIdentity(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{"--from-identity", "1", "--from-identity", "2"}))
 	if diff := cmp.Diff(
@@ -337,7 +337,7 @@ func TestFromIdentity(t *testing.T) {
 	for _, id := range identity.GetAllReservedIdentities() {
 		t.Run(id.String(), func(t *testing.T) {
 			f := newFlowFilter()
-			cmd := newFlowsCmd(viper.New(), f)
+			cmd := newFlowsCmdWithFilter(viper.New(), f)
 			require.NoError(t, cmd.Flags().Parse([]string{"--from-identity", id.String()}))
 			if diff := cmp.Diff(
 				[]*flowpb.FlowFilter{
@@ -355,7 +355,7 @@ func TestFromIdentity(t *testing.T) {
 
 func TestToIdentity(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.NoError(t, cmd.Flags().Parse([]string{"--to-identity", "1", "--to-identity", "2"}))
 	if diff := cmp.Diff(
@@ -373,7 +373,7 @@ func TestToIdentity(t *testing.T) {
 	for _, id := range identity.GetAllReservedIdentities() {
 		t.Run(id.String(), func(t *testing.T) {
 			f := newFlowFilter()
-			cmd := newFlowsCmd(viper.New(), f)
+			cmd := newFlowsCmdWithFilter(viper.New(), f)
 			require.NoError(t, cmd.Flags().Parse([]string{"--to-identity", id.String()}))
 			if diff := cmp.Diff(
 				[]*flowpb.FlowFilter{
@@ -391,7 +391,7 @@ func TestToIdentity(t *testing.T) {
 
 func TestInvalidIdentity(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	require.Error(t, cmd.Flags().Parse([]string{"--from-identity", "bad"}))
 	require.Error(t, cmd.Flags().Parse([]string{"--to-identity", "bad"}))
@@ -400,7 +400,7 @@ func TestInvalidIdentity(t *testing.T) {
 
 func TestTcpFlags(t *testing.T) {
 	f := newFlowFilter()
-	cmd := newFlowsCmd(viper.New(), f)
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
 
 	// valid TCP flags
 	validflags := []string{"SYN", "syn", "FIN", "RST", "PSH", "ACK", "URG", "ECE", "CWR", "NS", "syn,ack"}

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -4,8 +4,14 @@
 package observe
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/cilium/hubble/pkg/defaults"
 	hubprinter "github.com/cilium/hubble/pkg/printer"
+	hubtime "github.com/cilium/hubble/pkg/time"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -35,9 +41,122 @@ var (
 	}
 
 	printer *hubprinter.Printer
+
+	// selector flags
+	selectorFlags = pflag.NewFlagSet("selectors", pflag.ContinueOnError)
+	// generic formatting flags, available to `hubble observe`, including sub-commands.
+	formattingFlags = pflag.NewFlagSet("Formatting", pflag.ContinueOnError)
+	// other flags
+	otherFlags = pflag.NewFlagSet("other", pflag.ContinueOnError)
 )
+
+func init() {
+	selectorFlags.BoolVar(&selectorOpts.all, "all", false, "Get all flows stored in Hubble's buffer")
+	selectorFlags.Uint64Var(&selectorOpts.last, "last", 0, fmt.Sprintf("Get last N flows stored in Hubble's buffer (default %d)", defaults.FlowPrintCount))
+	selectorFlags.Uint64Var(&selectorOpts.first, "first", 0, "Get first N flows stored in Hubble's buffer")
+	selectorFlags.BoolVarP(&selectorOpts.follow, "follow", "f", false, "Follow flows output")
+	selectorFlags.StringVar(&selectorOpts.since,
+		"since", "",
+		fmt.Sprintf(`Filter flows since a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
+  StampMilli:             %s
+  YearMonthDay:           %s
+  YearMonthDayHour:       %s
+  YearMonthDayHourMinute: %s
+  RFC3339:                %s
+  RFC3339Milli:           %s
+  RFC3339Micro:           %s
+  RFC3339Nano:            %s
+  RFC1123Z:               %s
+ `,
+			time.StampMilli,
+			hubtime.YearMonthDay,
+			hubtime.YearMonthDayHour,
+			hubtime.YearMonthDayHourMinute,
+			time.RFC3339,
+			hubtime.RFC3339Milli,
+			hubtime.RFC3339Micro,
+			time.RFC3339Nano,
+			time.RFC1123Z,
+		),
+	)
+	selectorFlags.StringVar(&selectorOpts.until,
+		"until", "",
+		fmt.Sprintf(`Filter flows until a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
+  StampMilli:             %s
+  YearMonthDay:           %s
+  YearMonthDayHour:       %s
+  YearMonthDayHourMinute: %s
+  RFC3339:                %s
+  RFC3339Milli:           %s
+  RFC3339Micro:           %s
+  RFC3339Nano:            %s
+  RFC1123Z:               %s
+ `,
+			time.StampMilli,
+			hubtime.YearMonthDay,
+			hubtime.YearMonthDayHour,
+			hubtime.YearMonthDayHourMinute,
+			time.RFC3339,
+			hubtime.RFC3339Milli,
+			hubtime.RFC3339Micro,
+			time.RFC3339Nano,
+			time.RFC1123Z,
+		),
+	)
+
+	formattingFlags.StringVarP(
+		&formattingOpts.output, "output", "o", "compact",
+		`Specify the output format, one of:
+  compact:  Compact output
+  dict:     Each flow is shown as KEY:VALUE pair
+  jsonpb:   JSON encoded GetFlowResponse according to proto3's JSON mapping
+  json:     Alias for jsonpb
+  table:    Tab-aligned columns
+`)
+	formattingFlags.BoolVarP(&formattingOpts.nodeName, "print-node-name", "", false, "Print node name in output")
+	formattingFlags.StringVar(
+		&formattingOpts.timeFormat, "time-format", "StampMilli",
+		fmt.Sprintf(`Specify the time format for printing. This option does not apply to the json and jsonpb output type. One of:
+  StampMilli:             %s
+  YearMonthDay:           %s
+  YearMonthDayHour:       %s
+  YearMonthDayHourMinute: %s
+  RFC3339:                %s
+  RFC3339Milli:           %s
+  RFC3339Micro:           %s
+  RFC3339Nano:            %s
+  RFC1123Z:               %s
+ `,
+			time.StampMilli,
+			hubtime.YearMonthDay,
+			hubtime.YearMonthDayHour,
+			hubtime.YearMonthDayHourMinute,
+			time.RFC3339,
+			hubtime.RFC3339Milli,
+			hubtime.RFC3339Micro,
+			time.RFC3339Nano,
+			time.RFC1123Z,
+		),
+	)
+
+	otherFlags.BoolVarP(&otherOpts.ignoreStderr,
+		"silent-errors", "s", false,
+		"Silently ignores errors and warnings")
+	otherFlags.BoolVar(&otherOpts.printRawFilters,
+		"print-raw-filters", false,
+		"Print allowlist/denylist filters and exit without sending the request to Hubble server")
+}
 
 // New observer command.
 func New(vp *viper.Viper) *cobra.Command {
-	return newFlowsCmd(vp, newFlowFilter())
+	observeCmd := newObserveCmd(vp)
+	flowsCmd := newFlowsCmd(vp)
+
+	observeCmd.AddCommand(
+		newAgentEventsCommand(vp),
+		newDebugEventsCommand(vp),
+		flowsCmd,
+	)
+
+	return observeCmd
 }

--- a/cmd/observe_help.txt
+++ b/cmd/observe_help.txt
@@ -1,31 +1,13 @@
-Observe provides visibility into flow information on the network and
-application level. Rich filtering enable observing specific flows related to
-individual pods, services, TCP connections, DNS queries, HTTP requests and
-more.
+Observe flows and events of a Hubble server
 
 Usage:
   hubble observe [flags]
   hubble observe [command]
 
-Examples:
-* Piping flows to hubble observe
-
-  Save output from 'hubble observe -o jsonpb' command to a file, and pipe it to
-  the observe command later for offline processing. For example:
-
-    hubble observe -o jsonpb --last 1000 > flows.json
-
-  Then,
-
-    cat flows.json | hubble observe
-
-  Note that the observe command ignores --follow, --last, and server flags when it
-  reads flows from stdin. The observe command processes and output flows in the same
-  order they are read from stdin without sorting them by timestamp.
-
 Available Commands:
   agent-events Observe Cilium agent events
   debug-events Observe Cilium debug events
+  flows        Observe flows of a Hubble server
 
 Selectors Flags:
       --all            Get all flows stored in Hubble's buffer
@@ -120,9 +102,6 @@ Raw-Filters Flags:
       --denylist stringArray    Specify denylist as JSON encoded FlowFilters
 
 Formatting Flags:
-      --color string         Colorize the output when the output format is one of 'compact' or 'dict'. The value is one of 'auto' (default), 'always' or 'never' (default "auto")
-      --ip-translation       Translate IP addresses to logical names such as pod name, FQDN, ... (default true)
-      --numeric              Display all information in numeric form
   -o, --output string        Specify the output format, one of:
                                compact:  Compact output
                                dict:     Each flow is shown as KEY:VALUE pair
@@ -142,6 +121,11 @@ Formatting Flags:
                                RFC3339Nano:            2006-01-02T15:04:05.999999999Z07:00
                                RFC1123Z:               Mon, 02 Jan 2006 15:04:05 -0700
                                (default "StampMilli")
+
+Flow Format Flags:
+      --color string     Colorize the output when the output format is one of 'compact' or 'dict'. The value is one of 'auto' (default), 'always' or 'never' (default "auto")
+      --ip-translation   Translate IP addresses to logical names such as pod name, FQDN, ... (default true)
+      --numeric          Display all information in numeric form
 
 Server Flags:
       --server string                 Address of a Hubble server (default "localhost:4245")


### PR DESCRIPTION
Attempt number two for https://github.com/cilium/hubble/pull/851 and https://github.com/cilium/hubble/issues/543. 

Hubble observe is now an alias for hubble observe flows. The only major difference is the help text for hubble observe is now briefer and indicates it is an alias for hubble observe flows. Additionally, while refactoring, I removed the flow formatting flags from the general formatting flagset and just moved it to it's own flagset.

This is currently based on #874 which adds unit tests to ensure things do not break this time.