### PR TITLE
Add example links to renovate configuration in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -149,11 +149,11 @@ to point to the newly created branch, instead of the old stable branch.
 
 After a new stable `v$MAJOR.$MINOR` release branch has been created, update `renovate.json5`:
 
-- Add the new branch to the `baseBranches` field and remove the previous release branch (we only maintain the most recent Hubble release).
-- Add the new branch to the `all-go-deps-stable` packageRule in the `matchBaseBranches` field and remove the previous release branch.
-- Update or add a new `golang-stable` packageRule to pin the Go version used to the current minor version for the release. (TODO: Add link to example)
-- Update or add a new `alpine-stable` packageRule to pin the Alpine image version used to the current minor version for the release. (TODO: Add link to example)
-- Add the new branch to the `golangci-lint` packageRule in the `matchBaseBranches` field and remove the previous release release branch.
+- Add the new branch to the `baseBranches` field and remove the previous release branch (we only maintain the most recent Hubble release). [Example](https://github.com/cilium/hubble/blob/3680a3193ac35e962bb9806c00bd481932a18725/.github/renovate.json5#L31).
+- Add the new branch to the `all-go-deps-stable` packageRule in the `matchBaseBranches` field and remove the previous release branch. [Example](https://github.com/cilium/hubble/blob/3680a3193ac35e962bb9806c00bd481932a18725/.github/renovate.json5#L85-L97).
+- Add the new branch to the `golang-stable` packageRule to pin the Go version used to the current minor version for the release and remove the previous release branch. [Example](https://github.com/cilium/hubble/blob/3680a3193ac35e962bb9806c00bd481932a18725/.github/renovate.json5#L127-L137).
+- Add the new branch to the `alpine-stable` packageRule to pin the Alpine image version used to the current minor version for the release and remove the previous release branch. [Example](https://github.com/cilium/hubble/blob/3680a3193ac35e962bb9806c00bd481932a18725/.github/renovate.json5#L146-L155).
+- Add the new branch to the `golangci-lint` packageRule in the `matchBaseBranches` field and remove the previous release release branch. [Example](https://github.com/cilium/hubble/blob/3680a3193ac35e962bb9806c00bd481932a18725/.github/renovate.json5#L164-L174).
 
 ## Get the Docker image build for the release approved
 


### PR DESCRIPTION
This is a follow up from https://github.com/cilium/hubble/pull/1011. Now that renovate.json5 is in the repo, we can easily link to it in our release.md for examples to help guide a developer making a release.