### PR TITLE
Remove the vendor team from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,6 @@
 # @cilium/contributing       Developer documentation & tools
 # @cilium/github-sec         GitHub security (handling of secrets, consequences of pull_request_target, etc.)
 # @cilium/sig-hubble         All related to Hubble (client and server)
-# @cilium/vendor             Vendoring, dependency management
 
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
@@ -11,6 +10,3 @@
 * @cilium/sig-hubble
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure @cilium/sig-hubble
 /CODEOWNERS @cilium/contributing @cilium/sig-hubble
-/go.sum @cilium/vendor
-/go.mod @cilium/vendor
-/vendor/ @cilium/vendor


### PR DESCRIPTION
Now the only dependency is github.com/cilium/cilium [^1]. Let's not pull in the vendor team for reviewing that.

[^1]: https://github.com/cilium/hubble/blob/5fcb8c343b65fb894c820b7558387d69cbdde446/go.mod#L5