### PR TITLE
.github: Add permissions for release workflow and support manually triggering it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,14 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  workflow_dispatch:
+    # Support re-running the workflow manually from the Actions tab in case it
+    # fails and we need to fix something in the automation but still have it
+    # run against the existing tag.
+    inputs:
+      tag:
+        description: 'release tag version'
+        required: true
 
 name: Create a release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     environment: release
     if: github.repository == 'cilium/hubble'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: 'write'
+      id-token: 'write'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The latest release failed since we locked down the default permissions: https://github.com/cilium/hubble/actions/runs/24745109153/job/72394610612

Fix is to explicitly request permissions in the release workflow. Also make it possible to execute the release workflow against an existing tag so we can re-run it against the tag that failed.