### PR TITLE
observe: Support -f and --first at the same time

### DIFF
--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -616,9 +616,6 @@ func getFlowsRequest(ofilter *flowFilter, allowlist []string, denylist []string)
 	if first && selectorOpts.all {
 		return nil, fmt.Errorf("cannot set both --first and --all")
 	}
-	if first && selectorOpts.follow {
-		return nil, fmt.Errorf("cannot set both --first and --follow")
-	}
 	if last && selectorOpts.all {
 		return nil, fmt.Errorf("cannot set both --last and --all")
 	}


### PR DESCRIPTION
This PR removes the safeguard for support for -f and --first at the same time. This would support the following PR in the cilium repository as well to make sure the server supports it as well 

Refers to https://github.com/cilium/hubble/issues/959