### PR TITLE
migrate Renovate config take #2

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,7 +83,7 @@
     {
       "groupName": "all go dependencies main",
       "groupSlug": "all-go-deps-main",
-      "matchFiles": [
+      "matchFileNames": [
         "go.mod",
         "go.sum",
       ],


### PR DESCRIPTION
Commit 5ef17d1368802fef26765e111136f8bd06474da3 missed a conversion from `matchFiles` to `matchFileNames`.