### PR TITLE
Fix raw-filter flags by binding flags to viper only if command is run

### DIFF
--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -31,6 +31,13 @@ func init() {
 	expectedObserveHelp = fmt.Sprintf(expectedObserveHelp, defaults.ConfigFile)
 }
 
+var observeRawFilterArgs = []string{"--allowlist", `{"source_pod":["kube-system/"]}`, "--denylist", `{"source_ip":["1.1.1.1"]}`, "--print-raw-filters"}
+var observeRawFilterOut = `allowlist:
+    - '{"source_pod":["kube-system/"]}'
+denylist:
+    - '{"source_ip":["1.1.1.1"]}'
+`
+
 func TestTestHubbleObserve(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -85,6 +92,16 @@ Use "hubble [command] --help" for more information about a command.
 			name:           "observe help",
 			args:           []string{"observe", "--help"},
 			expectedOutput: expectedObserveHelp,
+		},
+		{
+			name:           "observe raw filters",
+			args:           append([]string{"observe"}, observeRawFilterArgs...),
+			expectedOutput: observeRawFilterOut,
+		},
+		{
+			name:           "observe flows raw filters",
+			args:           append([]string{"observe", "flows"}, observeRawFilterArgs...),
+			expectedOutput: observeRawFilterOut,
 		},
 	}
 


### PR DESCRIPTION
The raw-filter flags are broken since we bind them to viper twice with the same name, during initalization. Once for `hubble observe` and once for `hubble observe flows`. This means that only the flags for `hubble observe flows` work, as it is registered later and overwrites the binding for `hubble observe`

We fix this by only binding the flags of the command we actually run.

Fixes: #1201