### PR TITLE
Fix client certificate requests when no client certificate is specified

### DIFF
--- a/cmd/common/conn/tls.go
+++ b/cmd/common/conn/tls.go
@@ -52,17 +52,13 @@ func grpcOptionTLS(vp *viper.Viper) (grpc.DialOption, error) {
 	// optional mTLS
 	clientCertFile := vp.GetString(config.KeyTLSClientCertFile)
 	clientKeyFile := vp.GetString(config.KeyTLSClientKeyFile)
-	var cert *tls.Certificate
 	if clientCertFile != "" && clientKeyFile != "" {
 		c, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
 		if err != nil {
 			return nil, err
 		}
-		cert = &c
-	}
-	if cert != nil {
 		tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			return cert, nil
+			return &c, nil
 		}
 	}
 


### PR DESCRIPTION
Only set GetClientCertificate if client certificate is configured.

In docs for `GetClientCertificate` it specifies:

>  GetClientCertificate must return a non-nil Certificate. If
>  Certificate.Certificate is empty then no certificate will be sent to the
>  server.

If a nil certificate is sent when the server requests a client
certificate, the client will return an error. Instead, only configure
GetClientCertificate if certificates are provided and the server may
choose to how to handle the lack of a client certificate.

This is needed primarily for when the server is using RequestClientCert,
which requests a certificate, but does not require the client to send
one.

Previously, you would see this log message:

```
transport: authentication handshake failed: mTLS client certificate requested, but not provided
```

From the client when the server requested a client cert, even if it was not required.