### PR TITLE
Makefile cleanups / improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ local-release: clean
 		for ARCH in $$ARCHS; do \
 			echo Building release binary for $$OS/$$ARCH...; \
 			test -d release/$$OS/$$ARCH|| mkdir -p release/$$OS/$$ARCH; \
-			env GOOS=$$OS GOARCH=$$ARCH $(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/cilium/hubble/pkg.Version=${VERSION}'" -o release/$$OS/$$ARCH/$(TARGET)$$EXT; \
+			GOOS=$$OS GOARCH=$$ARCH $(MAKE) hubble; \
+			mv $(TARGET) release/$$OS/$$ARCH/$(TARGET)$$EXT; \
 			tar -czf release/$(TARGET)-$$OS-$$ARCH.tar.gz -C release/$$OS/$$ARCH $(TARGET)$$EXT; \
 			(cd release && sha256sum $(TARGET)-$$OS-$$ARCH.tar.gz > $(TARGET)-$$OS-$$ARCH.tar.gz.sha256sum); \
 		done; \

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,10 @@ local-release: clean
 				ARCHS='amd64 arm64'; \
 				;; \
 			linux) \
-				ARCHS='386 amd64 arm arm64'; \
+				ARCHS='amd64 arm64'; \
 				;; \
 			windows) \
-				ARCHS='386 amd64 arm64'; \
+				ARCHS='amd64 arm64'; \
 				EXT=".exe"; \
 				;; \
 		esac; \


### PR DESCRIPTION
2 commits:

- drop building 32-bit release binaries
- use hubble target to build release binaries