### PR TITLE
make: use `command -v` instead of `which` for better portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ BINDIR ?= /usr/local/bin
 TARGET=hubble
 VERSION=$(shell cat VERSION)
 # homebrew uses the github release's tarball of the source that does not contain the '.git' directory.
-GIT_BRANCH = $(shell which git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD 2> /dev/null)
-GIT_HASH = $(shell which git >/dev/null 2>&1 && git rev-parse --short HEAD 2> /dev/null)
+GIT_BRANCH = $(shell command -v git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD 2> /dev/null)
+GIT_HASH = $(shell command -v git >/dev/null 2>&1 && git rev-parse --short HEAD 2> /dev/null)
 GO_TAGS ?=
 IMAGE_REPOSITORY ?= quay.io/cilium/hubble
 IMAGE_TAG ?= $(if $(findstring -dev,$(VERSION)),latest,v$(VERSION))


### PR DESCRIPTION
The `command -v` command is more portable than `which`, see standard link below:
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html