### PR TITLE
Replace stdin detection with --flows-file flag which supports reading flows from a file or stdin

### DIFF
--- a/cmd/common/config/flags.go
+++ b/cmd/common/config/flags.go
@@ -43,7 +43,7 @@ func initGlobalFlags() {
 }
 
 func initServerFlags() {
-	ServerFlags.String(KeyServer, defaults.ServerAddress, "Address of a Hubble server")
+	ServerFlags.String(KeyServer, defaults.ServerAddress, "Address of a Hubble server. Ignored when --input-file is provided.")
 	ServerFlags.Duration(KeyTimeout, defaults.DialTimeout, "Hubble server dialing timeout")
 	ServerFlags.Bool(
 		KeyTLS,

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -38,6 +38,7 @@ var (
 	otherOpts struct {
 		ignoreStderr    bool
 		printRawFilters bool
+		inputFile       string
 	}
 
 	printer *hubprinter.Printer
@@ -145,6 +146,9 @@ func init() {
 	otherFlags.BoolVar(&otherOpts.printRawFilters,
 		"print-raw-filters", false,
 		"Print allowlist/denylist filters and exit without sending the request to Hubble server")
+
+	otherFlags.StringVar(&otherOpts.inputFile, "input-file", "",
+		"Query flows from this file instead of the server. Use '-' to read from stdin.")
 }
 
 // New observer command.

--- a/cmd/observe_help.txt
+++ b/cmd/observe_help.txt
@@ -129,7 +129,7 @@ Flow Format Flags:
       --numeric          Display all information in numeric form
 
 Server Flags:
-      --server string                 Address of a Hubble server (default "localhost:4245")
+      --server string                 Address of a Hubble server. Ignored when --input-file is provided. (default "localhost:4245")
       --timeout duration              Hubble server dialing timeout (default 5s)
       --tls                           Specify that TLS must be used when establishing a connection to a Hubble server.
                                       By default, TLS is only enabled if the server address starts with 'tls://'.
@@ -144,6 +144,7 @@ Server Flags:
       --tls-server-name string        Specify a server name to verify the hostname on the returned certificate (eg: 'instance.hubble-relay.cilium.io').
 
 Other Flags:
+      --input-file string   Query flows from this file instead of the server. Use '-' to read from stdin.
       --print-raw-filters   Print allowlist/denylist filters and exit without sending the request to Hubble server
   -s, --silent-errors       Silently ignores errors and warnings
 


### PR DESCRIPTION
Closes #942 

Motivation as described in the GH issue. Basically, automatically detecting stdin is fraught with gotchas and can cause issues when trying to use hubble CLI in GitHub actions. Instead, add a flag to explicitly support reading flows from a file or stdin.