### PR TITLE
Add --cluster flag for filtering by cluster

### DIFF
--- a/cmd/observe/flows.go
+++ b/cmd/observe/flows.go
@@ -348,6 +348,9 @@ func newFlowsCmdHelper(usage cmdUsage, vp *viper.Viper, ofilter *flowFilter) *co
 		"node-name", ofilter,
 		`Show all flows which match the given node names (e.g. "k8s*", "test-cluster/*.company.com")`))
 	filterFlags.Var(filterVar(
+		"cluster", ofilter,
+		`Show all flows which match the cluster names (e.g. "test-cluster", "prod-*")`))
+	filterFlags.Var(filterVar(
 		"protocol", ofilter,
 		`Show only flows which match the given L4/L7 flow protocol (e.g. "udp", "http")`))
 	filterFlags.Var(filterVar(

--- a/cmd/observe/flows_filter.go
+++ b/cmd/observe/flows_filter.go
@@ -205,7 +205,7 @@ func newFlowFilter() *flowFilter {
 			{"identity", "from-identity"},
 			{"workload", "to-workload"},
 			{"workload", "from-workload"},
-			{"node-name"},
+			{"node-name", "cluster"},
 			{"tcp-flags"},
 			{"uuid"},
 			{"traffic-direction"},
@@ -655,6 +655,12 @@ func (of *flowFilter) set(f *filterTracker, name, val string, track bool) error 
 	case "node-name":
 		f.apply(func(f *flowpb.FlowFilter) {
 			f.NodeName = append(f.GetNodeName(), val)
+		})
+
+		// cluster Name filters
+	case "cluster":
+		f.apply(func(f *flowpb.FlowFilter) {
+			f.NodeName = append(f.GetNodeName(), val+"/")
 		})
 
 	// TCP Flags filter

--- a/cmd/observe/flows_filter_test.go
+++ b/cmd/observe/flows_filter_test.go
@@ -869,3 +869,51 @@ func TestNamespace(t *testing.T) {
 		})
 	}
 }
+
+func TestCluster(t *testing.T) {
+	tt := []struct {
+		name    string
+		flags   []string
+		filters []*flowpb.FlowFilter
+		err     string
+	}{
+		{
+			name:  "Single cluster filter",
+			flags: []string{"--cluster", "foo"},
+			filters: []*flowpb.FlowFilter{
+				{NodeName: []string{"foo/"}},
+			},
+		},
+		{
+			name:  "Multiple cluster filter",
+			flags: []string{"--cluster", "foo", "--cluster", "bar"},
+			filters: []*flowpb.FlowFilter{
+				{NodeName: []string{"foo/", "bar/"}},
+			},
+		},
+		{
+			name:    "Cluster and node-name conflict",
+			flags:   []string{"--cluster", "foo", "--node-name", "baz"},
+			filters: []*flowpb.FlowFilter{},
+			err:     `invalid argument "baz" for "--node-name" flag: filters --node-name and --cluster cannot be combined`,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFlowFilter()
+			cmd := newFlowsCmdWithFilter(viper.New(), f)
+			err := cmd.Flags().Parse(tc.flags)
+			if tc.err != "" {
+				require.Errorf(t, err, tc.err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Nil(t, f.blacklist)
+			diff := cmp.Diff(tc.filters, f.whitelist.flowFilters(), cmpopts.IgnoreUnexported(flowpb.FlowFilter{}))
+			if diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/observe_help.txt
+++ b/cmd/observe_help.txt
@@ -38,6 +38,7 @@ Selectors Flags:
                         
 
 Filters Flags:
+      --cluster filter             Show all flows which match the cluster names (e.g. "test-cluster", "prod-*")
       --fqdn filter                Show all flows related to the given fully qualified domain name (e.g. "*.cilium.io").
       --from-fqdn filter           Show all flows originating at the given fully qualified domain name (e.g. "*.cilium.io").
       --from-identity filter       Show all flows originating at an endpoint with the given security identity


### PR DESCRIPTION
This is just a short-cut to `--node-name <cluster-name>/` but should make it more easier for users to filter by cluster, since many users are not aware the cluster name is part of the node name field on a flow.