### PR TITLE
renovate: Use allowedVersions to limit updates to stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -140,12 +140,7 @@
         "go",
         "golang"
       ],
-      "matchUpdateTypes": [
-        "patch",
-        "digest",
-        "pin",
-        "pinDigest"
-      ],
+      "allowedVersions": "<=1.20",
       "matchBaseBranches": [
         "v0.12"
       ],
@@ -163,12 +158,7 @@
       "matchPackageNames": [
         "docker.io/library/alpine"
       ],
-      "matchUpdateTypes": [
-        "patch",
-        "digest",
-        "pin",
-        "pinDigest"
-      ],
+      "allowedVersions": "<=3.18",
       "matchBaseBranches": [
         "v0.12"
       ]


### PR DESCRIPTION
`matchUpdateTypes` is the wrong option for limiting updates in the stable branch. When I wrote this config, it was based off Cilium's config, which I looked at, and has since changed to using `allowedVersions`. It seems we're all slowly learning the lesson of how to correctly configure renovate. Ref https://github.com/cilium/hubble/pull/1239#issuecomment-1750266739