### PR TITLE
Improve help message for --last option

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -52,7 +52,7 @@ var (
 
 func init() {
 	selectorFlags.BoolVar(&selectorOpts.all, "all", false, "Get all flows stored in Hubble's buffer")
-	selectorFlags.Uint64Var(&selectorOpts.last, "last", 0, fmt.Sprintf("Get last N flows stored in Hubble's buffer (default %d)", defaults.FlowPrintCount))
+	selectorFlags.Uint64Var(&selectorOpts.last, "last", 0, fmt.Sprintf("Get last N flows stored in Hubble's buffer (default %d). When querying against Hubble Relay, this gets N flows per instance of Hubble connected to that Relay", defaults.FlowPrintCount))
 	selectorFlags.Uint64Var(&selectorOpts.first, "first", 0, "Get first N flows stored in Hubble's buffer")
 	selectorFlags.BoolVarP(&selectorOpts.follow, "follow", "f", false, "Follow flows output")
 	selectorFlags.StringVar(&selectorOpts.since,

--- a/cmd/observe_help.txt
+++ b/cmd/observe_help.txt
@@ -13,7 +13,7 @@ Selectors Flags:
       --all            Get all flows stored in Hubble's buffer
       --first uint     Get first N flows stored in Hubble's buffer
   -f, --follow         Follow flows output
-      --last uint      Get last N flows stored in Hubble's buffer (default 20)
+      --last uint      Get last N flows stored in Hubble's buffer (default 20). When querying against Hubble Relay, this gets N flows per instance of Hubble connected to that Relay
       --since string   Filter flows since a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
                          StampMilli:             Jan _2 15:04:05.000
                          YearMonthDay:           2006-01-02


### PR DESCRIPTION
Fixes #861 

Improve help message for --last option 
```
 --last uint      Get last N flows stored in Hubble's buffer (default 20). When querying against Hubble Relay, this gets N flows per instance of Hubble connected to that Relay
```