### PR TITLE
.github: Update renovate for v0.13 branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -168,7 +168,7 @@
         "go",
         "golang"
       ],
-      "allowedVersions": "<=1.20",
+      "allowedVersions": "<1.22",
       "matchBaseBranches": [
         "v0.13"
       ],
@@ -187,7 +187,7 @@
       "matchPackageNames": [
         "docker.io/library/alpine"
       ],
-      "allowedVersions": "<=3.18",
+      "allowedVersions": "<3.20",
       "matchBaseBranches": [
         "v0.13"
       ]


### PR DESCRIPTION
These were never updated to reflect the new base image versions in 0.13