### PR TITLE
Log when connection is successful

### DIFF
--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -161,6 +161,7 @@ var GetHubbleClientFunc = func(ctx context.Context, vp *viper.Viper) (client obs
 	if err != nil {
 		return nil, nil, err
 	}
+	logger.Logger.WithField("server", config.KeyServer).Debug("connected to Hubble API")
 	cleanup = hubbleConn.Close
 	client = observerpb.NewObserverClient(hubbleConn)
 	return client, cleanup, nil


### PR DESCRIPTION
We only log when we make a request, not when we connect. I think logging connections separately from requests could be useful for debugging.  