### PR TITLE
build-images-release: Specify pattern when downloading image digests

### DIFF
--- a/.github/workflows/build-images-release.yaml
+++ b/.github/workflows/build-images-release.yaml
@@ -117,6 +117,7 @@ jobs:
       - name: Download digests of all images built
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
+          pattern: "*image-digest *"
           path: image-digest/
 
       - name: Image Digests Output


### PR DESCRIPTION
This commit introduces a fix for the "Display Digests" job of the image build workflow. The job fails when trying to download image digest artifacts, which is caused by a recent change made to the docker/build-push-action that adjusted the way artifacts were stored. The fix is based off of
https://github.com/cilium/cilium/pull/33216, more details can be found there.