### PR TITLE
Add experimental-field-mask flags

### DIFF
--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -550,6 +550,7 @@ func handleFlowArgs(writer io.Writer, ofilter *flowFilter, debug bool) (err erro
 		hubprinter.WithColor(formattingOpts.color),
 	}
 
+	jsonOut := false
 	switch formattingOpts.output {
 	case "compact":
 		opts = append(opts, hubprinter.Compact())
@@ -563,6 +564,7 @@ func handleFlowArgs(writer io.Writer, ofilter *flowFilter, debug bool) (err erro
 		fallthrough
 	case "jsonpb":
 		opts = append(opts, hubprinter.JSONPB())
+		jsonOut = true
 	case "tab", "table":
 		if selectorOpts.follow {
 			return fmt.Errorf("table output format is not compatible with follow mode")
@@ -571,6 +573,15 @@ func handleFlowArgs(writer io.Writer, ofilter *flowFilter, debug bool) (err erro
 	default:
 		return fmt.Errorf("invalid output format: %s", formattingOpts.output)
 	}
+	if !jsonOut {
+		if len(experimentalOpts.fieldMask) > 0 {
+			return fmt.Errorf("%s output format is not compatible with custom field mask", formattingOpts.output)
+		}
+		if experimentalOpts.useDefaultMasks {
+			experimentalOpts.fieldMask = defaults.FieldMask
+		}
+	}
+
 	if otherOpts.ignoreStderr {
 		opts = append(opts, hubprinter.IgnoreStderr())
 	}

--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v3"
 )
@@ -699,6 +700,16 @@ func getFlowsRequest(ofilter *flowFilter, allowlist []string, denylist []string)
 		Since:     since,
 		Until:     until,
 		First:     first,
+	}
+
+	if len(experimentalOpts.fieldMask) > 0 {
+		fm, err := fieldmaskpb.New(&flowpb.Flow{}, experimentalOpts.fieldMask...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct field mask: %w", err)
+		}
+		req.Experimental = &observerpb.GetFlowsRequest_Experimental{
+			FieldMask: fm,
+		}
 	}
 
 	return req, nil

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -43,7 +43,8 @@ var (
 	}
 
 	experimentalOpts struct {
-		fieldMask []string
+		fieldMask       []string
+		useDefaultMasks bool
 	}
 
 	printer *hubprinter.Printer
@@ -157,6 +158,9 @@ func init() {
 
 	otherFlags.StringSliceVar(&experimentalOpts.fieldMask, "experimental-field-mask", nil,
 		"Experimental: Comma-separated list of fields for mask. Fields not in the mask will be removed from server response.")
+
+	otherFlags.BoolVar(&experimentalOpts.useDefaultMasks, "experimental-use-default-field-masks", false,
+		"Experimental: request only visible fields when the output format is compact, tab, or dict.")
 }
 
 // New observer command.

--- a/cmd/observe/observe.go
+++ b/cmd/observe/observe.go
@@ -42,6 +42,10 @@ var (
 		inputFile       string
 	}
 
+	experimentalOpts struct {
+		fieldMask []string
+	}
+
 	printer *hubprinter.Printer
 
 	// selector flags
@@ -150,6 +154,9 @@ func init() {
 
 	otherFlags.StringVar(&otherOpts.inputFile, "input-file", "",
 		"Query flows from this file instead of the server. Use '-' to read from stdin.")
+
+	otherFlags.StringSliceVar(&experimentalOpts.fieldMask, "experimental-field-mask", nil,
+		"Experimental: Comma-separated list of fields for mask. Fields not in the mask will be removed from server response.")
 }
 
 // New observer command.

--- a/cmd/observe_help.txt
+++ b/cmd/observe_help.txt
@@ -147,9 +147,11 @@ Server Flags:
       --tls-server-name string        Specify a server name to verify the hostname on the returned certificate (eg: 'instance.hubble-relay.cilium.io').
 
 Other Flags:
-      --input-file string   Query flows from this file instead of the server. Use '-' to read from stdin.
-      --print-raw-filters   Print allowlist/denylist filters and exit without sending the request to Hubble server
-  -s, --silent-errors       Silently ignores errors and warnings
+      --experimental-field-mask strings        Experimental: Comma-separated list of fields for mask. Fields not in the mask will be removed from server response.
+      --experimental-use-default-field-masks   Experimental: request only visible fields when the output format is compact, tab, or dict.
+      --input-file string                      Query flows from this file instead of the server. Use '-' to read from stdin.
+      --print-raw-filters                      Print allowlist/denylist filters and exit without sending the request to Hubble server
+  -s, --silent-errors                          Silently ignores errors and warnings
 
 Global Flags:
       --config string   Optional config file (default "%s")

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -50,6 +50,10 @@ var (
 	// ConfigFile is the path to an optional configuration file.
 	// It may be unset.
 	ConfigFile string
+
+	// FieldMask is a list of requested fields when using "dict", "tab", or "compact"
+	// output format and no custom mask is specified.
+	FieldMask = []string{"time", "source.identity", "source.namespace", "source.pod_name", "destination.identity", "destination.namespace", "destination.pod_name", "source_service", "destination_service", "l4", "IP", "ethernet", "l7", "Type", "node_name", "is_reply", "event_type", "verdict", "Summary"}
 )
 
 func init() {


### PR DESCRIPTION
Follow-up to change in cilium exposing a new experimental field in `GetFlowsRequest`s: https://github.com/cilium/cilium/pull/23198

Usage example with custom field mask and JSON output format:
```
% hubble observe --experimental-field-mask time,verdict --output jsonpb
```

Usage example with default field mask and default output format:
```
% hubble observe --experimental-use-default-field-masks
```

Example of providing invalid fieldmask:
```
% hubble observe --experimental-field-mask time,verdict,invalid --output jsonpb
failed to construct field mask: proto: invalid path "invalid" for message "flow.Flow"
```

Example of providing custom field mask for non-JSON output format:
```
% hubble observe --experimental-field-mask time,verdict
compact output format is not compatible with custom field mask
```