### PR TITLE
Makefile: Add renovate-local target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ CONTAINER_ENGINE ?= docker
 RELEASE_UID ?= $(shell id -u)
 RELEASE_GID ?= $(shell id -g)
 
+RENOVATE_GITHUB_USER ?= renovate
+RENOVATE_GITHUB_COM_TOKEN ?= $(shell gh auth token)
+
 TEST_TIMEOUT ?= 5s
 
 # renovate: datasource=docker depName=golangci/golangci-lint
@@ -98,4 +101,8 @@ endif
 image:
 	$(CONTAINER_ENGINE) build $(DOCKER_FLAGS) -t $(IMAGE_REPOSITORY)$(if $(IMAGE_TAG),:$(IMAGE_TAG)) .
 
-.PHONY: all hubble release install clean test bench check image
+renovate-local:
+	@echo "Running renovate --platform=local"
+	@docker run --rm -ti -e LOG_LEVEL=debug -e GITHUB_COM_TOKEN="$(RENOVATE_GITHUB_COM_TOKEN)" -v /tmp:/tmp -v $(PWD):/usr/src/app docker.io/renovate/renovate:full renovate --platform=local | tee renovate.log
+
+.PHONY: all hubble release install clean test bench check image renovate-local


### PR DESCRIPTION
Adds a target to the Makefile to help with running and debugging renovate locally. I've been using this in a few other repos and it's pretty helpful. Note that it's not aware of anything other than the current checkout, so if you want to test it against other branches, you will have to change branches (meaning the Makefile target may not exist), and/or adjust the rules in the `renovate.json` as needed for testing.