### PR TITLE
dependabot: prefix backport PRs with target-branch version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: "vendor:"
+      prefix: "[v0.11] vendor:"
     # Setting open-pull-requests-limit to 0 means that dependabot will not
     # update regular dependencies on this target branch, but still provide
     # security updates for our gomod dependencies
@@ -50,7 +50,7 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: "ci:"
+      prefix: "[v0.11] ci:"
     open-pull-requests-limit: 5
     rebase-strategy: disabled
     target-branch: "v0.11"
@@ -76,7 +76,7 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: "dockerfile:"
+      prefix: "[v0.11] dockerfile:"
     open-pull-requests-limit: 5
     rebase-strategy: disabled
     target-branch: "v0.11"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -133,9 +133,9 @@ unreleased hubble versions in a branch from releases.
 
 ## Update the `dependabot` configuration
 
-After a new stable `v$MAJOR.$MINOR` release branch has been created, update
-the `.github/dependabot.yml` field for `target-branch` to point to the newly
-created branch, instead of the old stable branch.
+After a new stable `v$MAJOR.$MINOR` release branch has been created, update the
+`target-branch` and `commit-message.prefix` fields in `.github/dependabot.yml`
+to point to the newly created branch, instead of the old stable branch.
 
 ## Announce the release on Slack
 


### PR DESCRIPTION
I got confused by https://github.com/cilium/hubble/pull/877 and https://github.com/cilium/hubble/pull/878 having the same name until I saw that they were targeting different branches.