### PR TITLE
[v0.13] Update Go to 1.21.8

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,15 +23,14 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - name: Setup Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-      with:
-        # renovate: datasource=golang-version depName=go
-        go-version: '1.21.6'
     - name: Checkout repo
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 1
+    - name: Setup Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version-file: 'go.mod'
     - name: Initialize CodeQL
       uses: github/codeql-action/init@47b3d888fe66b639e431abf22ebca059152f1eea # v3.24.5
       with:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -35,8 +35,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          # renovate: datasource=golang-version depName=go
-          go-version: '1.21.6'
+          go-version-file: 'go.mod'
       - name: Build hubble CLI
         run: make
       - name: Set up Helm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        # renovate: datasource=golang-version depName=go
-        go-version: '1.21.6'
+        go-version-file: 'go.mod'
     - name: Run static checks
       uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
       with:

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ GOLANGCILINT_IMAGE_SHA = sha256:e699df940be1810b08ba6ec050bfc34cc1931027283b5a7f
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
 # renovate: datasource=docker depName=library/golang
-GOLANG_IMAGE_VERSION = 1.21.6-alpine3.19
-GOLANG_IMAGE_SHA = sha256:a6a7f1fcf12f5efa9e04b1e75020931a616cd707f14f62ab5262bfbe109aa84a
+GOLANG_IMAGE_VERSION = 1.21.8-alpine3.19
+GOLANG_IMAGE_SHA = sha256:cd5189337d797eac9e2299dc07096c598cd4f4f73f068a033402f3ded7a51714
 
 # Add the ability to override variables
 -include Makefile.override

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/hubble
 
-go 1.21.6
+go 1.21.8
 
 require (
 	github.com/cilium/cilium v1.15.0-pre.2.0.20231201074209-a42c9e5ca657


### PR DESCRIPTION
Also use go.mod for version for setup-go GHA. Adapted from https://github.com/cilium/hubble/pull/1397 in main, I wanted to update Go (without waiting for renovate) and noticed we had the version spread out in so I also updated to source the version from `go.mod` when possible.