### PR TITLE
ci: run slowg analyzer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,10 @@ jobs:
         version: v1.53.3
         args: --config=.golangci.yml --verbose
         skip-cache: true
+    - name: Run slowg analyzer
+      run: | # TODO: remove once slowg is integrated in golangci-lint
+        go install github.com/cilium/linters@latest
+        linters -slowg ./...
     - name: Check module vendoring
       run: |
         go mod tidy


### PR DESCRIPTION
Slowg is a new analyzer that is part of Cilium's linters. It checks for inappropriate use of `Logger.With` from the `log/slog` package.

Check the URL below for more:
https://github.com/cilium/linters#slowg