### PR TITLE
Add flags to filter for pods and services in any namespace

### DIFF
--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -456,6 +456,19 @@ func newFlowsCmdHelper(usage cmdUsage, vp *viper.Viper, ofilter *flowFilter) *co
 		"Show all flows terminating in the given Kubernetes namespace."))
 
 	filterFlags.Var(filterVar(
+		"from-all-namespaces", ofilter,
+		"Show flows originating in any Kubernetes namespace."))
+	filterFlags.Lookup("from-all-namespaces").NoOptDefVal = "true" // add default val so none is required to be provided
+	filterFlags.VarP(filterVarP(
+		"all-namespaces", "A", ofilter, nil,
+		"Show all flows in any Kubernetes namespace."))
+	filterFlags.Lookup("all-namespaces").NoOptDefVal = "true" // add default val so none is required to be provided
+	filterFlags.Var(filterVar(
+		"to-all-namespaces", ofilter,
+		"Show flows terminating in any Kubernetes namespace."))
+	filterFlags.Lookup("to-all-namespaces").NoOptDefVal = "true" // add default val so none is required to be provided
+
+	filterFlags.Var(filterVar(
 		"from-label", ofilter,
 		`Show only flows originating in an endpoint with the given labels (e.g. "key1=value1", "reserved:world")`))
 	filterFlags.VarP(filterVarP(

--- a/cmd/observe/flows_filter.go
+++ b/cmd/observe/flows_filter.go
@@ -180,14 +180,14 @@ type flowFilter struct {
 func newFlowFilter() *flowFilter {
 	return &flowFilter{
 		conflicts: [][]string{
-			{"from-fqdn", "from-ip", "ip", "fqdn", "from-namespace", "namespace"},
+			{"from-fqdn", "from-ip", "ip", "fqdn", "from-namespace", "namespace", "from-all-namespaces", "all-namespaces"},
 			{"from-fqdn", "from-ip", "ip", "fqdn", "from-pod", "pod"},
-			{"to-fqdn", "to-ip", "ip", "fqdn", "to-namespace", "namespace"},
+			{"to-fqdn", "to-ip", "ip", "fqdn", "to-namespace", "namespace", "to-all-namespaces", "all-namespaces"},
 			{"to-fqdn", "to-ip", "ip", "fqdn", "to-pod", "pod"},
-			{"to-pod", "namespace"},
-			{"from-pod", "namespace"},
-			{"to-service", "namespace"},
-			{"from-service", "namespace"},
+			{"to-pod", "namespace", "all-namespaces"},
+			{"from-pod", "namespace", "all-namespaces"},
+			{"to-service", "namespace", "all-namespaces"},
+			{"from-service", "namespace", "all-namespaces"},
 			{"label", "from-label"},
 			{"label", "to-label"},
 			{"service", "from-service"},
@@ -473,6 +473,14 @@ func (of *flowFilter) set(f *filterTracker, name, val string, track bool) error 
 		f.srcNs = append(f.srcNs, val)
 	case "to-namespace":
 		f.dstNs = append(f.dstNs, val)
+
+	// namespace filters (will be applied to pods and/or service filters)
+	case "all-namespaces":
+		f.ns = append(f.ns, "")
+	case "from-all-namespaces":
+		f.srcNs = append(f.srcNs, "")
+	case "to-all-namespaces":
+		f.dstNs = append(f.dstNs, "")
 
 	// service filters
 	case "service":

--- a/cmd/observe/flows_filter_test.go
+++ b/cmd/observe/flows_filter_test.go
@@ -164,6 +164,8 @@ func TestConflicts_Table(t *testing.T) {
 		{"--pod", "--to-pod"},
 		{"--namespace", "--from-namespace"},
 		{"--namespace", "--to-namespace"},
+		{"--all-namespaces", "--from-all-namespaces"},
+		{"--all-namespaces", "--to-all-namespaces"},
 
 		{"--ip", "--fqdn"},
 		{"--ip", "--from-fqdn"},
@@ -180,12 +182,19 @@ func TestConflicts_Table(t *testing.T) {
 		{"--to-ip", "--pod"},
 		{"--to-ip", "--to-pod"},
 		{"--ip", "--namespace"},
+		{"--ip", "--all-namespaces"},
 		{"--ip", "--from-namespace"},
+		{"--ip", "--from-all-namespaces"},
 		{"--ip", "--to-namespace"},
+		{"--ip", "--to-all-namespaces"},
 		{"--from-ip", "--from-namespace"},
+		{"--from-ip", "--from-all-namespaces"},
 		{"--from-ip", "--namespace"},
+		{"--from-ip", "--all-namespaces"},
 		{"--to-ip", "--namespace"},
+		{"--to-ip", "--all-namespaces"},
 		{"--to-ip", "--to-namespace"},
+		{"--to-ip", "--to-all-namespaces"},
 
 		{"--pod", "--fqdn"},
 		{"--pod", "--from-fqdn"},
@@ -193,19 +202,38 @@ func TestConflicts_Table(t *testing.T) {
 		{"--from-pod", "--from-fqdn"},
 		{"--from-pod", "--fqdn"},
 		{"--from-pod", "--namepace"},
+		{"--from-pod", "--all-namepaces"},
 		{"--to-pod", "--fqdn"},
 		{"--to-pod", "--to-fqdn"},
 		{"--to-pod", "--namepace"},
+		{"--to-pod", "--all-namepaces"},
 
 		{"--namespace", "--fqdn"},
 		{"--namespace", "--from-fqdn"},
 		{"--namespace", "--to-fqdn"},
 		{"--namespace", "--from-service"},
 		{"--namespace", "--to-service"},
+		{"--namespace", "--all-namepaces"},
+		{"--namespace", "--from-all-namepaces"},
+		{"--namespace", "--to-all-namepaces"},
 		{"--from-namespace", "--from-fqdn"},
 		{"--from-namespace", "--fqdn"},
+		{"--from-namespace", "--from-all-namespaces"},
+		{"--from-namespace", "--all-namespaces"},
 		{"--to-namespace", "--fqdn"},
 		{"--to-namespace", "--to-fqdn"},
+		{"--to-namespace", "--to-all-namespaces"},
+		{"--to-namespace", "--all-namespaces"},
+
+		{"--all-namespaces", "--fqdn"},
+		{"--all-namespaces", "--from-fqdn"},
+		{"--all-namespaces", "--to-fqdn"},
+		{"--all-namespaces", "--from-service"},
+		{"--all-namespaces", "--to-service"},
+		{"--from-all-namespaces", "--from-fqdn"},
+		{"--from-all-namespaces", "--fqdn"},
+		{"--to-all-namespaces", "--fqdn"},
+		{"--to-all-namespaces", "--to-fqdn"},
 	}
 
 	for _, con := range conflicts {
@@ -868,6 +896,44 @@ func TestNamespace(t *testing.T) {
 			flags:   []string{"--from-service", "cilium/foo", "--from-pod", "kube-system/hubble"},
 			filters: []*flowpb.FlowFilter{},
 			err:     `conflicting namepace: namespace of service "cilium/foo" conflict with pod "kube-system/hubble"`,
+		},
+		{
+			name:  "Any request to any namespace with port",
+			flags: []string{"--to-all-namespaces", "--port", "443"},
+			filters: []*flowpb.FlowFilter{
+				{DestinationPod: []string{"/"}, SourcePort: []string{"443"}},
+				{DestinationPod: []string{"/"}, DestinationPort: []string{"443"}},
+			},
+		},
+		{
+			name:  "Any request to pod foo in any namespace",
+			flags: []string{"--to-all-namespaces", "--to-pod", "foo"},
+			filters: []*flowpb.FlowFilter{
+				{DestinationPod: []string{"/foo"}},
+			},
+		},
+		{
+			name:  "Any request to service bar in any namespace",
+			flags: []string{"--to-all-namespaces", "--to-service", "bar"},
+			filters: []*flowpb.FlowFilter{
+				{DestinationService: []string{"/bar"}},
+			},
+		},
+		{
+			name:  "Any request to and from pod foo in any namespace",
+			flags: []string{"--all-namespaces", "--pod", "foo"},
+			filters: []*flowpb.FlowFilter{
+				{SourcePod: []string{"/foo"}},
+				{DestinationPod: []string{"/foo"}},
+			},
+		},
+		{
+			name:  "Any request to and from service bar in any namespace",
+			flags: []string{"--all-namespaces", "--service", "bar"},
+			filters: []*flowpb.FlowFilter{
+				{SourceService: []string{"/bar"}},
+				{DestinationService: []string{"/bar"}},
+			},
 		},
 	}
 	for _, tc := range tt {

--- a/cmd/observe_help.txt
+++ b/cmd/observe_help.txt
@@ -38,69 +38,72 @@ Selectors Flags:
                         
 
 Filters Flags:
-      --cluster filter             Show all flows which match the cluster names (e.g. "test-cluster", "prod-*")
-      --fqdn filter                Show all flows related to the given fully qualified domain name (e.g. "*.cilium.io").
-      --from-fqdn filter           Show all flows originating at the given fully qualified domain name (e.g. "*.cilium.io").
-      --from-identity filter       Show all flows originating at an endpoint with the given security identity
-      --from-ip filter             Show all flows originating at the given IP address. Each of the source IPs can be specified as an exact match (e.g. '1.1.1.1') or as a CIDR range (e.g.'1.1.1.0/24').
-      --from-label filter          Show only flows originating in an endpoint with the given labels (e.g. "key1=value1", "reserved:world")
-      --from-namespace filter      Show all flows originating in the given Kubernetes namespace.
-      --from-pod filter            Show all flows originating in the given pod name prefix([namespace/]<pod-name>). If namespace is not provided, 'default' is used
-      --from-port filter           Show only flows with the given source port (e.g. 8080)
-      --from-service filter        Shows flows where the source IP address matches the ClusterIP address of the given service name prefix([namespace/]<svc-name>). If namespace is not provided, 'default' is used
-      --from-workload filter       Show all flows originating at an endpoint with the given workload
-      --http-header filter         Show only flows which match this HTTP header key:value pairs (e.g. "foo:bar")
-      --http-method filter         Show only flows which match this HTTP method (e.g. "get", "post")
-      --http-path filter           Show only flows which match this HTTP path regular expressions (e.g. "/page/\\d+")
-      --http-status filter         Show only flows which match this HTTP status code prefix (e.g. "404", "5+")
-      --http-url filter            Show only flows which match this HTTP URL regular expressions (e.g. "http://.*cilium\.io/page/\\d+")
-      --identity filter            Show all flows related to an endpoint with the given security identity
-      --ip filter                  Show all flows related to the given IP address. Each of the IPs can be specified as an exact match (e.g. '1.1.1.1') or as a CIDR range (e.g.'1.1.1.0/24').
-      --ip-version filter          Show only IPv4, IPv6 flows or non IP flows (e.g. ARP packets) (ie: "none", "v4", "v6")
-  -4, --ipv4 filter[=v4]           Show only IPv4 flows
-  -6, --ipv6 filter[=v6]           Show only IPv6 flows
-  -l, --label filter               Show only flows related to an endpoint with the given labels (e.g. "key1=value1", "reserved:world")
-  -n, --namespace filter           Show all flows related to the given Kubernetes namespace.
-      --node-name filter           Show all flows which match the given node names (e.g. "k8s*", "test-cluster/*.company.com")
-      --not filter[=true]          Reverses the next filter to be blacklist i.e. --not --from-ip 2.2.2.2
-      --pod filter                 Show all flows related to the given pod name prefix ([namespace/]<pod-name>). If namespace is not provided, 'default' is used.
-      --port filter                Show only flows with given port in either source or destination (e.g. 8080)
-      --protocol filter            Show only flows which match the given L4/L7 flow protocol (e.g. "udp", "http")
-      --service filter             Shows flows where either the source or destination IP address matches the ClusterIP address of the given service name prefix ([namespace/]<svc-name>). If namespace is not provided, 'default' is used. 
-      --tcp-flags filter           Show only flows which match the given TCP flags (e.g. "syn", "ack", "fin")
-      --to-fqdn filter             Show all flows terminating at the given fully qualified domain name (e.g. "*.cilium.io").
-      --to-identity filter         Show all flows terminating at an endpoint with the given security identity
-      --to-ip filter               Show all flows terminating at the given IP address. Each of the destination IPs can be specified as an exact match (e.g. '1.1.1.1') or as a CIDR range (e.g.'1.1.1.0/24').
-      --to-label filter            Show only flows terminating in an endpoint with given labels (e.g. "key1=value1", "reserved:world")
-      --to-namespace filter        Show all flows terminating in the given Kubernetes namespace.
-      --to-pod filter              Show all flows terminating in the given pod name prefix([namespace/]<pod-name>). If namespace is not provided, 'default' is used
-      --to-port filter             Show only flows with the given destination port (e.g. 8080)
-      --to-service filter          Shows flows where the destination IP address matches the ClusterIP address of the given service name prefix ([namespace/]<svc-name>). If namespace is not provided, 'default' is used
-      --to-workload filter         Show all flows terminating at an endpoint with the given workload
-      --trace-id filter            Show only flows which match this trace ID
-      --traffic-direction filter   Show all flows in the given traffic direction (either ingress or egress)
-  -t, --type filter                Filter by event types TYPE[:SUBTYPE]. Available types and subtypes:
-                                   TYPE             SUBTYPE
-                                   capture          n/a
-                                   drop             n/a
-                                   l7               n/a
-                                   policy-verdict   n/a
-                                   trace            from-endpoint
-                                                    from-host
-                                                    from-network
-                                                    from-overlay
-                                                    from-proxy
-                                                    from-stack
-                                                    to-endpoint
-                                                    to-host
-                                                    to-network
-                                                    to-overlay
-                                                    to-proxy
-                                                    to-stack
-                                   trace-sock       n/a
-      --uuid filter                Show the only flow matching this unique flow identifier, if any
-      --verdict filter             Show only flows with this verdict [FORWARDED, DROPPED, AUDIT, REDIRECTED, ERROR, TRACED, TRANSLATED]
-      --workload filter            Show all flows related to an endpoint with the given workload
+  -A, --all-namespaces filter[=true]        Show all flows in any Kubernetes namespace.
+      --cluster filter                      Show all flows which match the cluster names (e.g. "test-cluster", "prod-*")
+      --fqdn filter                         Show all flows related to the given fully qualified domain name (e.g. "*.cilium.io").
+      --from-all-namespaces filter[=true]   Show flows originating in any Kubernetes namespace.
+      --from-fqdn filter                    Show all flows originating at the given fully qualified domain name (e.g. "*.cilium.io").
+      --from-identity filter                Show all flows originating at an endpoint with the given security identity
+      --from-ip filter                      Show all flows originating at the given IP address. Each of the source IPs can be specified as an exact match (e.g. '1.1.1.1') or as a CIDR range (e.g.'1.1.1.0/24').
+      --from-label filter                   Show only flows originating in an endpoint with the given labels (e.g. "key1=value1", "reserved:world")
+      --from-namespace filter               Show all flows originating in the given Kubernetes namespace.
+      --from-pod filter                     Show all flows originating in the given pod name prefix([namespace/]<pod-name>). If namespace is not provided, 'default' is used
+      --from-port filter                    Show only flows with the given source port (e.g. 8080)
+      --from-service filter                 Shows flows where the source IP address matches the ClusterIP address of the given service name prefix([namespace/]<svc-name>). If namespace is not provided, 'default' is used
+      --from-workload filter                Show all flows originating at an endpoint with the given workload
+      --http-header filter                  Show only flows which match this HTTP header key:value pairs (e.g. "foo:bar")
+      --http-method filter                  Show only flows which match this HTTP method (e.g. "get", "post")
+      --http-path filter                    Show only flows which match this HTTP path regular expressions (e.g. "/page/\\d+")
+      --http-status filter                  Show only flows which match this HTTP status code prefix (e.g. "404", "5+")
+      --http-url filter                     Show only flows which match this HTTP URL regular expressions (e.g. "http://.*cilium\.io/page/\\d+")
+      --identity filter                     Show all flows related to an endpoint with the given security identity
+      --ip filter                           Show all flows related to the given IP address. Each of the IPs can be specified as an exact match (e.g. '1.1.1.1') or as a CIDR range (e.g.'1.1.1.0/24').
+      --ip-version filter                   Show only IPv4, IPv6 flows or non IP flows (e.g. ARP packets) (ie: "none", "v4", "v6")
+  -4, --ipv4 filter[=v4]                    Show only IPv4 flows
+  -6, --ipv6 filter[=v6]                    Show only IPv6 flows
+  -l, --label filter                        Show only flows related to an endpoint with the given labels (e.g. "key1=value1", "reserved:world")
+  -n, --namespace filter                    Show all flows related to the given Kubernetes namespace.
+      --node-name filter                    Show all flows which match the given node names (e.g. "k8s*", "test-cluster/*.company.com")
+      --not filter[=true]                   Reverses the next filter to be blacklist i.e. --not --from-ip 2.2.2.2
+      --pod filter                          Show all flows related to the given pod name prefix ([namespace/]<pod-name>). If namespace is not provided, 'default' is used.
+      --port filter                         Show only flows with given port in either source or destination (e.g. 8080)
+      --protocol filter                     Show only flows which match the given L4/L7 flow protocol (e.g. "udp", "http")
+      --service filter                      Shows flows where either the source or destination IP address matches the ClusterIP address of the given service name prefix ([namespace/]<svc-name>). If namespace is not provided, 'default' is used. 
+      --tcp-flags filter                    Show only flows which match the given TCP flags (e.g. "syn", "ack", "fin")
+      --to-all-namespaces filter[=true]     Show flows terminating in any Kubernetes namespace.
+      --to-fqdn filter                      Show all flows terminating at the given fully qualified domain name (e.g. "*.cilium.io").
+      --to-identity filter                  Show all flows terminating at an endpoint with the given security identity
+      --to-ip filter                        Show all flows terminating at the given IP address. Each of the destination IPs can be specified as an exact match (e.g. '1.1.1.1') or as a CIDR range (e.g.'1.1.1.0/24').
+      --to-label filter                     Show only flows terminating in an endpoint with given labels (e.g. "key1=value1", "reserved:world")
+      --to-namespace filter                 Show all flows terminating in the given Kubernetes namespace.
+      --to-pod filter                       Show all flows terminating in the given pod name prefix([namespace/]<pod-name>). If namespace is not provided, 'default' is used
+      --to-port filter                      Show only flows with the given destination port (e.g. 8080)
+      --to-service filter                   Shows flows where the destination IP address matches the ClusterIP address of the given service name prefix ([namespace/]<svc-name>). If namespace is not provided, 'default' is used
+      --to-workload filter                  Show all flows terminating at an endpoint with the given workload
+      --trace-id filter                     Show only flows which match this trace ID
+      --traffic-direction filter            Show all flows in the given traffic direction (either ingress or egress)
+  -t, --type filter                         Filter by event types TYPE[:SUBTYPE]. Available types and subtypes:
+                                            TYPE             SUBTYPE
+                                            capture          n/a
+                                            drop             n/a
+                                            l7               n/a
+                                            policy-verdict   n/a
+                                            trace            from-endpoint
+                                                             from-host
+                                                             from-network
+                                                             from-overlay
+                                                             from-proxy
+                                                             from-stack
+                                                             to-endpoint
+                                                             to-host
+                                                             to-network
+                                                             to-overlay
+                                                             to-proxy
+                                                             to-stack
+                                            trace-sock       n/a
+      --uuid filter                         Show the only flow matching this unique flow identifier, if any
+      --verdict filter                      Show only flows with this verdict [FORWARDED, DROPPED, AUDIT, REDIRECTED, ERROR, TRACED, TRANSLATED]
+      --workload filter                     Show all flows related to an endpoint with the given workload
 
 Raw-Filters Flags:
       --allowlist stringArray   Specify allowlist as JSON encoded FlowFilters


### PR DESCRIPTION
This PR introduces `to-all-namespaces`, `from-all-namespaces`, and `all-namespaces` flags that allow filtering for services and pods in all namespaces.

This allows us to for example list any flows to a service named `bar` in any namespace using

```
hubble observe --all-namespaces --service bar
```

This PR builds on https://github.com/cilium/cilium/pull/28921

Closes: #359