### PR TITLE
doc: update doc readme and remove broken links

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -2,16 +2,11 @@
 
 > The Hubble documentation has moved to [docs.cilium.io](https://docs.cilium.io/)
 
-This documentation is intended for users with **Cilium >=1.8**. If
-you are running Cilium 1.7, please follow [the documentation in the Hubble v0.5
-branch](https://github.com/cilium/hubble/tree/v0.5/Documentation).
-
 ## Getting Started
 
  * [Quickstart](https://docs.cilium.io/en/stable/gettingstarted/hubble)
  * [What is Hubble?](https://docs.cilium.io/en/stable/intro/#what-is-hubble)
  * [Installation with Cilium](https://docs.cilium.io/en/stable/gettingstarted/#installation)
- * [Running Prometheus and Grafana](https://docs.cilium.io/en/stable/gettingstarted/grafana/)
 
 ## Troubleshooting
 
@@ -21,7 +16,6 @@ branch](https://github.com/cilium/hubble/tree/v0.5/Documentation).
 ## Internals
 
  * [Contributing](https://docs.cilium.io/en/stable/contributing/development/)
- * [Components](https://docs.cilium.io/en/stable/concepts/overview/#hubble)
  * [Architecture](https://docs.cilium.io/en/stable/hubble/)
  * [Code Overview](https://docs.cilium.io/en/stable/contributing/development/codeoverview/#hubble)
  * [Metrics Reference](https://docs.cilium.io/en/stable/operations/metrics/#hubble)


### PR DESCRIPTION
The documentation has long been moved to cilium.io.