### PR TITLE
ci: run codeql job on Ubuntu 22.04 and only on supported release branch

### DIFF
--- a/.github/workflows/build-images-release.yaml
+++ b/.github/workflows/build-images-release.yaml
@@ -12,7 +12,7 @@ jobs:
   build-and-push:
     if: ${{ github.repository == 'cilium/hubble' }}
     environment: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       # matrix for easier code-sharing with workflows from cilium/cilium
       matrix:
@@ -77,7 +77,7 @@ jobs:
   image-digests:
     if: ${{ github.repository == 'cilium/hubble' }}
     name: Display Digests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-and-push
     steps:
       - name: Getting image tag

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,9 +5,7 @@ on:
   push:
     branches:
     - master
-    - v0.7
-    - v0.6
-    - v0.5
+    - v0.11
   pull_request:
     branches:
     - master
@@ -21,7 +19,7 @@ concurrency:
 jobs:
   analyze:
     if: github.repository == 'cilium/hubble'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
       - name: Checkout the repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Create Release
     if: github.repository == 'cilium/hubble'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9


### PR DESCRIPTION
See also this blog post about GHA sunsetting Ubuntu 18.04: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/