### PR TITLE
cmd/observe: improve help message for date formats of --since/--until

### DIFF
--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -5,6 +5,7 @@ package observe
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cilium/hubble/pkg/defaults"
@@ -70,13 +71,13 @@ func init() {
  `,
 			time.StampMilli,
 			hubtime.YearMonthDay,
-			hubtime.YearMonthDayHour,
-			hubtime.YearMonthDayHourMinute,
-			time.RFC3339,
-			hubtime.RFC3339Milli,
-			hubtime.RFC3339Micro,
-			time.RFC3339Nano,
-			time.RFC1123Z,
+			strings.Replace(hubtime.YearMonthDayHour, "Z", "-", 1),
+			strings.Replace(hubtime.YearMonthDayHourMinute, "Z", "-", 1),
+			strings.Replace(time.RFC3339, "Z", "-", 1),
+			strings.Replace(hubtime.RFC3339Milli, "Z", "-", 1),
+			strings.Replace(hubtime.RFC3339Micro, "Z", "-", 1),
+			strings.Replace(time.RFC3339Nano, "Z", "-", 1),
+			strings.Replace(time.RFC1123Z, "Z", "-", 1),
 		),
 	)
 	selectorFlags.StringVar(&selectorOpts.until,
@@ -94,13 +95,13 @@ func init() {
  `,
 			time.StampMilli,
 			hubtime.YearMonthDay,
-			hubtime.YearMonthDayHour,
-			hubtime.YearMonthDayHourMinute,
-			time.RFC3339,
-			hubtime.RFC3339Milli,
-			hubtime.RFC3339Micro,
-			time.RFC3339Nano,
-			time.RFC1123Z,
+			strings.Replace(hubtime.YearMonthDayHour, "Z", "-", 1),
+			strings.Replace(hubtime.YearMonthDayHourMinute, "Z", "-", 1),
+			strings.Replace(time.RFC3339, "Z", "-", 1),
+			strings.Replace(hubtime.RFC3339Milli, "Z", "-", 1),
+			strings.Replace(hubtime.RFC3339Micro, "Z", "-", 1),
+			strings.Replace(time.RFC3339Nano, "Z", "-", 1),
+			strings.Replace(time.RFC1123Z, "Z", "-", 1),
 		),
 	)
 

--- a/cmd/observe_help.txt
+++ b/cmd/observe_help.txt
@@ -17,23 +17,23 @@ Selectors Flags:
       --since string   Filter flows since a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
                          StampMilli:             Jan _2 15:04:05.000
                          YearMonthDay:           2006-01-02
-                         YearMonthDayHour:       2006-01-02T15Z07:00
-                         YearMonthDayHourMinute: 2006-01-02T15:04Z07:00
-                         RFC3339:                2006-01-02T15:04:05Z07:00
-                         RFC3339Milli:           2006-01-02T15:04:05.999Z07:00
-                         RFC3339Micro:           2006-01-02T15:04:05.999999Z07:00
-                         RFC3339Nano:            2006-01-02T15:04:05.999999999Z07:00
+                         YearMonthDayHour:       2006-01-02T15-07:00
+                         YearMonthDayHourMinute: 2006-01-02T15:04-07:00
+                         RFC3339:                2006-01-02T15:04:05-07:00
+                         RFC3339Milli:           2006-01-02T15:04:05.999-07:00
+                         RFC3339Micro:           2006-01-02T15:04:05.999999-07:00
+                         RFC3339Nano:            2006-01-02T15:04:05.999999999-07:00
                          RFC1123Z:               Mon, 02 Jan 2006 15:04:05 -0700
                         
       --until string   Filter flows until a specific date. The format is relative (e.g. 3s, 4m, 1h43,, ...) or one of:
                          StampMilli:             Jan _2 15:04:05.000
                          YearMonthDay:           2006-01-02
-                         YearMonthDayHour:       2006-01-02T15Z07:00
-                         YearMonthDayHourMinute: 2006-01-02T15:04Z07:00
-                         RFC3339:                2006-01-02T15:04:05Z07:00
-                         RFC3339Milli:           2006-01-02T15:04:05.999Z07:00
-                         RFC3339Micro:           2006-01-02T15:04:05.999999Z07:00
-                         RFC3339Nano:            2006-01-02T15:04:05.999999999Z07:00
+                         YearMonthDayHour:       2006-01-02T15-07:00
+                         YearMonthDayHourMinute: 2006-01-02T15:04-07:00
+                         RFC3339:                2006-01-02T15:04:05-07:00
+                         RFC3339Milli:           2006-01-02T15:04:05.999-07:00
+                         RFC3339Micro:           2006-01-02T15:04:05.999999-07:00
+                         RFC3339Nano:            2006-01-02T15:04:05.999999999-07:00
                          RFC1123Z:               Mon, 02 Jan 2006 15:04:05 -0700
                         
 


### PR DESCRIPTION
The help message for the `--since` and `--until` flags of the `observe` command was misleading. To provide an example of each supported time format, Go time's layout format was used. However, the layout doesn't correspond to an actually valid time when the time zone is used. This is because to instruct Go's time formatting to use Z for the UTC timezone and a `±hh:mm` offset format otherwise (following the ISO8601 behavior), both `Z07:00` needs to be provided which, in itself, is an invalid timezone indicator as it means UTC (offset 00:00) and an offset of -07:00. To address this problem and improve the help output, this patch replaces `Z` in the formatting string by `-` so that the example formats print with the help are actually valid examples. Note that the help message for `--time-format` is unchanged as in this case, a Go's time format string needs to be provided, not an actual date time string.