### PR TITLE
Correctly handle --first/--last when reading flows from a stdin

### DIFF
--- a/cmd/observe/agent_events.go
+++ b/cmd/observe/agent_events.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/signal"
 
@@ -102,7 +103,7 @@ func getAgentEventsRequest() (*observerpb.GetAgentEventsRequest, error) {
 		switch {
 		case selectorOpts.all:
 			// all is an alias for last=uint64_max
-			selectorOpts.last = ^uint64(0)
+			selectorOpts.last = math.MaxUint64
 		case selectorOpts.last == 0:
 			// no specific parameters were provided, just a vanilla `hubble events agent`
 			selectorOpts.last = defaults.EventsPrintCount

--- a/vendor/github.com/cilium/cilium/pkg/container/ring_buffer.go
+++ b/vendor/github.com/cilium/cilium/pkg/container/ring_buffer.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package container
+
+import (
+	"sort"
+)
+
+// RingBuffer is a generic ring buffer implementation that contains
+// sequential data (i.e. such as time ordered data).
+// RingBuffer is implemented using slices. From testing, this should
+// be fast than linked-list implementations, and also allows for efficient
+// indexing of ordered data.
+type RingBuffer struct {
+	buffer  []interface{}
+	next    int // index of ring buffer head.
+	maxSize int
+}
+
+// NewRingBuffer constructs a new ring buffer for a given buffer size.
+func NewRingBuffer(bufferSize int) *RingBuffer {
+	return &RingBuffer{
+		buffer:  make([]interface{}, 0, bufferSize),
+		maxSize: bufferSize,
+	}
+}
+
+func (eb *RingBuffer) isFull() bool {
+	return len(eb.buffer) >= eb.maxSize
+}
+
+func (eb *RingBuffer) incr() {
+	eb.next = (eb.next + 1) % eb.maxSize
+}
+
+// Add adds an element to the buffer.
+func (eb *RingBuffer) Add(e interface{}) {
+	if eb.maxSize == 0 {
+		return
+	}
+	if eb.isFull() {
+		eb.buffer[eb.next] = e
+		eb.incr()
+		return
+	}
+	eb.incr()
+	eb.buffer = append(eb.buffer, e)
+}
+
+func (eb *RingBuffer) dumpWithCallback(callback func(v interface{})) {
+	for i := 0; i < len(eb.buffer); i++ {
+		callback(eb.at(i))
+	}
+}
+
+func (eb *RingBuffer) at(i int) interface{} {
+	return eb.buffer[eb.mapIndex(i)]
+}
+
+// firstValidIndex returns the first **absolute** index in the buffer that satisfies
+// isValid.
+// note: this value needs to be mapped before indexing the buffer.
+func (eb *RingBuffer) firstValidIndex(isValid func(interface{}) bool) int {
+	return sort.Search(len(eb.buffer), func(i int) bool {
+		return isValid(eb.at(i))
+	})
+}
+
+// IterateValid calls the callback on each element of the buffer, starting with
+// the first element in the buffer that satisfies "isValid".
+func (eb *RingBuffer) IterateValid(isValid func(interface{}) bool, callback func(interface{})) {
+	startIndex := eb.firstValidIndex(isValid)
+	l := len(eb.buffer) - startIndex
+	for i := 0; i < l; i++ {
+		index := eb.mapIndex(startIndex + i)
+		callback(eb.buffer[index])
+	}
+}
+
+// maps index in [0:len(buffer)) to the actual index in buffer.
+func (eb *RingBuffer) mapIndex(indexOffset int) int {
+	ret := (eb.next + indexOffset) % len(eb.buffer)
+	return ret
+}
+
+// Compact clears out invalidated elements in the buffer.
+// This may require copying the entire buffer.
+// It is assumed that if buffer[i] is invalid then every entry [0...i-1] is also not valid.
+func (eb *RingBuffer) Compact(isValid func(interface{}) bool) {
+	if len(eb.buffer) == 0 {
+		return
+	}
+	startIndex := eb.firstValidIndex(isValid)
+	// In this case, we compact the entire buffer.
+	if startIndex >= len(eb.buffer) {
+		eb.buffer = []interface{}{}
+		eb.next = 0
+		return
+	}
+
+	mappedStart := eb.mapIndex(startIndex) // mapped start is the new index 0 of our buffer.
+	// new length will be how long the current buffer is, minus the absolute starting index.
+	newBufferLength := len(eb.buffer) - startIndex
+	// case where the head index is to the left of the tail index.
+	// e.x. [... head, tail, ...]
+	// mappedStart + newBufferLength is the upper bound of the new buffer list
+	// if we don't have to worry about mapping.
+	//
+	// e.x. [mappedStart:mappedStart+newBufferLength] <- this is our new buffer.
+	//
+	// If this value is less than or equal to the length then we don't need
+	// to worry about any part of the list wrapping around.
+	if mappedStart+newBufferLength > len(eb.buffer) {
+		// now we can find the actual end index, by offsetting the startIndex
+		// by the length and mapping it.
+		// [... startIndex+newBufferLen ... startIndex ...]
+		end := eb.mapIndex(startIndex + newBufferLength)
+		tmp := make([]interface{}, len(eb.buffer[:end]))
+		copy(tmp, eb.buffer[:end])
+
+		eb.buffer = eb.buffer[mappedStart:]
+		eb.buffer = append(eb.buffer, tmp...)
+
+		// at this point the buffer is such that the 0th element
+		// maps to the 0th index in the buffer array.
+		eb.next = len(eb.buffer)
+		if eb.isFull() {
+			eb.next = eb.next % eb.maxSize
+		}
+		return
+	}
+	// otherwise, the head is to the right of the tail.
+	begin := mappedStart
+	end := mappedStart + newBufferLength
+	eb.buffer = eb.buffer[begin:end]
+	eb.next = len(eb.buffer)
+	if eb.isFull() {
+		eb.next = eb.next % eb.maxSize
+	}
+}
+
+// Iterate is a convenience function over IterateValid that iterates
+// all elements in the buffer.
+func (eb *RingBuffer) Iterate(callback func(interface{})) {
+	eb.IterateValid(func(e interface{}) bool { return true }, callback)
+}
+
+// Size returns the size of the buffer.
+func (eb *RingBuffer) Size() int {
+	return len(eb.buffer)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -38,6 +38,7 @@ github.com/cilium/cilium/pkg/clustermesh/types
 github.com/cilium/cilium/pkg/command
 github.com/cilium/cilium/pkg/common
 github.com/cilium/cilium/pkg/components
+github.com/cilium/cilium/pkg/container
 github.com/cilium/cilium/pkg/defaults
 github.com/cilium/cilium/pkg/endpoint/id
 github.com/cilium/cilium/pkg/health/client


### PR DESCRIPTION
As the title says, when reading flows from stdin, hubble CLI does not correctly handle --first/--last, but this fixes it.


here's a rough demonstration (pardon the jq, it's to condense the JSON output so it's a bit easier to see).
```
(⎈|kind-kind:N/A) ~/p/w/hubble ❯❯❯ ./hubble observe --first 5 < flows.json                                                                                                pr/chancez/file_input_handle_first_last ✭ ◼
Mar 20 16:16:36.501: 10.0.0.139:35044 (host) <- monitoring/prometheus-prometheus-k8s-0:9090 (ID:23751) to-stack FORWARDED (TCP Flags: ACK, PSH)
Mar 20 16:16:36.501: 10.0.0.139:35044 (host) <- monitoring/prometheus-prometheus-k8s-0:9090 (ID:23751) to-stack FORWARDED (TCP Flags: ACK, FIN)
Mar 20 16:16:36.501: 10.0.0.139:35038 (host) <- monitoring/prometheus-prometheus-k8s-0:9090 (ID:23751) to-stack FORWARDED (TCP Flags: ACK, PSH)
Mar 20 16:16:36.501: 10.0.0.139:35038 (host) <- monitoring/prometheus-prometheus-k8s-0:9090 (ID:23751) to-stack FORWARDED (TCP Flags: ACK, FIN)
Mar 20 16:16:36.515: monitoring/prometheus-prometheus-k8s-0:56640 (ID:23751) <- 172.18.0.2:10250 (host) to-endpoint FORWARDED (TCP Flags: ACK)
(⎈|kind-kind:N/A) ~/p/w/hubble ❯❯❯ head -n5 flows.json | jq '"src id: \(.flow.source.identity) dst id: \(.flow.destination.identity)" '                                   pr/chancez/file_input_handle_first_last ✭ ◼
"src id: 23751 dst id: 1"
"src id: 23751 dst id: 1"
"src id: 23751 dst id: 1"
"src id: 23751 dst id: 1"
"src id: 1 dst id: 23751"
(⎈|kind-kind:N/A) ~/p/w/hubble ❯❯❯ ./hubble observe --last 5 < flows.json                                                                                                 pr/chancez/file_input_handle_first_last ✭ ◼
Mar 20 16:16:37.345: monitoring/prometheus-adapter-75b56bdb5b-svjdg:33732 (ID:8198) <- monitoring/prometheus-prometheus-k8s-0:9090 (ID:23751) to-endpoint FORWARDED (TCP Flags: ACK)
Mar 20 16:16:37.780: monitoring/prometheus-prometheus-k8s-0:55926 (ID:23751) -> monitoring/kube-state-metrics-56c49c7f8c-9xlw8:8080 (ID:36611) to-endpoint FORWARDED (TCP Flags: SYN)
Mar 20 16:16:37.780: monitoring/prometheus-prometheus-k8s-0:55926 (ID:23751) <- monitoring/kube-state-metrics-56c49c7f8c-9xlw8:8080 (ID:36611) to-endpoint FORWARDED (TCP Flags: SYN, ACK)
Mar 20 16:16:37.780: monitoring/prometheus-prometheus-k8s-0:55926 (ID:23751) -> monitoring/kube-state-metrics-56c49c7f8c-9xlw8:8080 (ID:36611) to-endpoint FORWARDED (TCP Flags: ACK)
Mar 20 16:16:37.780: monitoring/prometheus-prometheus-k8s-0:55926 (ID:23751) -> monitoring/kube-state-metrics-56c49c7f8c-9xlw8:8080 (ID:36611) to-endpoint FORWARDED (TCP Flags: ACK, PSH)
(⎈|kind-kind:N/A) ~/p/w/hubble ❯❯❯ tail -n5 flows.json | jq '"src id: \(.flow.source.identity) dst id: \(.flow.destination.identity)" '                                   pr/chancez/file_input_handle_first_last ✭ ◼
"src id: 23751 dst id: 8198"
"src id: 23751 dst id: 36611"
"src id: 36611 dst id: 23751"
"src id: 23751 dst id: 36611"
"src id: 23751 dst id: 36611"
```