### PR TITLE
.github: Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/build-images-release.yaml
+++ b/.github/workflows/build-images-release.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          echo ::set-output name=tag::${GITHUB_REF##*/}
+          echo "tag=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
       - name: Downloading Image Digests
         shell: bash
         run: |


### PR DESCRIPTION
## Description

Resolve #1048 

Update `.github/workflows/build-images-release.yaml` and shell scripts to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' -o -name '*.sh'  | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: |
  echo ::set-output name=tag::${GITHUB_REF##*/}
```

**TO-BE**

```yml
run: |
  echo "tag=${GITHUB_REF##*/}%22%20%3E%3E%20$GITHUB_OUTPUT
```