### PR TITLE
Add support for supplying basic authentication credentials

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,8 @@ issues:
       text: "do not define dynamic errors, use wrapped static errors instead"
     - linters: [gosec]
       text: "G402" # TLS InsecureSkipVerify may be true
+    - linters: [gosec]
+      text: "G101" # Potential hardcoded credentials
     - linters: [revive]
       text: "should have a package comment"
     - linters: [dupword]

--- a/cmd/common/config/flags.go
+++ b/cmd/common/config/flags.go
@@ -23,6 +23,8 @@ const (
 	KeyTLSClientCertFile = "tls-client-cert-file" // string
 	KeyTLSClientKeyFile  = "tls-client-key-file"  // string
 	KeyTLSServerName     = "tls-server-name"      // string
+	KeyBasicAuthUsername = "basic-auth-username"  // string
+	KeyBasicAuthPassword = "basic-auth-password"  // string
 	KeyTimeout           = "timeout"              // time.Duration
 )
 
@@ -80,5 +82,15 @@ func initServerFlags() {
 		KeyTLSServerName,
 		"",
 		"Specify a server name to verify the hostname on the returned certificate (eg: 'instance.hubble-relay.cilium.io').",
+	)
+	ServerFlags.String(
+		KeyBasicAuthUsername,
+		"",
+		"Specify a username for basic auth",
+	)
+	ServerFlags.String(
+		KeyBasicAuthPassword,
+		"",
+		"Specify a password for basic auth",
 	)
 }

--- a/cmd/common/conn/auth.go
+++ b/cmd/common/conn/auth.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package conn
+
+import (
+	"context"
+	"encoding/base64"
+
+	"google.golang.org/grpc"
+)
+
+// WithBasicAuth configures basic authentication credentials for the connection.
+func WithBasicAuth(username, password string) grpc.DialOption {
+	return grpc.WithPerRPCCredentials(basicAuthCredentials{username: username, password: password})
+}
+
+type basicAuthCredentials struct {
+	username, password string
+}
+
+func (c basicAuthCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{
+		"authorization": "Basic " + basicAuth(c.username, c.password),
+	}, nil
+}
+
+func (c basicAuthCredentials) RequireTransportSecurity() bool {
+	return true
+}
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}

--- a/cmd/common/validate/auth.go
+++ b/cmd/common/validate/auth.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package validate
+
+import (
+	"fmt"
+
+	"github.com/cilium/hubble/cmd/common/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	// ErrInvalidBasicAuthCredentials occurs when only one of basic-auth-user or basic-auth-password is configured.
+	ErrInvalidBasicAuthCredentials = fmt.Errorf("must specify both %s and %s", config.KeyBasicAuthUsername, config.KeyBasicAuthPassword)
+)
+
+func init() {
+	FlagFuncs = append(FlagFuncs, validateBasicAuth)
+}
+
+// validateBasicAuth validates that both username and password are set.
+func validateBasicAuth(_ *cobra.Command, vp *viper.Viper) error {
+	if vp.GetString(config.KeyBasicAuthUsername) != "" && vp.GetString(config.KeyBasicAuthPassword) == "" ||
+		vp.GetString(config.KeyBasicAuthUsername) == "" && vp.GetString(config.KeyBasicAuthPassword) != "" {
+		return ErrInvalidBasicAuthCredentials
+	}
+	return nil
+}

--- a/cmd/observe_help.txt
+++ b/cmd/observe_help.txt
@@ -130,6 +130,8 @@ Flow Format Flags:
       --numeric          Display all information in numeric form
 
 Server Flags:
+      --basic-auth-password string    Specify a password for basic auth
+      --basic-auth-username string    Specify a username for basic auth
       --server string                 Address of a Hubble server. Ignored when --input-file is provided. (default "localhost:4245")
       --timeout duration              Hubble server dialing timeout (default 5s)
       --tls                           Specify that TLS must be used when establishing a connection to a Hubble server.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/hubble/cmd/watch"
 	"github.com/cilium/hubble/pkg"
 	"github.com/cilium/hubble/pkg/logger"
+	"google.golang.org/grpc"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -60,6 +61,15 @@ func NewWithViper(vp *viper.Viper) *cobra.Command {
 		logger.Initialize(vp)
 		if err == nil {
 			logger.Logger.WithField("config-file", vp.ConfigFileUsed()).Debug("Using config file")
+		}
+
+		username := vp.GetString(config.KeyBasicAuthUsername)
+		password := vp.GetString(config.KeyBasicAuthPassword)
+		if username != "" && password != "" {
+			optFunc := func(*viper.Viper) (grpc.DialOption, error) {
+				return conn.WithBasicAuth(username, password), nil
+			}
+			conn.GRPCOptionFuncs = append(conn.GRPCOptionFuncs, optFunc)
 		}
 	})
 


### PR DESCRIPTION
Use case: I want to configure my ingress controller to expose hubble relay with basic auth, but Hubble CLI cannot pass basic auth credentials through.