### PR TITLE
renovate: add dependency cooldown

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,11 @@
   ],
   stopUpdatingLabel: 'renovate/stop-updating',
   packageRules: [
+    {
+      // Dependency cooldown: skip versions published less than 5 days ago
+      matchUpdateTypes: ['major', 'minor', 'patch'],
+      minimumReleaseAge: '5 days',
+    },
     // Based on https://docs.renovatebot.com/key-concepts/automerge/#automerge-non-major-updates
     // and tetragon's automerge config.
     {


### PR DESCRIPTION
- adds a 5-day dependency cooldown to the Renovate config for stability and security to prevent supply chain vulnerabilities

- Vulnerability updates are exempt from this cooldown by default.