### PR TITLE
renovate: Do not update gobgp dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -116,6 +116,8 @@
         'github.com/cilium/metallb',
         'github.com/miekg/dns',
         'github.com/cilium/dns',
+        'github.com/osrg/gobgp/v3',
+        'github.com/cilium/gobgp/v3',
         'sigs.k8s.io/controller-tools',
         'github.com/cilium/controller-tools',
         'k8s.io/client-go',


### PR DESCRIPTION
Cilium maintains a fork and this dependency should be only be updated when updating cilium.

Should prevent renovate from opening PRs like https://github.com/cilium/hubble/pull/1798