### PR TITLE
ci: replace deprecated use of set-output

### DIFF
--- a/.github/workflows/build-images-release.yaml
+++ b/.github/workflows/build-images-release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          echo ::set-output name=tag::${GITHUB_REF##*/}
+          echo "tag=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
       - name: Checkout Source Code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
The set-output command is deprecated. See this blog post for more information:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/