### PR TITLE
build-images-release: Simplify the tag regex

### DIFF
--- a/.github/workflows/build-images-release.yaml
+++ b/.github/workflows/build-images-release.yaml
@@ -6,8 +6,7 @@ on:
     branches:
       - main
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Use the same tag regex as the `Create a release` workflow [^1]. No need to be extra fancy since this workflow is protected by an environment that requires an approval from a maintainer.

[^1]: https://github.com/cilium/hubble/blob/6274cee68c7abd28619f88c2d17dcb4b178a2e7e/.github/workflows/release.yml#L5