### PR TITLE
Don't set --last if --input-file is specified

### DIFF
--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -667,7 +667,7 @@ func getFlowsRequest(ofilter *flowFilter, allowlist []string, denylist []string)
 		case selectorOpts.all:
 			// all is an alias for last=uint64_max
 			selectorOpts.last = ^uint64(0)
-		case selectorOpts.last == 0 && !selectorOpts.follow:
+		case selectorOpts.last == 0 && !selectorOpts.follow && otherOpts.inputFile == "":
 			// no specific parameters were provided, just a vanilla
 			// `hubble observe` in non-follow mode
 			selectorOpts.last = defaults.FlowPrintCount

--- a/cmd/observe/flows_test.go
+++ b/cmd/observe/flows_test.go
@@ -174,3 +174,18 @@ func Test_getFlowsRequest_ExperimentalFieldMask_non_json_output(t *testing.T) {
 	err := handleFlowArgs(os.Stdout, filter, false)
 	assert.ErrorContains(t, err, "not compatible")
 }
+
+func Test_getFlowsRequestWithInputFile(t *testing.T) {
+	// Don't set the number flag in GetFlowsRequest by default if --input-file is specified
+	selectorOpts.last = 0
+	otherOpts.inputFile = "myfile"
+	req, err := getFlowsRequest(newFlowFilter(), nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), req.Number)
+
+	// .. but you can explicitly specify --last flag
+	selectorOpts.last = 42
+	req, err = getFlowsRequest(newFlowFilter(), nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(42), req.Number)
+}


### PR DESCRIPTION
Don't set --last to 20 if --input-file flag is specified to preserve the previous default behavior of processing all the flows from stdin.